### PR TITLE
Removing icon of external links in the navbar

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,3 +1,5 @@
+li.nav-item i.fa-external-link-alt { display: none }
+
 :root {
     /*****************************************************************************
     * Theme config


### PR DESCRIPTION
Looks like I forgot the styles to not show the navigation as external links in this project (we've got the same in c-blosc2 and python-blosc).

With this (and https://github.com/Blosc/blogsite/pull/7 which I'll merge after this one), all the work on having an integrated website with the docs should be complete. @martaiborra if you can have a quick look when you've got the time...