### PR TITLE
Update submodule and restore support for #29

### DIFF
--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -154,9 +154,9 @@ def decompress(src, dst=None, as_bytearray=False):
     True
     >>> b"" == blosc2.decompress(blosc2.compress(b"", 1))
     True
-    >>> b"1"*7 == blosc2.decompress(blosc2.compress(b"1"*7, 1))
+    >>> b"1"*7 == blosc2.decompress(blosc2.compress(b"1"*7, 8))
     True
-    >>> type(blosc2.decompress(blosc2.compress(b"1"*7, 1),
+    >>> type(blosc2.decompress(blosc2.compress(b"1"*7, 8),
     ...                                      as_bytearray=True)) is bytearray
     True
     >>> import numpy
@@ -175,7 +175,7 @@ def pack(obj, clevel=9, shuffle=blosc2_ext.SHUFFLE, cname="blosclz"):
 
     Parameters
     ----------
-    obj : Python object
+    obj : Python object  with `itemsize` attribute
         The Python object to be packed.
     clevel : int (optional)
         The compression level from 0 (no compression) to 9
@@ -197,8 +197,12 @@ def pack(obj, clevel=9, shuffle=blosc2_ext.SHUFFLE, cname="blosclz"):
 
     Raises
     ------
+    AttributeError
+        If the object does not have an `itemsize` attribute.
+        If the object does not have an `size` attribute.
     ValueError
         If the pickled object size is larger than the maximum allowed buffer size.
+        If typesize is not within the allowed range.
         If clevel is not within the allowed range.
         If cname is not within the supported compressors.
 
@@ -210,13 +214,19 @@ def pack(obj, clevel=9, shuffle=blosc2_ext.SHUFFLE, cname="blosclz"):
     >>> len(parray) < a.size*a.itemsize
     True
     """
-    _check_clevel(clevel)
-    _check_cname(cname)
-    pickled_object = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
-    # The object to be compressed is pickled_object, and not obj
-    _check_input_length("pickled object", len(pickled_object))
-    packed_object = compress(pickled_object, typesize=1, clevel=clevel, shuffle=shuffle, cname=cname)
-
+    if not hasattr(obj, "itemsize"):
+        raise AttributeError("The object must have an itemsize attribute.")
+    if not hasattr(obj, "size"):
+        raise AttributeError("The object must have an size attribute.")
+    else:
+         itemsize = obj.itemsize
+         _check_clevel(clevel)
+         _check_cname(cname)
+         _check_typesize(itemsize)
+         pickled_object = pickle.dumps(obj, pickle.HIGHEST_PROTOCOL)
+         # The object to be compressed is pickled_object, and not obj
+         _check_input_length("pickled object", len(pickled_object))
+         packed_object = compress(pickled_object, typesize=itemsize, clevel=clevel, shuffle=shuffle, cname=cname)
     return packed_object
 
 
@@ -267,8 +277,7 @@ def unpack(packed_object, **kwargs):
 
 
 def pack_array(arr, clevel=9, shuffle=blosc2_ext.SHUFFLE, cname="blosclz"):
-    """Pack (compress) a NumPy array. It is equivalent to the pack function, except that it only
-    takes Python objects with attributes `itemsize` and `size`.
+    """Pack (compress) a NumPy array. It is equivalent to the pack function.
 
     Parameters
     ----------
@@ -298,6 +307,7 @@ def pack_array(arr, clevel=9, shuffle=blosc2_ext.SHUFFLE, cname="blosclz"):
         If the object does not have an `itemsize` attribute.
         If the object does not have a `size` attribute.
     ValueError
+        If typesize is not within the allowed range.
         If the pickled object size is larger than the maximum allowed buffer size.
         If clevel is not within the allowed range.
         If cname is not within the supported compressors.
@@ -314,10 +324,6 @@ def pack_array(arr, clevel=9, shuffle=blosc2_ext.SHUFFLE, cname="blosclz"):
     >>> len(parray) < a.size*a.itemsize
     True
     """
-    if not hasattr(arr, "itemsize"):
-        raise AttributeError("The object must have an itemsize attribute.")
-    if not hasattr(arr, "size"):
-        raise AttributeError("The object must have an size attribute.")
     return pack(arr, clevel, shuffle, cname)
 
 

--- a/examples/schunk.py
+++ b/examples/schunk.py
@@ -27,8 +27,8 @@ for i in range(nchunks):
     nchunks_ = schunk.append_data(buffer)
     assert nchunks_ == (i + 1)
 
-# Decompress second the chunk in different ways
-buffer = 1 * numpy.arange(200 * 1000)
+# Decompress the second chunk in different ways
+buffer = 1 * numpy.arange(200 * 1000, dtype="int32")
 bytes_obj = buffer.tobytes()
 res = schunk.decompress_chunk(1)
 assert res == bytes_obj

--- a/tests/test_array.py
+++ b/tests/test_array.py
@@ -12,7 +12,7 @@ import pytest
 import blosc2
 
 
-@pytest.mark.parametrize("size, dtype", [(1e6, None)])
+@pytest.mark.parametrize("size, dtype", [(1e6, "int64")])
 def test_array(size, dtype):
     nparray = np.arange(size, dtype=dtype)
     parray = blosc2.pack_array(nparray)

--- a/tests/test_compress2.py
+++ b/tests/test_compress2.py
@@ -56,7 +56,7 @@ def test_compress2_numpy(obj, cparams, dparams):
         (7, {"compcode": blosc2.LZ4, "clevel": 6, "typesize": 1}, {}),
         (641091, {"typesize": 1}, {"nthreads": 4}),
         (136, {"typesize": 1}, {}),
-        (1231, {"typesize": 1}, blosc2.dparams_dflts),
+        (1231, {"typesize": 4}, blosc2.dparams_dflts),
     ],
 )
 def test_compress2(nbytes, cparams, dparams):

