### PR TITLE
Fix typos found by codespell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ with 64 GB RAM running Clear Linux::
       *** zstd   , bitshuffle ***  0.858 s (0.87 GB/s) / 0.054 s (13.71 GB/s)	cr:   4.6x
 
 
-For the matter of comparision, here are the results for an ARM box; an Apple MacBook Air M1 (2021)
+For the matter of comparison, here are the results for an ARM box; an Apple MacBook Air M1 (2021)
 with 8 GB of RAM::
 
     -=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,7 +20,7 @@
   different ways (sparse/contiguous and in memory/on-disk),
   as well as storing variable length metalayers.
 
-* Also, during the contruction of a `SChunk` instance,
+* Also, during the construction of a `SChunk` instance,
   an arbitrarily large data buffer can be given so that it is
   automatically split in chunks and those are appended to the
   `SChunk`.
@@ -58,7 +58,7 @@ https://www.blosc.org/posts/python-blosc2-initial-release/
 
 * Internal C-Blosc2 submodule updated to 2.0.0-rc2.
 
-* Repeating measurements 4 times in benchs so as to get more
+* Repeating measurements 4 times in benches so as to get more
   consistent figures.
 
 

--- a/bench/pack_compress.py
+++ b/bench/pack_compress.py
@@ -53,8 +53,8 @@ print(
     % (tcpy, ((N * 8 / tcpy) / 2 ** 30))
 )
 
-# Unlike numpy.zeros, numpy.zeros_like doens't use calloc, but instead uses
-# empty_like and explicitely assigns zeros, which is basically like calling
+# Unlike numpy.zeros, numpy.zeros_like doesn't use calloc, but instead uses
+# empty_like and explicitly assigns zeros, which is basically like calling
 # full like
 # Here we benchmark what happens when we allocate memory using calloc
 out_ = np.zeros(in_.shape, dtype=in_.dtype)

--- a/blosc2/SChunk.py
+++ b/blosc2/SChunk.py
@@ -37,7 +37,7 @@ class SChunk(blosc2_ext.SChunk):
     def __init__(self, chunksize=8 * 10 ** 6, data=None, mode="a", **kwargs):
         """Create a new super-chunk.
 
-        If `data` is diferent than `None`, the `data` is split into
+        If `data` is different than `None`, the `data` is split into
         chunks of size `chunksize` and these chunks are appended into the created SChunk.
 
         Parameters
@@ -47,7 +47,7 @@ class SChunk(blosc2_ext.SChunk):
             it is set to 8MB.
 
         data: bytes-like object, optional
-            The data to be splitted into different chunks of size `chunksize`.
+            The data to be split into different chunks of size `chunksize`.
 
         mode: str, optional
             Persistence mode: ‘r’ means read only (must exist);
@@ -92,7 +92,7 @@ class SChunk(blosc2_ext.SChunk):
     def append_data(self, data):
         """Append a data data to the SChunk.
 
-        Tha data buffer must be of size `chunksize` specified in
+        The data buffer must be of size `chunksize` specified in
         :func:`~blosc2.SChunk.__init__` .
 
         Parameters
@@ -130,7 +130,7 @@ class SChunk(blosc2_ext.SChunk):
         nchunk: int
             The index of the chunk that will be decompressed.
         dst: NumPy object or bytearray
-            The destination NumPy object or bytearray to fill wich
+            The destination NumPy object or bytearray to fill which
             length must be greater than 0. The user must make sure
             that it has enough capacity for hosting the decompressed
             chunk. Default is None, meaning that a new bytes object

