### PR TITLE
Remove redundant `.keys()`

### DIFF
--- a/bench/ndarray/transcode_data.py
+++ b/bench/ndarray/transcode_data.py
@@ -141,8 +141,8 @@ for fname in dir_path.iterdir():
                 "dspeed": dspeed,
                 "cratio": schunk.cratio,
             }
-            for k in meas.keys():
-                meas[k].append(this_meas[k])
+            for k, v in meas.items():
+                v.append(this_meas[k])
 
             # Skip the other filters when no compression is going on
             if clevel == 0:

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1467,7 +1467,7 @@ def register_codec(codec_name, id, encoder=None, decoder=None, version=1):
         id = 180
         blosc2.register_codec(codec_name, id, encoder, decoder)
     """
-    if id in blosc2.ucodecs_registry.keys():
+    if id in blosc2.ucodecs_registry:
         raise ValueError("Id already in use")
     blosc2_ext.register_codec(codec_name, id, encoder, decoder, version)
 
@@ -1528,6 +1528,6 @@ def register_filter(id, forward=None, backward=None, name=None):
         id = 160
         blosc2.register_filter(id, forward, backward)
     """
-    if id in blosc2.ufilters_registry.keys():
+    if id in blosc2.ufilters_registry:
         raise ValueError("Id already in use")
     blosc2_ext.register_filter(id, forward, backward, name)

--- a/blosc2/ndarray.py
+++ b/blosc2/ndarray.py
@@ -651,7 +651,7 @@ def _check_ndarray_kwargs(**kwargs):
         "contiguous",
         "mode",
     ]
-    for key in kwargs.keys():
+    for key in kwargs:
         if key not in supported_keys:
             raise KeyError(
                 f"Only {supported_keys} are supported as"

--- a/tests/ndarray/test_copy.py
+++ b/tests/ndarray/test_copy.py
@@ -33,7 +33,7 @@ def test_copy(shape, chunks1, blocks1, chunks2, blocks2, dtype):
     b = a.copy(chunks=chunks2, blocks=blocks2, cparams=cparams2)
     assert a.shape == b.shape
     assert a.schunk.dparams == b.schunk.dparams
-    for key in cparams2.keys():
+    for key in cparams2:
         if key in ("filters", "filters_meta"):
             assert b.schunk.cparams[key][: len(cparams2[key])] == cparams2[key]
             continue


### PR DESCRIPTION
When iterating over a dictionary, we iterate over the keys.