### PR TITLE
os.popen2 is deprecated → subprocess.run

### DIFF
--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -7,6 +7,7 @@
 
 import os
 import pickle
+import subprocess
 import sys
 
 import blosc2
@@ -989,7 +990,8 @@ def detect_number_of_cores():
             if isinstance(ncpus, int) and ncpus > 0:
                 return ncpus
         else:  # OSX:
-            return int(os.popen2("sysctl -n hw.ncpu")[1].read())
+            return int(subprocess.run(("sysctl", "-n", "hw.ncpu"),
+                                      stdout=subprocess.PIPE).stdout)
     # Windows:
     if "NUMBER_OF_PROCESSORS" in os.environ:
         ncpus = int(os.environ["NUMBER_OF_PROCESSORS"])


### PR DESCRIPTION
See:
https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module