### PR TITLE
Fix invalid pointer to urlpath argument

### DIFF
--- a/blosc2/blosc2_ext.pyx
+++ b/blosc2/blosc2_ext.pyx
@@ -686,7 +686,7 @@ cdef class SChunk:
 
     def __init__(self, schunk=None, chunksize=8*10**6, data=None, mode="a", **kwargs):
         # hold on to a bytestring of urlpath for the lifetime of the instance
-        # because it's value is referenced via a C-pointer
+        # because its value is referenced via a C-pointer
         urlpath = kwargs.get("urlpath", None)
         if urlpath is not None:
             self._urlpath = urlpath.encode() if isinstance(urlpath, str) else urlpath


### PR DESCRIPTION
Fixes segfaults during tests on Windows in "development mode".

The C pointer `storage.urlpath` was pointing to the value of a Python bytes instance, which got deleted while the pointer  was still in use.

I noticed that the return values of some C function calls are not checked for errors and c-blosc does not check some pointer arguments for NULL...