### PR TITLE
Useless inheritance from object

### DIFF
--- a/tests/test_python_blosc.py
+++ b/tests/test_python_blosc.py
@@ -135,7 +135,7 @@ class TestCodec(unittest.TestCase):
         self.assertRaises(ValueError, blosc2.compress, "abc", typesize=1, cname="foo")
 
         # Create a simple mock to avoid having to create a buffer of 2 GB
-        class LenMock(object):
+        class LenMock:
             def __len__(self):
                 return blosc2.MAX_BUFFERSIZE + 1
 


### PR DESCRIPTION
It is implicit under Python 3.