### PR TITLE
New NDArray.to_cframe() method and blosc2.ndarray_from_cframe() function

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,8 @@
 
 ## Changes from 2.2.9 to 2.2.10
 
-XXX version-specific blurb XXX
+* New `NDArray.to_cframe()` method and `blosc2.ndarray_from_cframe()` function for
+  serializing and deserializing NDArrays to/from contiguous in-memory frames.
 
 ## Changes from 2.2.8 to 2.2.9
 

--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -73,7 +73,8 @@ class Tuner(Enum):
 
     #: A 'simple' tuner. This is the default in the Blosc2 library
     STUNE = 0
-    #: A more sophisticated tuner that can select different codecs/filters for different chunks (more info `here <https://github.com/Blosc/blosc2_btune/>`_).
+    #: A more sophisticated tuner that can select different codecs/filters for different chunks
+    #: (more info `here <https://github.com/Blosc/blosc2_btune/>`_).
     BTUNE = 32
 
 
@@ -107,6 +108,7 @@ from .core import (
     get_compressor,
     load_array,
     load_tensor,
+    ndarray_from_cframe,
     pack,
     pack_array,
     pack_array2,

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1402,8 +1402,32 @@ def schunk_from_cframe(cframe, copy=False):
     return blosc2_ext.schunk_from_cframe(cframe, copy)
 
 
+def ndarray_from_cframe(cframe, copy=False):
+    """Create a :ref:`NDArray <NDArray>` instance out of a contiguous frame buffer.
+
+    Parameters
+    ----------
+    cframe: bytes /str
+        The bytes object containing the in-memory cframe.
+    copy: bool
+        Whether to internally do a copy or not. If `False`,
+        the user is responsible for keeping a reference to `cframe`.
+
+    Returns
+    -------
+    out: :ref:`NDArray <NDArray>`
+        A new :ref:`NDArray <NDArray>` containing the data passed.
+
+    See Also
+    --------
+    :func:`~blosc2.ndarray.NDArray.to_cframe`
+
+    """
+    return blosc2_ext.ndarray_from_cframe(cframe, copy)
+
+
 def register_codec(codec_name, id, encoder=None, decoder=None, version=1):
-    """Register an user defined codec.
+    """Register a user defined codec.
 
     Parameters
     ----------

--- a/blosc2/ndarray.py
+++ b/blosc2/ndarray.py
@@ -218,6 +218,21 @@ class NDArray(blosc2_ext.NDArray):
         """
         return super().tobytes()
 
+    def to_cframe(self):
+        """Get a bytes object containing the serialized :ref:`NDArray <NDArray>` instance.
+
+        Returns
+        -------
+        out: bytes
+            The buffer containing the serialized :ref:`NDArray <NDArray>` instance.
+
+        See Also
+        --------
+        :func:`~blosc2.ndarray_from_cframe`
+
+        """
+        return super(NDArray, self).to_cframe()
+
     def copy(self, dtype=None, **kwargs):
         """Create a copy of an array with same parameters.
 
@@ -654,9 +669,7 @@ def _check_ndarray_kwargs(**kwargs):
     for key in kwargs:
         if key not in supported_keys:
             raise KeyError(
-                f"Only {supported_keys} are supported as"
-                f" keyword arguments"
-                f", and you passed {key}"
+                f"Only {supported_keys} are supported as" f" keyword arguments" f", and you passed {key}"
             )
     if "cparams" in kwargs and "chunks" in kwargs["cparams"]:
         raise ValueError("You cannot pass chunks in cparams, use `chunks` argument instead")

--- a/tests/ndarray/test_ndarray.py
+++ b/tests/ndarray/test_ndarray.py
@@ -1,0 +1,46 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+import numpy as np
+import pytest
+
+import blosc2
+
+
+@pytest.mark.parametrize("contiguous", [True, False])
+@pytest.mark.parametrize("urlpath", [None, "b2frame"])
+@pytest.mark.parametrize(
+    "cparams, dparams, nchunks",
+    [
+        ({"codec": blosc2.Codec.LZ4, "clevel": 6, "typesize": 4}, {}, 1),
+        ({"typesize": 4}, {"nthreads": 4}, 1),
+        ({"splitmode": blosc2.SplitMode.ALWAYS_SPLIT, "typesize": 4}, {}, 5),
+        ({"codec": blosc2.Codec.LZ4HC, "typesize": 4}, {}, 10),
+    ],
+)
+@pytest.mark.parametrize("copy", [True, False])
+def test_ndarray_cframe(contiguous, urlpath, cparams, dparams, nchunks, copy):
+    storage = {"contiguous": contiguous, "urlpath": urlpath, "cparams": cparams, "dparams": dparams}
+    blosc2.remove_urlpath(urlpath)
+
+    data = np.arange(200 * 1000 * nchunks, dtype="int32").reshape(200, 1000, nchunks)
+    ndarray = blosc2.asarray(data, **storage)
+
+    cframe = ndarray.to_cframe()
+    ndarray2 = blosc2.ndarray_from_cframe(cframe, copy)
+
+    data2 = ndarray2[:]
+    assert np.array_equal(data, data2)
+
+    cframe = ndarray.to_cframe()
+    ndarray3 = blosc2.schunk_from_cframe(cframe, copy)
+    del ndarray3
+    # Check that we can still access the external cframe buffer
+    _ = str(cframe)
+
+    blosc2.remove_urlpath(urlpath)


### PR DESCRIPTION
This allows serializing and deserializing NDArrays to/from contiguous in-memory frames.

Closes feature requests #114 and #146.