### PR TITLE
Example on how a copy can be avoided when decompressing numpy arrays

### DIFF
--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -6,6 +6,15 @@ from .blosc2_ext import BLOSCLZ, LZ4, LZ4HC, ZLIB, ZSTD
 # Filters
 from .blosc2_ext import NOFILTER, SHUFFLE, BITSHUFFLE, DELTA, TRUNC_PREC
 
+# Filter names
+filter_names = {
+    NOFILTER: "nofilter",
+    SHUFFLE: "shuffle",
+    BITSHUFFLE: "bitshuffle",
+    DELTA: "delta",
+    TRUNC_PREC: "trun_prec",
+}
+
 # Public API for container module
 from .utils import (compress, decompress, set_compressor, free_resources, set_nthreads,
                     clib_info, get_clib, compressor_list, set_blocksize, pack, unpack,

--- a/blosc2/utils.py
+++ b/blosc2/utils.py
@@ -91,7 +91,7 @@ def compress(src, typesize=8, clevel=9, shuffle=blosc2_ext.SHUFFLE, cname='blosc
     return blosc2_ext.compress(src, typesize, clevel, shuffle, cname)
 
 
-def decompress(src, as_bytearray=False):
+def decompress(src, dst=None, as_bytearray=False):
     """Decompresses a bytes-like compressed object.
 
     Parameters
@@ -135,7 +135,7 @@ def decompress(src, as_bytearray=False):
     ...                                      as_bytearray=True)) is bytearray
     True
     """
-    return blosc2_ext.decompress(src, as_bytearray)
+    return blosc2_ext.decompress(src, dst, as_bytearray)
 
 
 def pack(obj, clevel=9, shuffle=blosc2_ext.SHUFFLE, cname='blosclz'):
@@ -235,7 +235,7 @@ def unpack(packed_object, **kwargs):
     >>> numpy.alltrue(a == a2)
     True
     """
-    pickled_object = decompress(packed_object, False)
+    pickled_object = decompress(packed_object)
     if kwargs:
         obj = pickle.loads(pickled_object, **kwargs)
     else:
@@ -331,7 +331,7 @@ def unpack_array(packed_array, **kwargs):
     >>> numpy.alltrue(a == a2)
     True
     """
-    pickled_array = decompress(packed_array, False)
+    pickled_array = decompress(packed_array)
     if kwargs:
         arr = pickle.loads(pickled_array, **kwargs)
         if all(isinstance(x, bytes) for x in arr.tolist()):

--- a/blosc2/utils.py
+++ b/blosc2/utils.py
@@ -100,6 +100,11 @@ def decompress(src, dst=None, as_bytearray=False):
         The data to be decompressed.  Must be a bytes-like object
         that supports the Python Buffer Protocol, like bytes, bytearray,
         memoryview, or numpy.ndarray.
+    dst : NumPy object
+        The destination NumPy object to fill.  The user must make sure
+        that it has enough capacity for hosting the decompressed data.
+        Default is None, meaning that a new `bytes` or `bytearray` object
+        is created, filled and returned.
     as_bytearray : bool (optional)
         If this flag is True then the return type will be a bytearray object
         instead of a bytesobject.


### PR DESCRIPTION
This is mainly for illustrative purposes.  Here are the speeds for compress/decompress on an M1-powered MacBook:

```
$ env PYTHONPATH=. python bench/compress_numpy.py
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
python-blosc2 version: 2.0.0-alpha
Blosc version: 2.0.0.beta.6.dev ($Date:: 2020-04-21 #$)
Compressors available: ['blosclz', 'lz4', 'lz4hc', 'zlib', 'zstd']
Compressor library versions:
  blosclz: 2.3.0
  lz4: 1.9.3
  lz4hc: 1.9.3
  zlib: 1.2.11.zlib-ng
  zstd: 1.4.9
Python version: 3.8.5 (default, Sep  4 2020, 02:22:02)
[Clang 10.0.0 ]
Platform: Darwin-20.3.0-x86_64 (Darwin Kernel Version 20.3.0: Thu Jan 21 00:06:51 PST 2021; root:xnu-7195.81.3~1/RELEASE_ARM64_T8101)
Processor: i386
Byte-ordering: little
Detected cores: 8
Number of threads to use by default: 8
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Creating NumPy arrays with 10**8 int64/float64 elements:
  *** ctypes.memmove() *** Time for memcpy():	1.073 s	(0.69 GB/s)

Times for compressing/decompressing with clevel=5 and 8 threads

*** the arange linear distribution ***
  *** blosclz , nofilter   ***  0.363 s (2.05 GB/s) / 0.117 s (6.37 GB/s)	Compr. ratio:   1.0x
  *** blosclz , shuffle    ***  0.054 s (13.71 GB/s) / 0.060 s (12.46 GB/s)	Compr. ratio: 331.3x
  *** blosclz , bitshuffle ***  0.104 s (7.17 GB/s) / 0.114 s (6.51 GB/s)	Compr. ratio: 182.9x
  *** lz4     , nofilter   ***  0.448 s (1.66 GB/s) / 0.203 s (3.67 GB/s)	Compr. ratio:   2.0x
  *** lz4     , shuffle    ***  0.051 s (14.58 GB/s) / 0.097 s (7.68 GB/s)	Compr. ratio: 123.9x
  *** lz4     , bitshuffle ***  0.102 s (7.28 GB/s) / 0.149 s (4.99 GB/s)	Compr. ratio:  60.5x
  *** lz4hc   , nofilter   ***  1.471 s (0.51 GB/s) / 0.196 s (3.80 GB/s)	Compr. ratio:   2.0x
  *** lz4hc   , shuffle    ***  0.131 s (5.69 GB/s) / 0.097 s (7.67 GB/s)	Compr. ratio: 143.7x
  *** lz4hc   , bitshuffle ***  0.320 s (2.33 GB/s) / 0.137 s (5.46 GB/s)	Compr. ratio: 228.7x
  *** zlib    , nofilter   ***  1.940 s (0.38 GB/s) / 0.322 s (2.31 GB/s)	Compr. ratio:   5.3x
  *** zlib    , shuffle    ***  0.237 s (3.15 GB/s) / 0.122 s (6.13 GB/s)	Compr. ratio: 232.3x
  *** zlib    , bitshuffle ***  0.305 s (2.44 GB/s) / 0.195 s (3.83 GB/s)	Compr. ratio: 375.4x
  *** zstd    , nofilter   ***  2.849 s (0.26 GB/s) / 0.240 s (3.11 GB/s)	Compr. ratio:   7.9x
  *** zstd    , shuffle    ***  0.082 s (9.13 GB/s) / 0.097 s (7.69 GB/s)	Compr. ratio: 468.9x
  *** zstd    , bitshuffle ***  0.191 s (3.91 GB/s) / 0.133 s (5.61 GB/s)	Compr. ratio: 1005.5x

*** the linspace linear distribution ***
  *** blosclz , nofilter   ***  1.127 s (0.66 GB/s) / 0.096 s (7.79 GB/s)	Compr. ratio:   1.0x
  *** blosclz , shuffle    ***  0.107 s (6.98 GB/s) / 0.042 s (17.72 GB/s)	Compr. ratio:  23.7x
  *** blosclz , bitshuffle ***  0.250 s (2.98 GB/s) / 0.128 s (5.83 GB/s)	Compr. ratio:  10.1x
  *** lz4     , nofilter   ***  0.255 s (2.92 GB/s) / 0.084 s (8.86 GB/s)	Compr. ratio:   1.0x
  *** lz4     , shuffle    ***  0.104 s (7.17 GB/s) / 0.058 s (12.80 GB/s)	Compr. ratio:   9.9x
  *** lz4     , bitshuffle ***  0.142 s (5.24 GB/s) / 0.158 s (4.72 GB/s)	Compr. ratio:  18.8x
  *** lz4hc   , nofilter   ***  4.114 s (0.18 GB/s) / 0.758 s (0.98 GB/s)	Compr. ratio:   1.1x
  *** lz4hc   , shuffle    ***  0.334 s (2.23 GB/s) / 0.038 s (19.77 GB/s)	Compr. ratio:  23.8x
  *** lz4hc   , bitshuffle ***  0.644 s (1.16 GB/s) / 0.110 s (6.75 GB/s)	Compr. ratio:  31.8x
  *** zlib    , nofilter   ***  2.986 s (0.25 GB/s) / 0.517 s (1.44 GB/s)	Compr. ratio:   1.6x
  *** zlib    , shuffle    ***  0.445 s (1.68 GB/s) / 0.134 s (5.55 GB/s)	Compr. ratio:  25.4x
  *** zlib    , bitshuffle ***  0.509 s (1.46 GB/s) / 0.211 s (3.52 GB/s)	Compr. ratio:  37.3x
  *** zstd    , nofilter   ***  3.684 s (0.20 GB/s) / 0.242 s (3.07 GB/s)	Compr. ratio:   1.9x
  *** zstd    , shuffle    ***  0.284 s (2.63 GB/s) / 0.121 s (6.14 GB/s)	Compr. ratio:  34.2x
  *** zstd    , bitshuffle ***  0.331 s (2.25 GB/s) / 0.162 s (4.60 GB/s)	Compr. ratio:  48.7x

*** the random distribution ***
  *** blosclz , nofilter   ***  1.826 s (0.41 GB/s) / 0.099 s (7.54 GB/s)	Compr. ratio:   1.0x
  *** blosclz , shuffle    ***  0.146 s (5.11 GB/s) / 0.048 s (15.45 GB/s)	Compr. ratio:   4.0x
  *** blosclz , bitshuffle ***  0.364 s (2.05 GB/s) / 0.177 s (4.21 GB/s)	Compr. ratio:   1.0x
  *** lz4     , nofilter   ***  0.488 s (1.53 GB/s) / 0.084 s (8.91 GB/s)	Compr. ratio:   2.5x
  *** lz4     , shuffle    ***  0.174 s (4.27 GB/s) / 0.101 s (7.38 GB/s)	Compr. ratio:   4.9x
  *** lz4     , bitshuffle ***  0.140 s (5.31 GB/s) / 0.169 s (4.41 GB/s)	Compr. ratio:   6.2x
  *** lz4hc   , nofilter   ***  2.465 s (0.30 GB/s) / 0.109 s (6.80 GB/s)	Compr. ratio:   3.8x
  *** lz4hc   , shuffle    ***  0.814 s (0.92 GB/s) / 0.110 s (6.77 GB/s)	Compr. ratio:   5.2x
  *** lz4hc   , bitshuffle ***  0.391 s (1.91 GB/s) / 0.170 s (4.37 GB/s)	Compr. ratio:   6.2x
  *** zlib    , nofilter   ***  1.569 s (0.47 GB/s) / 0.305 s (2.44 GB/s)	Compr. ratio:   4.2x
  *** zlib    , shuffle    ***  0.981 s (0.76 GB/s) / 0.153 s (4.86 GB/s)	Compr. ratio:   6.0x
  *** zlib    , bitshuffle ***  0.668 s (1.11 GB/s) / 0.215 s (3.46 GB/s)	Compr. ratio:   6.3x
  *** zstd    , nofilter   ***  5.818 s (0.13 GB/s) / 0.303 s (2.46 GB/s)	Compr. ratio:   4.2x
  *** zstd    , shuffle    ***  1.408 s (0.53 GB/s) / 0.109 s (6.82 GB/s)	Compr. ratio:   6.0x
  *** zstd    , bitshuffle ***  0.238 s (3.13 GB/s) / 0.135 s (5.52 GB/s)	Compr. ratio:   6.4x
```

And here for the pack/unpack counterpart:

```
$ > env PYTHONPATH=. python bench/pack_unpack_deep.py
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
python-blosc2 version: 2.0.0-alpha
Blosc version: 2.0.0.beta.6.dev ($Date:: 2020-04-21 #$)
Compressors available: ['blosclz', 'lz4', 'lz4hc', 'zlib', 'zstd']
Compressor library versions:
  blosclz: 2.3.0
  lz4: 1.9.3
  lz4hc: 1.9.3
  zlib: 1.2.11.zlib-ng
  zstd: 1.4.9
Python version: 3.8.5 (default, Sep  4 2020, 02:22:02)
[Clang 10.0.0 ]
Platform: Darwin-20.3.0-x86_64 (Darwin Kernel Version 20.3.0: Thu Jan 21 00:06:51 PST 2021; root:xnu-7195.81.3~1/RELEASE_ARM64_T8101)
Processor: i386
Byte-ordering: little
Detected cores: 8
Number of threads to use by default: 8
-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
Creating NumPy arrays with 10**8 int64/float64 elements:
  *** ctypes.memmove() *** Time for memcpy():	0.657 s	(1.13 GB/s)

Times for compressing/decompressing with clevel=5 and 8 threads

*** the arange linear distribution ***
  *** blosclz , nofilter   ***  0.701 s (1.06 GB/s) / 0.995 s (0.75 GB/s)	Compr. ratio:   1.0x
  *** blosclz , shuffle    ***  0.445 s (1.67 GB/s) / 0.473 s (1.58 GB/s)	Compr. ratio: 330.7x
  *** blosclz , bitshuffle ***  0.305 s (2.44 GB/s) / 0.443 s (1.68 GB/s)	Compr. ratio: 178.2x
  *** lz4     , nofilter   ***  0.707 s (1.05 GB/s) / 0.729 s (1.02 GB/s)	Compr. ratio:   2.0x
  *** lz4     , shuffle    ***  0.258 s (2.88 GB/s) / 0.434 s (1.72 GB/s)	Compr. ratio: 122.8x
  *** lz4     , bitshuffle ***  0.336 s (2.22 GB/s) / 0.478 s (1.56 GB/s)	Compr. ratio: 205.5x
  *** lz4hc   , nofilter   ***  1.661 s (0.45 GB/s) / 0.685 s (1.09 GB/s)	Compr. ratio:   2.0x
  *** lz4hc   , shuffle    ***  0.368 s (2.03 GB/s) / 0.457 s (1.63 GB/s)	Compr. ratio: 142.9x
  *** lz4hc   , bitshuffle ***  0.552 s (1.35 GB/s) / 0.479 s (1.56 GB/s)	Compr. ratio: 222.9x
  *** zlib    , nofilter   ***  2.194 s (0.34 GB/s) / 0.710 s (1.05 GB/s)	Compr. ratio:   5.3x
  *** zlib    , shuffle    ***  0.449 s (1.66 GB/s) / 0.479 s (1.55 GB/s)	Compr. ratio: 230.3x
  *** zlib    , bitshuffle ***  0.520 s (1.43 GB/s) / 0.553 s (1.35 GB/s)	Compr. ratio: 420.3x
  *** zstd    , nofilter   ***  3.101 s (0.24 GB/s) / 0.593 s (1.26 GB/s)	Compr. ratio:   7.9x
  *** zstd    , shuffle    ***  0.342 s (2.18 GB/s) / 0.516 s (1.44 GB/s)	Compr. ratio: 454.1x
  *** zstd    , bitshuffle ***  0.422 s (1.76 GB/s) / 0.548 s (1.36 GB/s)	Compr. ratio: 1426.3x

*** the linspace linear distribution ***
  *** blosclz , nofilter   ***  2.101 s (0.35 GB/s) / 0.602 s (1.24 GB/s)	Compr. ratio:   1.0x
  *** blosclz , shuffle    ***  0.346 s (2.15 GB/s) / 0.414 s (1.80 GB/s)	Compr. ratio:  23.7x
  *** blosclz , bitshuffle ***  0.486 s (1.53 GB/s) / 0.495 s (1.51 GB/s)	Compr. ratio:  10.1x
  *** lz4     , nofilter   ***  0.526 s (1.42 GB/s) / 0.843 s (0.88 GB/s)	Compr. ratio:   1.0x
  *** lz4     , shuffle    ***  0.365 s (2.04 GB/s) / 0.435 s (1.71 GB/s)	Compr. ratio:   9.9x
  *** lz4     , bitshuffle ***  0.379 s (1.97 GB/s) / 0.483 s (1.54 GB/s)	Compr. ratio:  18.9x
  *** lz4hc   , nofilter   ***  4.648 s (0.16 GB/s) / 0.693 s (1.08 GB/s)	Compr. ratio:   1.1x
  *** lz4hc   , shuffle    ***  0.530 s (1.41 GB/s) / 0.438 s (1.70 GB/s)	Compr. ratio:  23.8x
  *** lz4hc   , bitshuffle ***  0.846 s (0.88 GB/s) / 0.864 s (0.86 GB/s)	Compr. ratio:  31.8x
  *** zlib    , nofilter   ***  5.026 s (0.15 GB/s) / 0.890 s (0.84 GB/s)	Compr. ratio:   1.6x
  *** zlib    , shuffle    ***  1.076 s (0.69 GB/s) / 0.560 s (1.33 GB/s)	Compr. ratio:  25.4x
  *** zlib    , bitshuffle ***  0.779 s (0.96 GB/s) / 0.909 s (0.82 GB/s)	Compr. ratio:  37.3x
  *** zstd    , nofilter   ***  5.208 s (0.14 GB/s) / 0.592 s (1.26 GB/s)	Compr. ratio:   1.9x
  *** zstd    , shuffle    ***  0.586 s (1.27 GB/s) / 0.600 s (1.24 GB/s)	Compr. ratio:  34.3x
  *** zstd    , bitshuffle ***  0.559 s (1.33 GB/s) / 0.604 s (1.23 GB/s)	Compr. ratio:  47.7x

*** the random distribution ***
  *** blosclz , nofilter   ***  3.185 s (0.23 GB/s) / 0.638 s (1.17 GB/s)	Compr. ratio:   1.0x
  *** blosclz , shuffle    ***  0.557 s (1.34 GB/s) / 0.413 s (1.80 GB/s)	Compr. ratio:   4.0x
  *** blosclz , bitshuffle ***  0.397 s (1.88 GB/s) / 0.485 s (1.53 GB/s)	Compr. ratio:   6.1x
  *** lz4     , nofilter   ***  0.589 s (1.27 GB/s) / 0.547 s (1.36 GB/s)	Compr. ratio:   2.5x
  *** lz4     , shuffle    ***  0.373 s (2.00 GB/s) / 0.584 s (1.28 GB/s)	Compr. ratio:   4.9x
  *** lz4     , bitshuffle ***  0.366 s (2.03 GB/s) / 0.513 s (1.45 GB/s)	Compr. ratio:   6.2x
  *** lz4hc   , nofilter   ***  2.655 s (0.28 GB/s) / 0.618 s (1.20 GB/s)	Compr. ratio:   3.8x
  *** lz4hc   , shuffle    ***  1.077 s (0.69 GB/s) / 0.495 s (1.51 GB/s)	Compr. ratio:   5.2x
  *** lz4hc   , bitshuffle ***  0.675 s (1.10 GB/s) / 0.454 s (1.64 GB/s)	Compr. ratio:   6.2x
  *** zlib    , nofilter   ***  1.830 s (0.41 GB/s) / 0.864 s (0.86 GB/s)	Compr. ratio:   4.2x
  *** zlib    , shuffle    ***  1.229 s (0.61 GB/s) / 0.540 s (1.38 GB/s)	Compr. ratio:   6.0x
  *** zlib    , bitshuffle ***  0.881 s (0.85 GB/s) / 0.574 s (1.30 GB/s)	Compr. ratio:   6.3x
  *** zstd    , nofilter   ***  6.137 s (0.12 GB/s) / 0.885 s (0.84 GB/s)	Compr. ratio:   4.2x
  *** zstd    , shuffle    ***  1.935 s (0.39 GB/s) / 0.501 s (1.49 GB/s)	Compr. ratio:   6.0x
  *** zstd    , bitshuffle ***  0.656 s (1.13 GB/s) / 0.532 s (1.40 GB/s)	Compr. ratio:   6.4x
```

So, apparently we don't understand well the promise of zero-copy for the pickle 5 on NumPy objects.  Food for thought.