### PR TITLE
Fix vlmeta.to_dict not honoring tuple encoding

### DIFF
--- a/blosc2/blosc2_ext.pyx
+++ b/blosc2/blosc2_ext.pyx
@@ -1649,7 +1649,7 @@ cdef class vlmeta:
             raise RuntimeError
         res = {}
         for i in range(rc):
-            res[names[i]] = unpackb(self.get_vlmeta(names[i]))
+            res[names[i]] = unpackb(self.get_vlmeta(names[i]), list_hook=decode_tuple)
         return res
 
 

--- a/tests/test_vlmeta.py
+++ b/tests/test_vlmeta.py
@@ -57,6 +57,7 @@ def test_schunk(contiguous, urlpath, nbytes, cparams, dparams, nchunks):
         assert nchunks_ == (i + 1)
 
     add(schunk)
+    to_dict(schunk)
     iter(schunk)
     delete(schunk)
     clear(schunk)
@@ -68,12 +69,26 @@ def add(schunk):
     schunk.vlmeta["vlmeta1"] = b"val1"
     schunk.vlmeta["vlmeta2"] = "val2"
     schunk.vlmeta["vlmeta3"] = {b"lorem": 4231}
+    schunk.vlmeta["vlmeta4"] = [1, 2, 3]
+    schunk.vlmeta["vlmeta5"] = (1, 2, 3)
 
     assert schunk.vlmeta["vlmeta1"] == b"val1"
     assert schunk.vlmeta["vlmeta2"] == "val2"
     assert schunk.vlmeta["vlmeta3"] == {b"lorem": 4231}
+    assert schunk.vlmeta["vlmeta4"] == [1, 2, 3]
+    assert schunk.vlmeta["vlmeta5"] == (1, 2, 3)
     assert "vlmeta1" in schunk.vlmeta
-    assert len(schunk.vlmeta) == 3
+    assert len(schunk.vlmeta) == 5
+
+
+def to_dict(schunk):
+    assert schunk.vlmeta.to_dict() == {
+        b"vlmeta1": b"val1",
+        b"vlmeta2": "val2",
+        b"vlmeta3": {b"lorem": 4231},
+        b"vlmeta4": [1, 2, 3],
+        b"vlmeta5": (1, 2, 3),
+    }
 
 
 def delete(schunk):
@@ -83,13 +98,15 @@ def delete(schunk):
     assert "vlmeta2" not in schunk.vlmeta
     assert schunk.vlmeta["vlmeta1"] == b"val1"
     assert schunk.vlmeta["vlmeta3"] == {b"lorem": 4231}
+    assert schunk.vlmeta["vlmeta4"] == [1, 2, 3]
+    assert schunk.vlmeta["vlmeta5"] == (1, 2, 3)
     with pytest.raises(KeyError):
         schunk.vlmeta["vlmeta2"]
-    assert len(schunk.vlmeta) == 2
+    assert len(schunk.vlmeta) == 4
 
 
 def iter(schunk):
-    keys = ["vlmeta1", "vlmeta2", "vlmeta3"]
+    keys = ["vlmeta1", "vlmeta2", "vlmeta3", "vlmeta4", "vlmeta5"]
     i = 0
     for vlmeta in schunk.vlmeta:
         assert vlmeta == keys[i]
@@ -100,7 +117,7 @@ def clear(schunk):
     nparray = np.arange(start=0, stop=2)
     schunk.vlmeta["vlmeta2"] = nparray.tobytes()
     assert schunk.vlmeta["vlmeta2"] == nparray.tobytes()
-    assert schunk.vlmeta.__len__() == 3
+    assert schunk.vlmeta.__len__() == 5
 
     schunk.vlmeta.clear()
     assert schunk.vlmeta.__len__() == 0


### PR DESCRIPTION
All other vlmeta encoding/decoding code uses `blosc2_ext.encode/decode_tuple` to preserve tuple objects, but `vlmeta.to_dict()` in the extension was an exception:

```
>>> import blosc2
>>> a = blosc2.empty(shape=(10,10))
>>> a.schunk.vlmeta['l'] = [1,2,3]
>>> a.schunk.vlmeta['t'] = (1,2,3)
>>> a.schunk.vlmeta['l']
[1, 2, 3]
>>> a.schunk.vlmeta['t']
(1, 2, 3)
>>> a.schunk.vlmeta.to_dict()
{b'l': [1, 2, 3], b't': ['__tuple__', 1, 2, 3]}
```

This fixes the issue and performs some minor extra testing for list and tuple encoding.