--- a/tests/test_compressors.py
+++ b/tests/test_compressors.py
@@ -13,7 +13,7 @@ import blosc2
 
 @pytest.mark.parametrize(
     "typesize, clevel, cname",
-    [(1, 8, "blosclz"), (1, 9, "lz4"), (1, 3, "lz4hc"), (1, 5, "zlib"), (1, 2, "zstd")],
+    [(7, 8, "blosclz"), (2, 9, "lz4"), (7, 3, "lz4hc"), (3, 5, "zlib"), (20, 2, "zstd")],
 )
 @pytest.mark.parametrize(
     "filt", [blosc2.BITSHUFFLE, blosc2.SHUFFLE, blosc2.NOFILTER, blosc2.DELTA, blosc2.TRUNC_PREC]

--- a/tests/test_decompress.py
+++ b/tests/test_decompress.py
@@ -54,7 +54,7 @@ def test_decompress_numpy(object, cname):
     ],
 )
 def test_decompress(object, cname):
-    c = blosc2.compress(object, cname=cname, typesize=1)
+    c = blosc2.compress(object, cname=cname)
 
     dest = bytearray(object)
     blosc2.decompress(c, dst=dest)

--- a/tests/test_python_blosc.py
+++ b/tests/test_python_blosc.py
@@ -227,15 +227,16 @@ class TestCodec(unittest.TestCase):
         # Check the fix for #133
         x = numpy.ones(27266, dtype="uint8")
         xx = x.tobytes()
-        zxx = blosc2.compress(xx, typesize=1, shuffle=blosc2.BITSHUFFLE)
+        zxx = blosc2.compress(xx, typesize=8, shuffle=blosc2.BITSHUFFLE)
         last_xx = blosc2.decompress(zxx)[-3:]
         self.assertEqual(last_xx, b"\x01\x01\x01")
 
-    def test_bithuffle_leftovers(self):
+    def test_bitshuffle_leftovers(self):
         # Test for https://github.com/blosc2/c-blosc22/pull/100
         buffer = b" " * 641091  # a buffer that is not divisible by 8
-        self.assertRaises(ValueError, blosc2.compress, buffer, typesize=8, shuffle=blosc2.BITSHUFFLE, clevel=1)
-
+        cbuffer = blosc2.compress(buffer, typesize=8, shuffle=blosc2.BITSHUFFLE, clevel=1)
+        dbuffer = blosc2.decompress(cbuffer)
+        self.assertTrue(buffer == dbuffer)
 
 def run(verbosity=2):
     import blosc2.core

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -60,10 +60,10 @@ def test_schunk_numpy(contiguous, urlpath, cparams, dparams, nchunks):
 @pytest.mark.parametrize(
     "nbytes, cparams, dparams, nchunks",
     [
-        (7, {"compcode": blosc2.LZ4, "clevel": 6, "typesize": 1}, {}, 0),
-        (641091, {"typesize": 1}, {"nthreads": 2}, 1),
+        (7, {"compcode": blosc2.LZ4, "clevel": 6, "typesize": 5}, {}, 1),
+        (641091, {"typesize": 3}, {"nthreads": 2}, 1),
         (136, {"typesize": 1}, {}, 5),
-        (1231, {"typesize": 1}, blosc2.dparams_dflts, 10),
+        (1231, {"typesize": 8}, blosc2.dparams_dflts, 10),
     ],
 )
 def test_schunk(contiguous, urlpath, nbytes, cparams, dparams, nchunks):

