### PR TITLE
Apply some pyupgrade suggestions

### DIFF
--- a/blosc2/SChunk.py
+++ b/blosc2/SChunk.py
@@ -46,8 +46,7 @@ class vlmeta(MutableMapping, blosc2_ext.vlmeta):
 
     def __iter__(self):
         keys = super(vlmeta, self).get_names()
-        for name in keys:
-            yield name
+        yield from keys
 
     def getall(self):
         """

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1009,14 +1009,14 @@ for codec, value in blosc2.Codec.__members__.items():
 def os_release_pretty_name():
     for p in ("/etc/os-release", "/usr/lib/os-release"):
         try:
-            f = open(p, "rt")
+            f = open(p)
             for line in f:
                 name, _, value = line.rstrip().partition("=")
                 if name == "PRETTY_NAME":
                     if len(value) >= 2 and value[0] in "\"'" and value[0] == value[-1]:
                         value = value[1:-1]
                     return value
-        except IOError:
+        except OSError:
             pass
         finally:
             f.close()


### PR DESCRIPTION
* The default mode for `open()` is `'r'`, a synonym of `'rt'`:
  	https://docs.python.org/3/library/functions.html#open
* `IOError` is kept for compatibility with previous versions; starting from Python 3.3, it is an alias of `OSError`:
  	https://docs.python.org/3/library/exceptions.html#IOError
* Directly yield from an iterable instead of iterating to yield items.