### PR TITLE
Iterchunks info

### DIFF
--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -57,6 +57,14 @@ class SplitMode(Enum):
     FORWARD_COMPAT_SPLIT = 4
 
 
+class SpecialValue(Enum):
+    NOT_SPECIAL = 0
+    ZERO = 1
+    NAN = 2
+    VALUE = 3
+    UNINIT = 4
+
+
 from .blosc2_ext import (
     DEFINED_CODECS_STOP,
     EXTENDED_HEADER_LENGTH,

--- a/blosc2/blosc2_ext.pyx
+++ b/blosc2/blosc2_ext.pyx
@@ -1134,8 +1134,6 @@ cdef class SChunk:
         if not is_lazy:
             # Put a cap on the buffer size for the non-lazy chunk
             cbytes = MAX_OVERHEAD
-            # Set the lazy flag for temporarily fix the chunk
-            chunk[BLOSC2_MAX_OVERHEAD - 1] |= 0x08
         ret_chunk = PyBytes_FromStringAndSize(<char*>chunk, cbytes)
         if needs_free:
             free(chunk)

--- a/blosc2/ndarray.py
+++ b/blosc2/ndarray.py
@@ -179,20 +179,21 @@ class NDArray(blosc2_ext.NDArray):
             A namedtuple with the following fields:
             nchunk: the index of the chunk.
             coords: the coordinates where the chunk starts.
+            cratio: the compression ratio of the chunk.
             special: the special value enum of the chunk; if 0, the chunk is not special.
             repeated_value: the repeated value for the chunk; if not SpecialValue.VALUE, it is None.
             lazychunk: a buffer with the complete lazy chunk.
         """
         ChunkInfoNDArray = namedtuple(
-            "ChunkInfoNDArray", ["nchunk", "coords", "special", "repeated_value", "lazychunk"]
+            "ChunkInfoNDArray", ["nchunk", "coords", "cratio", "special", "repeated_value", "lazychunk"]
         )
         chunks_idx = np.array(self.shape) // np.array(self.chunks)
         for cinfo in self.schunk.iterchunks_info():
-            nchunk, special, repeated_value, lazychunk = cinfo
+            nchunk, cratio, special, repeated_value, lazychunk = cinfo
             coords = tuple(np.unravel_index(cinfo.nchunk, chunks_idx) * np.array(self.chunks))
             if cinfo.special == SpecialValue.VALUE:
                 repeated_value = np.frombuffer(cinfo.repeated_value, dtype=self.dtype)[0]
-            yield ChunkInfoNDArray(nchunk, coords, special, repeated_value, lazychunk)
+            yield ChunkInfoNDArray(nchunk, coords, cratio, special, repeated_value, lazychunk)
 
     def tobytes(self):
         """Returns a buffer with the data contents.

--- a/blosc2/ndarray.py
+++ b/blosc2/ndarray.py
@@ -177,20 +177,20 @@ class NDArray(blosc2_ext.NDArray):
         ------
         info: namedtuple
             A namedtuple with the following fields:
-            nchunk: the index of the chunk.
-            coords: the coordinates where the chunk starts.
-            cratio: the compression ratio of the chunk.
-            special: the special value enum of the chunk; if 0, the chunk is not special.
+            nchunk: the index of the chunk (int).
+            coords: the coordinates of the chunk, in chunk units (tuple).
+            cratio: the compression ratio of the chunk (float).
+            special: the special value enum of the chunk; if 0, the chunk is not special (SpecialValue).
             repeated_value: the repeated value for the chunk; if not SpecialValue.VALUE, it is None.
-            lazychunk: a buffer with the complete lazy chunk.
+            lazychunk: a buffer with the complete lazy chunk (bytes).
         """
         ChunkInfoNDArray = namedtuple(
             "ChunkInfoNDArray", ["nchunk", "coords", "cratio", "special", "repeated_value", "lazychunk"]
         )
-        chunks_idx = np.array(self.shape) // np.array(self.chunks)
+        chunks_idx = np.array(self.ext_shape) // np.array(self.chunks)
         for cinfo in self.schunk.iterchunks_info():
             nchunk, cratio, special, repeated_value, lazychunk = cinfo
-            coords = tuple(np.unravel_index(cinfo.nchunk, chunks_idx) * np.array(self.chunks))
+            coords = tuple(np.unravel_index(cinfo.nchunk, chunks_idx))
             if cinfo.special == SpecialValue.VALUE:
                 repeated_value = np.frombuffer(cinfo.repeated_value, dtype=self.dtype)[0]
             yield ChunkInfoNDArray(nchunk, coords, cratio, special, repeated_value, lazychunk)

--- a/blosc2/schunk.py
+++ b/blosc2/schunk.py
@@ -672,6 +672,7 @@ class SChunk(blosc2_ext.SChunk):
         for nchunk in range(self.nchunks):
             lazychunk = self.get_lazychunk(nchunk)
             # Blosc2 flags are encoded at the end of the header
+            # (see https://github.com/Blosc/c-blosc2/blob/main/README_CHUNK_FORMAT.rst)
             is_special = (lazychunk[31] & 0x70) >> 4
             special = SpecialValue(is_special)
             # The special value is encoded at the end of the header

--- a/blosc2/schunk.py
+++ b/blosc2/schunk.py
@@ -662,11 +662,11 @@ class SChunk(blosc2_ext.SChunk):
         ------
         info: namedtuple
             A namedtuple with the following fields:
-            nchunk: the index of the chunk.
-            cratio: the compression ratio of the chunk.
-            special: the special value enum of the chunk; if 0, the chunk is not special.
+            nchunk: the index of the chunk (int).
+            cratio: the compression ratio of the chunk (float).
+            special: the special value enum of the chunk; if 0, the chunk is not special (SpecialValue).
             repeated_value: the repeated value for the chunk; if not SpecialValue.VALUE, it is None.
-            lazychunk: a buffer with the complete lazy chunk.
+            lazychunk: a buffer with the complete lazy chunk (bytes).
         """
         ChunkInfo = namedtuple("ChunkInfo", ["nchunk", "cratio", "special", "repeated_value", "lazychunk"])
         for nchunk in range(self.nchunks):
@@ -677,10 +677,10 @@ class SChunk(blosc2_ext.SChunk):
             special = SpecialValue(is_special)
             # The special value is encoded at the end of the header
             repeated_value = lazychunk[32:] if special == SpecialValue.VALUE else None
-            # Compression ratio
+            # Compression ratio (nbytes and cbytes are little-endian)
             cratio = (
-                np.frombuffer(lazychunk[4:8], dtype=np.int32)[0]
-                / np.frombuffer(lazychunk[12:16], dtype=np.int32)[0]
+                np.frombuffer(lazychunk[4:8], dtype="<i4")[0]
+                / np.frombuffer(lazychunk[12:16], dtype="<i4")[0]
             )
             yield ChunkInfo(nchunk, cratio, special, repeated_value, lazychunk)
 

--- a/doc/reference/ndarray_api.rst
+++ b/doc/reference/ndarray_api.rst
@@ -17,6 +17,7 @@ Methods
     __getitem__
     __setitem__
     copy
+    iterchunks_info
     slice
     squeeze
     resize

--- a/doc/reference/schunk_api.rst
+++ b/doc/reference/schunk_api.rst
@@ -20,6 +20,7 @@ Methods
     SChunk.insert_chunk
     SChunk.insert_data
     SChunk.iterchunks
+    SChunk.iterchunks_info
     SChunk.update_chunk
     SChunk.update_data
     SChunk.get_slice

--- a/examples/ndarray/iterchunks_info.py
+++ b/examples/ndarray/iterchunks_info.py
@@ -1,0 +1,28 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+# Using the iterchunks_info for efficient iteration over chunks
+
+from time import time
+
+import blosc2
+
+shape = (1_000,) * 3
+chunks = (500,) * 3
+dtype = "f4"
+a = blosc2.full(shape, fill_value=9, chunks=chunks, dtype=dtype)
+# a = blosc2.zeros(shape, chunks=chunks, dtype=dtype)
+# print(a.info)
+
+# Iterate over chunks
+t0 = time()
+for info in a.iterchunks_info():
+    print(info)
+    # Do something with the chunk
+    pass
+print(f"Time for iterating over {a.schunk.nchunks} chunks: {time() - t0:.4f} s")

--- a/examples/ndarray/iterchunks_info.py
+++ b/examples/ndarray/iterchunks_info.py
@@ -28,5 +28,5 @@ a[slice_] = 1  # blosc2 is currently not able to determine special values in thi
 t0 = time()
 for info in a.iterchunks_info():
     print(info)
-    # Do something with the chunk
+    # Do something fancy with the chunk
 print(f"Time for iterating over {a.schunk.nchunks} chunks: {time() - t0:.4f} s")

--- a/examples/ndarray/iterchunks_info.py
+++ b/examples/ndarray/iterchunks_info.py
@@ -15,14 +15,18 @@ import blosc2
 shape = (1_000,) * 3
 chunks = (500,) * 3
 dtype = "f4"
-a = blosc2.full(shape, fill_value=9, chunks=chunks, dtype=dtype)
+
+# Create the NDArray with a mix of different special values (and not special too!)
 # a = blosc2.zeros(shape, chunks=chunks, dtype=dtype)
-# print(a.info)
+a = blosc2.full(shape, fill_value=9, chunks=chunks, dtype=dtype)
+slice_ = (slice(0, 500), slice(0, 500), slice(0, 500))
+a[slice_] = 0  # introduce a zeroed chunk (another type of special value)
+slice_ = (slice(-500, -1), slice(-500, -1), slice(-500, -1))
+a[slice_] = 1  # blosc2 is currently not able to determine special values in this case
 
 # Iterate over chunks
 t0 = time()
 for info in a.iterchunks_info():
     print(info)
     # Do something with the chunk
-    pass
 print(f"Time for iterating over {a.schunk.nchunks} chunks: {time() - t0:.4f} s")

--- a/examples/ndarray/iterchunks_info.py
+++ b/examples/ndarray/iterchunks_info.py
@@ -12,7 +12,7 @@ from time import time
 
 import blosc2
 
-shape = (1_000,) * 3
+shape = (1000,) * 3
 chunks = (500,) * 3
 dtype = "f4"
 

--- a/tests/ndarray/test_iterchunks_info.py
+++ b/tests/ndarray/test_iterchunks_info.py
@@ -15,10 +15,10 @@ import blosc2
 @pytest.mark.parametrize(
     "shape, chunks, dtype, fill_value",
     [
-        ((400, 100), (200, 10), "S10", "Hola!"),  # repeated string
-        ((1000, 100), (200, 20), np.bool_, False),  # zeros
-        ((1000, 100), (200, 20), np.int32, 1),  # ones
-        ((800, 100), (20, 20), np.float64, np.nan),  # repeated float
+        ((401, 100), (200, 10), "S10", "Hola!"),  # repeated string
+        ((1020, 100), (200, 20), np.bool_, False),  # zeros
+        ((1000, 99), (200, 20), np.int32, 1),  # ones
+        ((799, 99), (20, 20), np.float64, np.nan),  # repeated float
     ],
 )
 def test_iterchunks_info(shape, chunks, dtype, fill_value):

--- a/tests/ndarray/test_iterchunks_info.py
+++ b/tests/ndarray/test_iterchunks_info.py
@@ -1,0 +1,35 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+import numpy as np
+import pytest
+
+import blosc2
+
+
+@pytest.mark.parametrize(
+    "shape, chunks, dtype, fill_value",
+    [
+        ((400, 100), (200, 10), "S10", "Hola!"),  # repeated string
+        ((1000, 100), (200, 20), np.bool_, False),  # zeros
+        ((1000, 100), (200, 20), np.int32, 1),  # ones
+        ((800, 100), (20, 20), np.float64, np.nan),  # repeated float
+    ],
+)
+def test_iterchunks_info(shape, chunks, dtype, fill_value):
+    a = blosc2.full(shape, fill_value=fill_value, chunks=chunks, dtype=dtype)
+    slice_ = (slice(0, chunks[0]), slice(0, chunks[1]))
+    a[slice_] = 0  # introduce a zeroed chunk (another type of special value)
+
+    for i, info in enumerate(a.iterchunks_info()):
+        # print(info)
+        assert info.nchunk == i
+        if info.special == blosc2.SpecialValue.NOT_SPECIAL:
+            assert info.cratio >= 10
+        else:
+            assert info.cratio >= 50


### PR DESCRIPTION
This is a new chunk iterator optimized for retrieving metadata from chunks: cratio, whether they contain special values, and if so, which is the special value.

This is handy for iterating over datasets with a large number of chunks that are special; e.g. if some chunk is all made of zeros, it can be skipped during a reduction operation.  This can provide large speedups in e.g. sparse arrays (or arrays with lots of NaNs, or repeated values).