### PR TITLE
Fix partition computation (i.e. blockshape from max nitems)

### DIFF
--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1150,12 +1150,9 @@ def compute_partition(nitems, parts, maxs, blocks=False):
                     "blocks should be smaller than chunks or shape in any dim!"
                     " If you do want this blocks, please specify a chunks too."
                 )
-            if parts[i] * 2 <= maxs[i]:
-                if math.prod(parts) * 2 <= nitems:
-                    parts[i] *= 2
-            else:
-                if math.prod(parts) // parts[i] * maxs[i] <= nitems:
-                    parts[i] = maxs[i]
+            new_part = parts[i] * 2 if parts[i] * 2 <= maxs[i] else maxs[i]
+            if math.prod(parts) // parts[i] * new_part <= nitems:
+                parts[i] = new_part
         nitems_new = math.prod(parts)
         if nitems_new == nitems_prev:
             # Not progressing anymore

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1141,7 +1141,7 @@ def compute_partition(nitems, parts, maxs, blocks=False):
     if nitems == 0:
         raise ValueError("partitions with 0 dims are not supported")
     parts = list(parts)
-    while math.prod(parts) <= nitems:
+    while math.prod(parts) < nitems:
         nitems_prev = math.prod(parts)
         # Increase dims starting from the latest
         for i in reversed(range(len(parts))):

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1150,8 +1150,6 @@ def compute_partition(nitems, parts, maxs, blocks=False):
                     "blocks should be smaller than chunks or shape in any dim!"
                     " If you do want this blocks, please specify a chunks too."
                 )
-            if nitems_prev > nitems:
-                break
             if parts[i] * 2 <= maxs[i]:
                 if math.prod(parts) * 2 <= nitems:
                     parts[i] *= 2

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1156,7 +1156,8 @@ def compute_partition(nitems, parts, maxs, blocks=False):
                 if math.prod(parts) * 2 <= nitems:
                     parts[i] *= 2
             else:
-                parts[i] = maxs[i]
+                if math.prod(parts) // parts[i] * maxs[i] <= nitems:
+                    parts[i] = maxs[i]
         nitems_new = math.prod(parts)
         if nitems_new == nitems_prev:
             # Not progressing anymore


### PR DESCRIPTION
This fixes a few issues with `blosc2.core.compute_partition`, the main one being that it may return some blockshapes which exceed the given maximum number of items (`nitems`) in certain cases. For instance, a maximum shape of 3x2 with a maximum `nitems` of 4 resulted in a blockshape of 3x2 (with 6 items). Quick code to test:

```python
from blosc2.core import compute_partition as cp

chunkshape = [3, 2]
blockitems0 = 4
#chunkshape = (10, 25, 50, 50)
#blockitems0 = 2048000 // 8

# This is the initial blockshape as set by `blosc2.compute_chunks_blocks` with `blocks=None` (auto).
blockshape0 = [1 if cd == 1 else 2 for cd in chunkshape]

blockshape = compute_partition(blockitems0, blockshape0, chunkshape, True)
print(blockshape, math.prod(blockshape), '>?', blockitems0, chunkshape)
# Prints "[3, 2] 6 >? 4 [3, 2]", note that 6 > 4.
```

This does not fix the case where the initial blockshape already exceeds `nitems` (which should be unlikely).

Please note that this affects the results returned by the aforementioned function (at least in some corner cases), which may affect other software implementing the same algorithm to get the same output from the same input arguments. For instance, in the previous example not only does the new version not exceed `nitems`, i also returns a blockshape (2x2) which is not a multiple of the given chunkshape (3x2).