### PR TITLE
Close file and remove unnecessary 'else' clause

### DIFF
--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -603,8 +603,9 @@ def os_release_pretty_name():
                     return value
         except IOError:
             pass
-    else:
-        return None
+        finally:
+			f.close()
+    return None
 
 
 def print_versions():


### PR DESCRIPTION
File handles are a limited resource.

The '`for`' statement has a redundant '`else`' as no '`break`' is present in the body.