### PR TITLE
Add optional offset to open function

### DIFF
--- a/blosc2/blosc2_ext.pyx
+++ b/blosc2/blosc2_ext.pyx
@@ -337,7 +337,7 @@ cdef extern from "blosc2.h":
     blosc2_schunk *blosc2_schunk_new(blosc2_storage *storage)
     blosc2_schunk *blosc2_schunk_copy(blosc2_schunk *schunk, blosc2_storage *storage)
     blosc2_schunk *blosc2_schunk_from_buffer(uint8_t *cframe, int64_t len, c_bool copy)
-    blosc2_schunk *blosc2_schunk_open(const char* urlpath)
+    blosc2_schunk *blosc2_schunk_open_offset(const char* urlpath, int64_t offset)
 
     int64_t blosc2_schunk_to_buffer(blosc2_schunk* schunk, uint8_t** cframe, c_bool* needs_free)
     void blosc2_schunk_avoid_cframe_free(blosc2_schunk *schunk, c_bool avoid_cframe_free)
@@ -1680,11 +1680,11 @@ def meta_keys(self):
     return keys
 
 
-def open(urlpath, mode, **kwargs):
+def open(urlpath, mode, offset, **kwargs):
     urlpath_ = urlpath.encode("utf-8") if isinstance(urlpath, str) else urlpath
-    cdef blosc2_schunk* schunk = blosc2_schunk_open(urlpath_)
+    cdef blosc2_schunk* schunk = blosc2_schunk_open_offset(urlpath_, offset)
     if schunk == NULL:
-        raise RuntimeError(f'blosc2_schunk_open({urlpath!r}) returned NULL')
+        raise RuntimeError(f'blosc2_schunk_open_offset({urlpath!r}, {offset!r}) returned NULL')
 
     meta1 = "b2nd"
     meta1 = meta1.encode("utf-8") if isinstance(meta1, str) else meta1

--- a/blosc2/schunk.py
+++ b/blosc2/schunk.py
@@ -924,7 +924,7 @@ class SChunk(blosc2_ext.SChunk):
         super(SChunk, self).__dealloc__()
 
 
-def open(urlpath, mode="a", **kwargs):
+def open(urlpath, mode="a", offset=0, **kwargs):
     """Open a persistent :ref:`SChunk <SChunk>` (or :ref:`NDArray <NDArray>`).
 
     Parameters
@@ -934,6 +934,9 @@ def open(urlpath, mode="a", **kwargs):
         is stored.
     mode: str, optional
         The open mode.
+    offset: int, optional
+        An offset in the file where super-chunk or array data is located
+        (e.g. in a file containing several such objects).
 
     Other parameters
     ----------------
@@ -980,4 +983,4 @@ def open(urlpath, mode="a", **kwargs):
     """
     if not os.path.exists(urlpath):
         raise FileNotFoundError(f"No such file or directory: {urlpath}")
-    return blosc2_ext.open(urlpath, mode, **kwargs)
+    return blosc2_ext.open(urlpath, mode, offset, **kwargs)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -83,3 +83,39 @@ def test_open(contiguous, urlpath, cparams, dparams, nchunks, chunk_nitems, dtyp
 def test_open_fake():
     with pytest.raises(FileNotFoundError):
         _ = blosc2.open("none.b2nd")
+
+
+@pytest.mark.parametrize("offset", [0, 42])
+@pytest.mark.parametrize("urlpath", ["schunk.b2frame"])
+def test_open_offset(offset, urlpath):
+    urlpath_temp = urlpath + ".temp"
+
+    blosc2.remove_urlpath(urlpath)
+    blosc2.remove_urlpath(urlpath_temp)
+
+    # Create a temporary file with data.
+    data = np.arange(100)
+    schunk_temp = blosc2.SChunk(data=data, urlpath=urlpath_temp)
+    del schunk_temp
+    # Create the final file with the temporary data after "offset" bytes.
+    with open(urlpath, "wb") as schunk_file:
+        schunk_temp_data = None
+        with open(urlpath_temp, "rb") as schunk_temp_file:
+            schunk_temp_data = schunk_temp_file.read()
+        schunk_file.seek(offset)
+        schunk_file.write(schunk_temp_data)
+    blosc2.remove_urlpath(urlpath_temp)
+
+    schunk_open = blosc2.open(urlpath, "r", offset=offset)
+    schunk_data = schunk_open[:]
+    del schunk_open
+    assert np.array_equal(schunk_data, data.tobytes())
+
+    with pytest.raises(RuntimeError):
+        blosc2.open(urlpath, "r", offset=offset + 1)
+
+    if offset > 0:
+        with pytest.raises(RuntimeError):
+            blosc2.open(urlpath, "r")
+
+    blosc2.remove_urlpath(urlpath)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -95,8 +95,7 @@ def test_open_offset(offset, urlpath):
 
     # Create a temporary file with data.
     data = np.arange(100)
-    schunk_temp = blosc2.SChunk(data=data, urlpath=urlpath_temp)
-    del schunk_temp
+    blosc2.SChunk(data=data, urlpath=urlpath_temp)
     # Create the final file with the temporary data after "offset" bytes.
     with open(urlpath, "wb") as schunk_file:
         schunk_temp_data = None
@@ -106,9 +105,7 @@ def test_open_offset(offset, urlpath):
         schunk_file.write(schunk_temp_data)
     blosc2.remove_urlpath(urlpath_temp)
 
-    schunk_open = blosc2.open(urlpath, "r", offset=offset)
-    schunk_data = schunk_open[:]
-    del schunk_open
+    schunk_data = blosc2.open(urlpath, "r", offset=offset)[:]
     assert np.array_equal(schunk_data, data.tobytes())
 
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
The new optional `offset` argument to `blosc2.schunk.open` allows providing an offset for Blosc2 super-chunks stored inside of other container files (like HDF5). Doc updates and a simple unit test are provided.