--- a/tests/test_schunk_constructor.py
+++ b/tests/test_schunk_constructor.py
@@ -16,9 +16,9 @@ import blosc2
 @pytest.mark.parametrize(
     "cparams, dparams, chunksize",
     [
-        ({"compcode": blosc2.LZ4, "clevel": 6, "typesize": 4}, {}, 40000),
-        ({"typesize": 4}, {"nthreads": 4}, 20000),
-        ({"splitmode": blosc2.ALWAYS_SPLIT, "nthreads": 5, "typesize": 4}, {"schunk": None}, 20000),
+        ({"compcode": blosc2.LZ4, "clevel": 6}, {}, 40000),
+        ({}, {"nthreads": 4}, 20000),
+        ({"splitmode": blosc2.ALWAYS_SPLIT, "nthreads": 5}, {"schunk": None}, 20000),
         ({"compcode": blosc2.LZ4HC, "typesize": 4}, {}, 40000),
     ],
 )

--- a/tests/test_schunk_delete.py
+++ b/tests/test_schunk_delete.py
@@ -27,7 +27,7 @@ def test_schunk_delete_numpy(contiguous, urlpath, nchunks, ndeletes):
     storage = {
         "contiguous": contiguous,
         "urlpath": urlpath,
-        "cparams": {"nthreads": 2, "typesize": 4},
+        "cparams": {"nthreads": 2},
         "dparams": {"nthreads": 2},
     }
     blosc2.remove_urlpath(urlpath)
@@ -70,7 +70,7 @@ def test_schunk_delete(contiguous, urlpath, nchunks, ndeletes):
     storage = {
         "contiguous": contiguous,
         "urlpath": urlpath,
-        "cparams": {"nthreads": 2, "typesize": 1},
+        "cparams": {"nthreads": 2},
         "dparams": {"nthreads": 2},
     }
     blosc2.remove_urlpath(urlpath)

--- a/tests/test_schunk_insert.py
+++ b/tests/test_schunk_insert.py
@@ -29,7 +29,7 @@ def test_schunk_insert_numpy(contiguous, urlpath, nchunks, ninserts, copy, creat
     storage = {
         "contiguous": contiguous,
         "urlpath": urlpath,
-        "cparams": {"nthreads": 2, "typesize": 4},
+        "cparams": {"nthreads": 2},
         "dparams": {"nthreads": 2},
     }
     blosc2.remove_urlpath(urlpath)
@@ -79,7 +79,7 @@ def test_insert(contiguous, urlpath, nchunks, ninserts, copy, create_chunk):
     storage = {
         "contiguous": contiguous,
         "urlpath": urlpath,
-        "cparams": {"nthreads": 2, "typesize": 1},
+        "cparams": {"nthreads": 2},
         "dparams": {"nthreads": 2},
     }
 
@@ -96,7 +96,7 @@ def test_insert(contiguous, urlpath, nchunks, ninserts, copy, create_chunk):
         pos = random.randint(0, nchunks + i)
         bytes_obj = b"i " * nbytes
         if create_chunk:
-            chunk = blosc2.compress2(bytes_obj, **storage["cparams"])
+            chunk = blosc2.compress2(bytes_obj)
             schunk.insert_chunk(pos, chunk)
         else:
             schunk.insert_data(pos, bytes_obj, copy)

--- a/tests/test_schunk_update.py
+++ b/tests/test_schunk_update.py
@@ -28,7 +28,7 @@ def test_schunk_update_numpy(contiguous, urlpath, nchunks, nupdates, copy, creat
     storage = {
         "contiguous": contiguous,
         "urlpath": urlpath,
-        "cparams": {"nthreads": 2, "typesize": 4},
+        "cparams": {"nthreads": 2},
         "dparams": {"nthreads": 2},
     }
     blosc2.remove_urlpath(urlpath)
@@ -77,7 +77,7 @@ def test_update(contiguous, urlpath, nchunks, nupdates, copy, create_chunk):
     storage = {
         "contiguous": contiguous,
         "urlpath": urlpath,
-        "cparams": {"nthreads": 2, "typesize": 1},
+        "cparams": {"nthreads": 2},
         "dparams": {"nthreads": 2},
     }
 
@@ -94,7 +94,7 @@ def test_update(contiguous, urlpath, nchunks, nupdates, copy, create_chunk):
         pos = random.randint(0, nchunks - 1)
         bytes_obj = b"i " * nbytes
         if create_chunk:
-            chunk = blosc2.compress2(bytes_obj, **storage["cparams"])
+            chunk = blosc2.compress2(bytes_obj)
             schunk.update_chunk(pos, chunk)
         else:
             schunk.update_data(pos, bytes_obj, copy)


### PR DESCRIPTION
Update c-blosc2 submodule to support again a buffer size non divisible by the `cparams.typesize`, restore some tests with that condition and restore the `pack` function in order to use the type size of the object passed and obtain better compression results.