### PR TITLE
Reductions now output numpy arrays

### DIFF
--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -398,13 +398,10 @@ def test_save():
     chunks = tuple([i // 2 for i in nres.shape])
     blocks = tuple([i // 4 for i in nres.shape])
     urlpath_eval = "eval_expr.b2nd"
-    res = expr.eval(urlpath=urlpath_eval, cparams=cparams, dparams=dparams, chunks=chunks, blocks=blocks)
+    res = expr.eval(
+        urlpath=urlpath_eval, cparams=cparams, dparams=dparams, mode="w", chunks=chunks, blocks=blocks
+    )
     np.testing.assert_allclose(res[:], nres, rtol=tol, atol=tol)
-
-    # Remove data in memory before opening on-disk LazyExpr
-    for op in ops:
-        del op
-    del expr
 
     expr = blosc2.open(urlpath_save)
     # Check the dtype (should be upcasted to float64)
@@ -417,7 +414,7 @@ def test_save():
 
     urlpath_save2 = "expr_str.b2nd"
     x = 3
-    expr = "a1  / a2 + a2 - a3 * a4**x"
+    expr = "a1 / a2 + a2 - a3 * a4**x"
     var_dict = {"a1": ops[0], "a2": ops[1], "a3": ops[2], "a4": ops[3], "x": x}
     lazy_expr = eval(expr, var_dict)
     lazy_expr.save(urlpath=urlpath_save2)

--- a/tests/ndarray/test_lazyexpr_fields.py
+++ b/tests/ndarray/test_lazyexpr_fields.py
@@ -234,3 +234,15 @@ def test_where_reduction(array_fixture):
     res = expr.where(0, 1).sum(axis=axis)
     nres = ne.evaluate("where(na1**2 + na2**2 > 2 * na1 * na2 + 1, 0, 1)").sum(axis=axis)
     np.testing.assert_allclose(res, nres)
+
+
+# Test an expression with where() and a reduction
+# This is a more complex case with two where() calls
+def test_where_reduction2(array_fixture):
+    sa1, sa2, nsa1, nsa2, a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    expr = a1**2 + a2**2 > 2 * a1 * a2 + 1
+    npexpr = na1**2 + na2**2 > 2 * na1 * na2 + 1
+    axis = None if sa1.ndim == 1 else 1
+    res = expr.where(0, 1) + expr.where(0, 1).sum(axis=axis)
+    nres = np.where(npexpr, 0, 1) + np.where(npexpr, 0, 1).sum(axis=axis)
+    np.testing.assert_allclose(res[:], nres)

--- a/tests/ndarray/test_lazyexpr_fields.py
+++ b/tests/ndarray/test_lazyexpr_fields.py
@@ -230,9 +230,7 @@ def test_where_getitem_field(array_fixture):
 def test_where_reduction(array_fixture):
     sa1, sa2, nsa1, nsa2, a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
     expr = a1**2 + a2**2 > 2 * a1 * a2 + 1
-    # Test with eval only, as reduction always returns an NDArray
     axis = None if sa1.ndim == 1 else 1
     res = expr.where(0, 1).sum(axis=axis)
-    assert isinstance(res, blosc2.NDArray)
     nres = ne.evaluate("where(na1**2 + na2**2 > 2 * na1 * na2 + 1, 0, 1)").sum(axis=axis)
-    np.testing.assert_allclose(res[()], nres)
+    np.testing.assert_allclose(res, nres)

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -92,14 +92,11 @@ def test_reduce_params(array_fixture, axis, keepdims, dtype_out, reduce_op):
         res = getattr(expr, reduce_op)(axis=axis, keepdims=keepdims)
         nres = getattr(nres, reduce_op)(axis=axis, keepdims=keepdims)
     tol = 1e-15 if a1.dtype == "float64" else 1e-6
-    # TODO: the [()] should not be needed, because it should be a NumPy array
-    np.testing.assert_allclose(res[()], nres, atol=tol, rtol=tol)
+    np.testing.assert_allclose(res, nres, atol=tol, rtol=tol)
 
 
-# TODO: "any" and "all" are not supported yet because:
-# ne.evaluate('(o0 + o1)', local_dict = {'o0': np.array(True), 'o1': np.array(True)})
-# is not supported by NumExpr
-@pytest.mark.parametrize("reduce_op", ["sum", "min", "max", "mean", "std", "var"])
+# TODO: "prod" is not supported here because it overflows with current values
+@pytest.mark.parametrize("reduce_op", ["sum", "min", "max", "mean", "std", "var", "any", "all"])
 @pytest.mark.parametrize("axis", [0, 1, None])
 def test_reduce_expr_arr(array_fixture, axis, reduce_op):
     a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
@@ -108,11 +105,9 @@ def test_reduce_expr_arr(array_fixture, axis, reduce_op):
     expr = a1 + a2 - a3 * a4
     nres = eval("na1 + na2 - na3 * na4")
     res = getattr(expr, reduce_op)(axis=axis) + getattr(a1, reduce_op)(axis=axis)
-    # print(f"res: {res}")
     nres = getattr(nres, reduce_op)(axis=axis) + getattr(na1, reduce_op)(axis=axis)
     tol = 1e-15 if a1.dtype == "float64" else 1e-6
-    # TODO: the [()] should not be needed, because it should be a NumPy array
-    np.testing.assert_allclose(res[()], nres, atol=tol, rtol=tol)
+    np.testing.assert_allclose(res, nres, atol=tol, rtol=tol)
 
 
 # Test broadcasting
@@ -145,5 +140,4 @@ def test_broadcast_params(axis, keepdims, reduce_op, shapes):
     nres = eval(f"na1 + na2 - na3 - (na1 * na2 + 1).{reduce_op}(axis={axis}, keepdims={keepdims})")
 
     tol = 1e-14 if a1.dtype == "float64" else 1e-5
-    # TODO: the [()] should not be needed, because it should be a NumPy array
-    np.testing.assert_allclose(res[()], nres, atol=tol, rtol=tol)
+    np.testing.assert_allclose(res[:], nres, atol=tol, rtol=tol)

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -58,7 +58,7 @@ def test_reduce_bool(array_fixture, reduce_op):
     res = getattr(expr, reduce_op)()
     nres = getattr(nres, reduce_op)()
     tol = 1e-15 if a1.dtype == "float64" else 1e-6
-    np.testing.assert_allclose(res[()], nres, atol=tol, rtol=tol)
+    np.testing.assert_allclose(res, nres, atol=tol, rtol=tol)
 
 
 @pytest.mark.parametrize("reduce_op", ["sum", "prod", "mean", "std", "var", "min", "max", "any", "all"])
@@ -92,6 +92,7 @@ def test_reduce_params(array_fixture, axis, keepdims, dtype_out, reduce_op):
         res = getattr(expr, reduce_op)(axis=axis, keepdims=keepdims)
         nres = getattr(nres, reduce_op)(axis=axis, keepdims=keepdims)
     tol = 1e-15 if a1.dtype == "float64" else 1e-6
+    # TODO: the [()] should not be needed, because it should be a NumPy array
     np.testing.assert_allclose(res[()], nres, atol=tol, rtol=tol)
 
 
@@ -108,10 +109,10 @@ def test_reduce_expr_arr(array_fixture, axis, reduce_op):
     nres = eval("na1 + na2 - na3 * na4")
     res = getattr(expr, reduce_op)(axis=axis) + getattr(a1, reduce_op)(axis=axis)
     # print(f"res: {res}")
-    res = res[()]
     nres = getattr(nres, reduce_op)(axis=axis) + getattr(na1, reduce_op)(axis=axis)
     tol = 1e-15 if a1.dtype == "float64" else 1e-6
-    np.testing.assert_allclose(res, nres, atol=tol, rtol=tol)
+    # TODO: the [()] should not be needed, because it should be a NumPy array
+    np.testing.assert_allclose(res[()], nres, atol=tol, rtol=tol)
 
 
 # Test broadcasting
@@ -144,4 +145,5 @@ def test_broadcast_params(axis, keepdims, reduce_op, shapes):
     nres = eval(f"na1 + na2 - na3 - (na1 * na2 + 1).{reduce_op}(axis={axis}, keepdims={keepdims})")
 
     tol = 1e-14 if a1.dtype == "float64" else 1e-5
+    # TODO: the [()] should not be needed, because it should be a NumPy array
     np.testing.assert_allclose(res[()], nres, atol=tol, rtol=tol)


### PR DESCRIPTION
By returning results of reductions as numpy arrays, users will receive the expected output in their workflows.  The drawbacks are that the data returned is uncompressed (numpy array), so it will take more space in memory, and that the user cannot specify the result to be on-disk.

This decision is justified not only by convenience, but also by the fact that reduced data should, in general, take (much) less space than regular NDArrays.  That should be enough for most of use cases.  For the rest, one could add a new `out` parameter (or `kwargs` for the NDArray properties, to be discussed) to the reduction functions in the future. 

Finally, this PR also enables expressions coming from the fusion of other expressions to be new instances.  This facilitates expression handling, as this is the normal behavior of programming languages. 