--- a/blosc2/SChunk.py
+++ b/blosc2/SChunk.py
@@ -37,7 +37,7 @@ class SChunk(blosc2_ext.SChunk):
     def __init__(self, chunksize=8 * 10 ** 6, data=None, mode="a", **kwargs):
         """Create a new super-chunk.
 
-        If `data` is different than `None`, the `data` is split into
+        If `data` is different from `None`, the `data` is split into
         chunks of size `chunksize` and these chunks are appended into the created SChunk.
 
         Parameters
@@ -90,7 +90,7 @@ class SChunk(blosc2_ext.SChunk):
         self.mode = mode
 
     def append_data(self, data):
-        """Append a data data to the SChunk.
+        """Append a data buffer to the SChunk.
 
         The data buffer must be of size `chunksize` specified in
         :func:`~blosc2.SChunk.__init__` .
@@ -130,8 +130,8 @@ class SChunk(blosc2_ext.SChunk):
         nchunk: int
             The index of the chunk that will be decompressed.
         dst: NumPy object or bytearray
-            The destination NumPy object or bytearray to fill which
-            length must be greater than 0. The user must make sure
+            The destination NumPy object or bytearray to fill, the length
+            of which must be greater than 0. The user must make sure
             that it has enough capacity for hosting the decompressed
             chunk. Default is None, meaning that a new bytes object
             is created, filled and returned.

--- a/blosc2/blosc2_ext.pyx
+++ b/blosc2/blosc2_ext.pyx
@@ -726,7 +726,7 @@ cdef class SChunk:
                 index = i*chunksize
                 nchunks_ = blosc2_schunk_append_buffer(self.schunk, <void*>&typed_view[index], len_chunk)
                 if nchunks_ != (i + 1):
-                    raise RuntimeError("An error occured while appending the chunks")
+                    raise RuntimeError("An error occurred while appending the chunks")
 
     @property
     def c_schunk(self):

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -111,7 +111,8 @@ def decompress(src, dst=None, as_bytearray=False):
         that supports the Python Buffer Protocol, like bytes, bytearray,
         memoryview, or numpy.ndarray.
     dst : NumPy object or bytearray
-        The destination NumPy object or bytearray to fill which length must be greater than 0.
+        The destination NumPy object or bytearray to fill,
+        the length of which must be greater than 0.
         The user must make sure
         that it has enough capacity for hosting the decompressed data.
         Default is None, meaning that a new `bytes` or `bytearray` object
@@ -710,8 +711,8 @@ def decompress2(src, dst=None, **kwargs):
         that supports the Python Buffer Protocol, like bytes,
         bytearray, memoryview, or numpy.ndarray.
     dst: NumPy object or bytearray
-        The destination NumPy object or bytearray to fill which
-        length must be greater than 0. The user must make sure
+        The destination NumPy object or bytearray to fill, the length
+        of which must be greater than 0. The user must make sure
         that it has enough capacity for hosting the decompressed
         data. Default is None, meaning that a new bytes object
         is created, filled and returned.

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -111,7 +111,7 @@ def decompress(src, dst=None, as_bytearray=False):
         that supports the Python Buffer Protocol, like bytes, bytearray,
         memoryview, or numpy.ndarray.
     dst : NumPy object or bytearray
-        The destination NumPy object or bytearray to fill wich length must be greater than 0.
+        The destination NumPy object or bytearray to fill which length must be greater than 0.
         The user must make sure
         that it has enough capacity for hosting the decompressed data.
         Default is None, meaning that a new `bytes` or `bytearray` object
@@ -479,7 +479,7 @@ def set_blocksize(blocksize=0):
 
     Notes
     -----
-    This is a low-level function and is recommened for expert users only.
+    This is a low-level function and is recommended for expert users only.
 
     Examples
     --------
@@ -710,7 +710,7 @@ def decompress2(src, dst=None, **kwargs):
         that supports the Python Buffer Protocol, like bytes,
         bytearray, memoryview, or numpy.ndarray.
     dst: NumPy object or bytearray
-        The destination NumPy object or bytearray to fill wich
+        The destination NumPy object or bytearray to fill which
         length must be greater than 0. The user must make sure
         that it has enough capacity for hosting the decompressed
         data. Default is None, meaning that a new bytes object

--- a/examples/tutorial-basics.ipynb
+++ b/examples/tutorial-basics.ipynb
@@ -10,7 +10,7 @@
    "source": [
     "# Basics on Python-Blosc2\n",
     "\n",
-    "Python-Blosc2 is a thin wrapper for the C-Blosc2 format and compresion library.  It allows to easily and quicly create, append, insert, update and delete data and metadata in a super-chunk container (SChunk class)."
+    "Python-Blosc2 is a thin wrapper for the C-Blosc2 format and compression library.  It allows to easily and quickly create, append, insert, update and delete data and metadata in a super-chunk container (SChunk class)."
    ]
   },
   {


### PR DESCRIPTION
This merely fixes simple typos.

There is room for further improvement, including in places where I have fixed typos, but that can be part of a different merge request:
* _different than_ ⤑ _different from_
* _Append a data data to the SChunk_ ⤑ _Append data to the SChunk_
* _object or bytearray to fill which length must be greater than 0_ ⤑ _object or bytearray to fill, the length of which must be greater than 0_