### PR TITLE
Variant for the © symbol: (C) → (c)

### DIFF
--- a/bench/compress_numpy.py
+++ b/bench/compress_numpy.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/get_slice.py
+++ b/bench/get_slice.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/ndarray/compare_getslice.py
+++ b/bench/ndarray/compare_getslice.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/ndarray/copy_postfilter.py
+++ b/bench/ndarray/copy_postfilter.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/ndarray/transcode_data.py
+++ b/bench/ndarray/transcode_data.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/pack_compress.py
+++ b/bench/pack_compress.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/pack_large.py
+++ b/bench/pack_large.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/pack_tensor.py
+++ b/bench/pack_tensor.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/set_slice.py
+++ b/bench/set_slice.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/bench/sum_postfilter.py
+++ b/bench/sum_postfilter.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/blosc2/blosc2_ext.pyx
+++ b/blosc2/blosc2_ext.pyx
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/blosc2/info.py
+++ b/blosc2/info.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/blosc2/schunk.py
+++ b/blosc2/schunk.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/compress2_decompress2.py
+++ b/examples/compress2_decompress2.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/compress_decompress.py
+++ b/examples/compress_decompress.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/filler.py
+++ b/examples/filler.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/gil.py
+++ b/examples/gil.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/asarray.py
+++ b/examples/ndarray/asarray.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/buffer.py
+++ b/examples/ndarray/buffer.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/bytedelta_filter.py
+++ b/examples/ndarray/bytedelta_filter.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/copy.py
+++ b/examples/ndarray/copy.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/empty.py
+++ b/examples/ndarray/empty.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/formats.py
+++ b/examples/ndarray/formats.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/getitem.py
+++ b/examples/ndarray/getitem.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/meta.py
+++ b/examples/ndarray/meta.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/ndmean.py
+++ b/examples/ndarray/ndmean.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/persistency.py
+++ b/examples/ndarray/persistency.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/resize.py
+++ b/examples/ndarray/resize.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/work_with_numpy.py
+++ b/examples/ndarray/work_with_numpy.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ndarray/zfp_codec.py
+++ b/examples/ndarray/zfp_codec.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/pack_array.py
+++ b/examples/pack_array.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/pack_tensor.py
+++ b/examples/pack_tensor.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/postfilter1.py
+++ b/examples/postfilter1.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/postfilter2.py
+++ b/examples/postfilter2.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/postfilter3.py
+++ b/examples/postfilter3.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/prefilter.py
+++ b/examples/prefilter.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/save_tensor.py
+++ b/examples/save_tensor.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/schunk.py
+++ b/examples/schunk.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/schunk_roundtrip.py
+++ b/examples/schunk_roundtrip.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ucodecs.py
+++ b/examples/ucodecs.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/ufilters.py
+++ b/examples/ufilters.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/examples/vlmeta.py
+++ b/examples/vlmeta.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_auto_parts.py
+++ b/tests/ndarray/test_auto_parts.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_buffer.py
+++ b/tests/ndarray/test_buffer.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_copy.py
+++ b/tests/ndarray/test_copy.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_empty.py
+++ b/tests/ndarray/test_empty.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_full.py
+++ b/tests/ndarray/test_full.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_getitem.py
+++ b/tests/ndarray/test_getitem.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_lossy.py
+++ b/tests/ndarray/test_lossy.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_metalayers.py
+++ b/tests/ndarray/test_metalayers.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_mode.py
+++ b/tests/ndarray/test_mode.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_numpy.py
+++ b/tests/ndarray/test_numpy.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_persistency.py
+++ b/tests/ndarray/test_persistency.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_resize.py
+++ b/tests/ndarray/test_resize.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_setitem.py
+++ b/tests/ndarray/test_setitem.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_slice.py
+++ b/tests/ndarray/test_slice.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_squeeze.py
+++ b/tests/ndarray/test_squeeze.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_struct_dtype.py
+++ b/tests/ndarray/test_struct_dtype.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/ndarray/test_zeros.py
+++ b/tests/ndarray/test_zeros.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_bytes_array.py
+++ b/tests/test_bytes_array.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_comp_info.py
+++ b/tests/test_comp_info.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_compress2.py
+++ b/tests/test_compress2.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_compression_parameters.py
+++ b/tests/test_compression_parameters.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_compressors.py
+++ b/tests/test_compressors.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_decompress.py
+++ b/tests/test_decompress.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_iterchunks.py
+++ b/tests/test_iterchunks.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_postfilters.py
+++ b/tests/test_postfilters.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_prefilters.py
+++ b/tests/test_prefilters.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_python_blosc.py
+++ b/tests/test_python_blosc.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_schunk.py
+++ b/tests/test_schunk.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_schunk_constructor.py
+++ b/tests/test_schunk_constructor.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_schunk_delete.py
+++ b/tests/test_schunk_delete.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_schunk_get_slice.py
+++ b/tests/test_schunk_get_slice.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_schunk_insert.py
+++ b/tests/test_schunk_insert.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_schunk_set_slice.py
+++ b/tests/test_schunk_set_slice.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_schunk_update.py
+++ b/tests/test_schunk_update.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_ucodecs.py
+++ b/tests/test_ucodecs.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_ufilters.py
+++ b/tests/test_ufilters.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the

--- a/tests/test_vlmeta.py
+++ b/tests/test_vlmeta.py
@@ -1,5 +1,5 @@
 #######################################################################
-# Copyright (C) 2019-present, Blosc Development team <blosc@blosc.org>
+# Copyright (c) 2019-present, Blosc Development team <blosc@blosc.org>
 # All rights reserved.
 #
 # This source code is licensed under a BSD-style license (found in the


### PR DESCRIPTION
As in https://github.com/Blosc/c-blosc2/pull/472.