### PR TITLE
No need to define the encoding in Python 3

### DIFF
--- a/tests/test_python_blosc.py
+++ b/tests/test_python_blosc.py
@@ -6,7 +6,6 @@
 
 
 # Test the python-blosc API
-# -*- coding: utf-8 -*-
 
 import ctypes
 import gc


### PR DESCRIPTION
UTF-8 is the default encoding in Python 3, no need to define it explicitly any more:
```
# -*- coding: utf-8 -*-
```