### PR TITLE
New lazyexpr() constructor

### DIFF
--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -181,7 +181,7 @@ from .ndarray import (  # noqa: I001
     get_slice_nchunks,
 )
 
-from .lazyexpr import LazyExpr, lazyudf, LazyArray, _open_lazyarray
+from .lazyexpr import LazyExpr, lazyudf, lazyexpr, LazyArray, _open_lazyarray
 
 from .schunk import SChunk, open
 from .version import __version__
@@ -347,4 +347,6 @@ __all__ = [
     "compute_chunks_blocks",
     "cpu_info",
     "get_slice_nchunks",
+    "lazyexpr",
+    "lazyudf",
 ]

--- a/blosc2/lazyexpr.py
+++ b/blosc2/lazyexpr.py
@@ -551,7 +551,7 @@ def slices_eval(
         if len(operands_) == 0:
             # We do not support this case yet.
             # TODO: use ndarray.compute_chunks_blocks() to get the chunks and blocks for this case
-            raise ValueError("At least one of the operands should be a NDArray instance")
+            raise ValueError("This case requires at least one of the operands to be a NDArray instance")
         operand = operands_[0]
         shape = operand.shape
     chunks = operand.chunks

--- a/blosc2/lazyexpr.py
+++ b/blosc2/lazyexpr.py
@@ -1500,6 +1500,8 @@ def lazyexpr(expression, operands, out=None):
     """
     if isinstance(expression, LazyExpr):
         expression.operands.update(operands)
+        if out is not None:
+            expression._output = out
         return expression
     return LazyExpr._new_expr(expression, operands, out=out)
 

--- a/doc/reference/lazyarray.rst
+++ b/doc/reference/lazyarray.rst
@@ -3,7 +3,16 @@
 LazyArray API
 =============
 
-This is a class for evaluating an expression or a Python user defined function.
+This is an interface for evaluating an expression or a Python user defined function.
+
+You can get an object following the LazyArray API with any of the following ways:
+
+* Any expression that involves one or more NDArray objects. e.g. ``a + b``, where
+  `a` and `b` are NDArray objects.
+* Using the `lazyexpr` constructor.
+* Using the `lazyudf` constructor.
+
+See the `LazyExpr`_ and `LazyUDF`_ sections for more information.
 
 .. currentmodule:: blosc2.LazyArray
 
@@ -14,8 +23,8 @@ Methods
     :toctree: autofiles/lazyarray
     :nosignatures:
 
-    eval
     __getitem__
+    eval
     save
 
 
@@ -24,16 +33,22 @@ Methods
 LazyExpr Usage
 --------------
 
-For getting a LazyArray from a expression, you would proceed in a similar manner
-than with numexpr.
+For getting a LazyArray-compliant object from an expression (à la numexpr), you can use the
+lazyexpr constructor.
+
+.. autosummary::
+    :toctree: autofiles/lazyarray
+    :nosignatures:
+
+    lazyexpr
 
 .. _LazyUDF:
 
 LazyUDF Usage
 -------------
 
-For getting a LazyArray from a user-defined Python function, you will have to
-follow the specifications in the lazyudf constructor.
+For getting a LazyArray-compliant object from a user-defined Python function, you can use the
+lazyudf constructor.
 
 .. currentmodule:: blosc2
 

--- a/examples/ndarray/general_expressions.py
+++ b/examples/ndarray/general_expressions.py
@@ -1,0 +1,51 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+# This shows how to build expressions with a general mix of NDArray and NumPy operands.
+
+import numpy as np
+
+import blosc2
+
+shape = (50, 50)
+
+# Create a NDArray from a NumPy array
+npa = np.linspace(0, 1, np.prod(shape), dtype=np.float32).reshape(shape)
+npb = np.linspace(1, 2, np.prod(shape), dtype=np.float64).reshape(shape)
+npc = npa**2 + npb**2 + 2 * npa * npb + 1
+
+a = blosc2.asarray(npa)
+b = blosc2.asarray(npb)
+
+# Get a LazyExpr instance with all NDArray operands
+c = blosc2.lazyexpr("a**2 + b**2 + 2 * a * b + 1", {"a": a, "b": b})
+d = c.eval()
+assert np.allclose(d[:], npc)
+
+# A LazyExpr instance with a mix of NDArray and NumPy operands
+c = blosc2.lazyexpr("a**2 + b**2 + 2 * a * b + 1", {"a": npa, "b": b})
+d = c.eval()
+assert np.allclose(d[:], npc)
+
+# A LazyExpr instance with a all NumPy operands
+c = blosc2.lazyexpr("a**2 + b**2 + 2 * a * b + 1", {"a": npa, "b": npb})
+d = c.eval()
+assert np.allclose(d[:], npc)
+
+# Evaluate partial slices
+npd = c[1]
+# Check
+assert np.allclose(npd, npc[1])
+
+npd = c[1:10]
+# Check
+assert np.allclose(npd, npc[1:10])
+
+print(d.info)
+
+print("Lazy expression evaluated correctly in-memory!")

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -676,3 +676,25 @@ def test_lazyexpr(array_fixture, operands):
     np.testing.assert_allclose(res, nres[0:10])
     res = expr[0:10:2]
     np.testing.assert_allclose(res, nres[0:10:2])
+
+
+@pytest.mark.parametrize(
+    "out_param",
+    ["NDArray", "numpy"],
+)
+def test_lazyexpr_out(array_fixture, out_param):
+    a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    operands = {"a1": na1, "a2": a2}
+    if out_param == "NDArray":
+        out = a3
+    else:
+        out = na3
+    expr = blosc2.lazyexpr("a1 + a2", operands=operands, out=out)
+    res = expr.eval()  # res should be equal to out
+    assert res is out
+    nres = ne.evaluate("na1 + na2", out=na4)
+    assert nres is na4
+    if out_param == "NDArray":
+        np.testing.assert_allclose(res[:], nres)
+    else:
+        np.testing.assert_allclose(na3, na4)

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -714,3 +714,11 @@ def test_lazyexpr_out(array_fixture, out_param, operand_mix):
         np.testing.assert_allclose(res[:], nres)
     else:
         np.testing.assert_allclose(na3, na4)
+
+    # Use an existing LazyExpr as expression
+    expr = blosc2.lazyexpr("a1 - a2", operands=operands)
+    operands = {"a1": a1, "a2": a2}
+    expr2 = blosc2.lazyexpr(expr, operands=operands, out=out)
+    assert expr2.eval() is out
+    nres = ne.evaluate("na1 - na2")
+    np.testing.assert_allclose(out[:], nres)

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -642,7 +642,7 @@ def test_broadcasting(broadcast_fixture):
 
 
 @pytest.mark.parametrize(
-    "operands",
+    "operand_mix",
     [
         ("NDArray", "numpy"),
         ("NDArray", "NDArray"),
@@ -650,13 +650,13 @@ def test_broadcasting(broadcast_fixture):
         ("numpy", "numpy"),
     ],
 )
-def test_lazyexpr(array_fixture, operands):
+def test_lazyexpr(array_fixture, operand_mix):
     a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
-    if operands[0] == "NDArray" and operands[1] == "NDArray":
+    if operand_mix[0] == "NDArray" and operand_mix[1] == "NDArray":
         operands = {"a1": a1, "a2": a2, "a3": a3, "a4": a4}
-    elif operands[0] == "NDArray" and operands[1] == "numpy":
+    elif operand_mix[0] == "NDArray" and operand_mix[1] == "numpy":
         operands = {"a1": a1, "a2": na2, "a3": a3, "a4": na4}
-    elif operands[0] == "numpy" and operands[1] == "NDArray":
+    elif operand_mix[0] == "numpy" and operand_mix[1] == "NDArray":
         operands = {"a1": na1, "a2": a2, "a3": na3, "a4": a4}
     else:
         operands = {"a1": na1, "a2": na2, "a3": na3, "a4": na4}
@@ -679,12 +679,28 @@ def test_lazyexpr(array_fixture, operands):
 
 
 @pytest.mark.parametrize(
+    "operand_mix",
+    [
+        ("NDArray", "numpy"),
+        ("NDArray", "NDArray"),
+        ("numpy", "NDArray"),
+        # ("numpy", "numpy"),    # TODO: Add support for this case
+    ],
+)
+@pytest.mark.parametrize(
     "out_param",
     ["NDArray", "numpy"],
 )
-def test_lazyexpr_out(array_fixture, out_param):
+def test_lazyexpr_out(array_fixture, out_param, operand_mix):
     a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
-    operands = {"a1": na1, "a2": a2}
+    if operand_mix[0] == "NDArray" and operand_mix[1] == "NDArray":
+        operands = {"a1": a1, "a2": a2}
+    elif operand_mix[0] == "NDArray" and operand_mix[1] == "numpy":
+        operands = {"a1": a1, "a2": na2}
+    elif operand_mix[0] == "numpy" and operand_mix[1] == "NDArray":
+        operands = {"a1": na1, "a2": a2}
+    else:
+        operands = {"a1": na1, "a2": na2}
     if out_param == "NDArray":
         out = a3
     else:


### PR DESCRIPTION
This allows to build expressions that contains all operands as numpy arrays.  Also has an `out=` param for allowing to store the output of the evaluation there (although both options at the same time are not supported yet).  E.g.:

```
operands = {"a1": na1, "a2": a2}
out = np.array_like(na1)
expr = blosc2.lazyexpr("a1 + a2", operands=operands, out=out)
res = expr.eval()
assert out is res
```