### PR TITLE
Apply DeepSource.io suggestions

### DIFF
--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -92,8 +92,7 @@ nthreads = ncores = detect_number_of_cores() // 2
 """Number of threads to be used in compression/decompression.
 """
 # Protection against too many threads
-if nthreads > 8:
-    nthreads = 8
+nthreads = min(nthreads, 8)
 set_nthreads(nthreads)
 
 # Defaults for compression params

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -874,7 +874,7 @@ def compressor_list():
     :func:`~blosc2.set_compressor`
 
     """
-    return list(key.lower() for key in blosc2.Codec.__members__.keys())
+    return list(key.lower() for key in blosc2.Codec.__members__)
 
 
 def set_blocksize(blocksize=0):


### PR DESCRIPTION
* Use `min` builtin
* Iterate the dictionary directly instead of `.keys()`