### PR TITLE
Caterva2 context managers

### DIFF
--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -185,7 +185,7 @@ from .ndarray import (  # noqa: I001
     get_slice_nchunks,
 )
 
-from .c2array import c2sub_urlbase, c2sub_auth_cookie, C2Array, URLPath
+from .c2array import c2context, C2Array, URLPath
 
 from .lazyexpr import LazyExpr, lazyudf, lazyexpr, LazyArray, _open_lazyarray
 

--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -184,7 +184,7 @@ from .ndarray import (  # noqa: I001
     get_slice_nchunks,
 )
 
-from .c2array import C2Array, URLPath
+from .c2array import c2sub_urlbase, c2sub_auth_cookie, C2Array, URLPath
 
 from .lazyexpr import LazyExpr, lazyudf, lazyexpr, LazyArray, _open_lazyarray
 

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -22,7 +22,7 @@ _subscriber_data = {'auth_cookie': None}
 
 
 @contextmanager
-def c2subscriber_auth_cookie(auth_cookie):
+def c2subscriber_auth_cookie(auth_cookie: str | None):
     """
     Context manager that adds `auth_cookie` to Caterva2 subscriber requests.
 
@@ -30,9 +30,10 @@ def c2subscriber_auth_cookie(auth_cookie):
 
     Parameters
     ----------
-    auth_cookie: str
+    auth_cookie: str | None
         A cookie that will be used when an individual C2Array instance has no
-        authorization cookie set.
+        authorization cookie set.  Use ``None`` to disable the cookie set by a
+        previous context manager.
 
     Yields
     ------

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -18,7 +18,7 @@ import numpy as np
 import blosc2
 
 
-C2SUB_DEFBASE_ENVVAR = 'CATERVA2_SUBSCRIBER_URL'
+C2SUB_URLBASE_ENVVAR = 'CATERVA2_SUBSCRIBER_URL'
 """Environment variable with a default Caterva2 subscriber URL base."""
 
 _subscriber_data = {
@@ -108,7 +108,7 @@ def _xpost(url, json=None, auth_cookie=None, timeout=15):
 def _sub_api_url(urlbase, apipath):
     try:
         urlbase = (urlbase or _subscriber_data['urlbase']
-                   or os.environ[C2SUB_DEFBASE_ENVVAR])
+                   or os.environ[C2SUB_URLBASE_ENVVAR])
     except KeyError as ke:
         raise RuntimeError("No default Caterva2 subscriber set") from ke
     return (f"{urlbase}api/{apipath}" if urlbase.endswith("/")

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -28,6 +28,18 @@ _subscriber_data = {
 """Caterva2 subscriber data saved by context manager."""
 
 
+def _sub_param_ctxmgr(param, value):
+    global _subscriber_data
+    try:
+        old_sub_data = _subscriber_data
+        new_sub_data = old_sub_data.copy()  # inherit old values
+        new_sub_data[param] = value
+        _subscriber_data = new_sub_data
+        yield
+    finally:
+        _subscriber_data = old_sub_data
+
+
 @contextmanager
 def c2subscriber_auth_cookie(auth_cookie: str | None):
     """
@@ -47,15 +59,7 @@ def c2subscriber_auth_cookie(auth_cookie: str | None):
     out: None
 
     """
-    global _subscriber_data
-    try:
-        old_sub_data = _subscriber_data
-        new_sub_data = old_sub_data.copy()  # inherit old values
-        new_sub_data['auth_cookie'] = auth_cookie
-        _subscriber_data = new_sub_data
-        yield
-    finally:
-        _subscriber_data = old_sub_data
+    return _sub_param_ctxmgr('auth_cookie', auth_cookie)
 
 
 @contextmanager
@@ -77,15 +81,7 @@ def c2subscriber_urlbase(urlbase: str | None):
     out: None
 
     """
-    global _subscriber_data
-    try:
-        old_sub_data = _subscriber_data
-        new_sub_data = old_sub_data.copy()  # inherit old values
-        new_sub_data['urlbase'] = urlbase
-        _subscriber_data = new_sub_data
-        yield
-    finally:
-        _subscriber_data = old_sub_data
+    return _sub_param_ctxmgr('urlbase', urlbase)
 
 
 def _xget(url, params=None, headers=None, auth_cookie=None, timeout=15):

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -129,7 +129,7 @@ class C2Array(blosc2.Operand):
         if path.startswith('/'):
             raise ValueError("The path should start with a root name, not a slash")
         self.path = path
-        self.root, self.filepath = path.split('/', 1)
+        root, _ = path.split('/', 1)
 
         if not urlbase.endswith('/'):
             urlbase += '/'
@@ -143,7 +143,7 @@ class C2Array(blosc2.Operand):
         except httpx.HTTPStatusError:
             # Subscribe to root and try again. It is less latency to subscribe directly
             # than to check for the subscription.
-            subscribe(self.root, self.urlbase, self.auth_cookie)
+            subscribe(root, self.urlbase, self.auth_cookie)
             try:
                 self.meta = get(urlpath, auth_cookie=self.auth_cookie)
             except httpx.HTTPStatusError as err:

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -69,8 +69,8 @@ def _xpost(url, json=None, auth_cookie=None, timeout=15):
     return response.json()
 
 
-def get(url, params=None, headers=None, model=None, auth_cookie=None):
-    response = _xget(url, params, headers, auth_cookie)
+def info(path, urlbase, params=None, headers=None, model=None, auth_cookie=None):
+    response = _xget(f"{urlbase}api/info/{path}", params, headers, auth_cookie)
     json = response.json()
     return json if model is None else model(**json)
 
@@ -140,15 +140,16 @@ class C2Array(blosc2.Operand):
         self.auth_cookie = auth_cookie
 
         # Try to 'open' the remote path
-        urlpath = f"{urlbase}api/info/{self.path}"
         try:
-            self.meta = get(urlpath, auth_cookie=self.auth_cookie)
+            self.meta = info(self.path, self.urlbase,
+                             auth_cookie=self.auth_cookie)
         except httpx.HTTPStatusError:
             # Subscribe to root and try again. It is less latency to subscribe directly
             # than to check for the subscription.
             subscribe(root, self.urlbase, self.auth_cookie)
             try:
-                self.meta = get(urlpath, auth_cookie=self.auth_cookie)
+                self.meta = info(self.path, self.urlbase,
+                                 auth_cookie=self.auth_cookie)
             except httpx.HTTPStatusError as err:
                 raise FileNotFoundError(f"Remote path not found: {path}.\n"
                                         f"Error was: {err}") from err

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -74,7 +74,8 @@ def c2subscriber_urlbase(urlbase: str | None):
     urlbase: str | None
         A URL base that will be used when an individual C2Array instance has
         no subscriber URL base set.  Use ``None`` to disable the base set by a
-        previous context manager.
+        previous context manager (and default to the value in the
+        ``CATERVA2_SUBSCRIBER_URL`` environment variable, if set).
 
     Yields
     ------

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -22,9 +22,9 @@ _subscriber_data = {}
 
 
 @contextmanager
-def subscriber_auth_cookie(auth_cookie):
+def c2subscriber_auth_cookie(auth_cookie):
     """
-    Context manager that adds the `auth_cookie` to subscriber requests.
+    Context manager that adds `auth_cookie` to Caterva2 subscriber requests.
 
     Please note that this manager is reentrant but not concurrency-safe.
 

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -45,6 +45,8 @@ def c2sub_auth_cookie(auth_cookie: str | None):
     """
     Context manager that adds `auth_cookie` to Caterva2 subscriber requests.
 
+    The cookie should have been previously obtained from the subscriber.
+
     Please note that this manager is reentrant but not concurrency-safe.
 
     Parameters

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -18,7 +18,7 @@ import numpy as np
 import blosc2
 
 
-C2SUB_URLBASE_ENVVAR = 'CATERVA2_SUBSCRIBER_URL'
+C2SUB_URLBASE_ENVVAR = 'BLOSC_C2URLBASE'
 """Environment variable with a default Caterva2 subscriber URL base."""
 
 _subscriber_data = {
@@ -77,7 +77,7 @@ def c2sub_urlbase(urlbase: str | None):
         A URL base that will be used when an individual C2Array instance has
         no subscriber URL base set.  Use ``None`` to disable the base set by a
         previous context manager (and default to the value in the
-        ``CATERVA2_SUBSCRIBER_URL`` environment variable, if set).
+        ``BLOSC_C2URLBASE`` environment variable, if set).
 
     Yields
     ------

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -26,6 +26,8 @@ def subscriber_auth_cookie(auth_cookie):
     """
     Context manager that adds the `auth_cookie` to subscriber requests.
 
+    Please note that this manager is reentrant but not concurrency-safe.
+
     Parameters
     ----------
     auth_cookie: str

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -17,7 +17,7 @@ import numpy as np
 import blosc2
 
 
-_subscriber_data = {}
+_subscriber_data = {'auth_cookie': None}
 """Caterva2 subscriber data saved by context manager."""
 
 
@@ -31,8 +31,8 @@ def c2subscriber_auth_cookie(auth_cookie):
     Parameters
     ----------
     auth_cookie: str
-        A cookie that takes precedence over authorization cookies set in
-        individual C2Array instances.
+        A cookie that will be used when an individual C2Array instance has no
+        authorization cookie set.
 
     Yields
     ------
@@ -49,7 +49,7 @@ def c2subscriber_auth_cookie(auth_cookie):
 
 
 def _xget(url, params=None, headers=None, auth_cookie=None, timeout=15):
-    auth_cookie = _subscriber_data.get('auth_cookie', auth_cookie)
+    auth_cookie = auth_cookie or _subscriber_data['auth_cookie']
     if auth_cookie:
         headers = headers.copy() if headers else {}
         headers["Cookie"] = auth_cookie
@@ -59,7 +59,7 @@ def _xget(url, params=None, headers=None, auth_cookie=None, timeout=15):
 
 
 def _xpost(url, json=None, auth_cookie=None, timeout=15):
-    auth_cookie = _subscriber_data.get('auth_cookie', auth_cookie)
+    auth_cookie = auth_cookie or _subscriber_data['auth_cookie']
     headers = {'Cookie': auth_cookie} if auth_cookie else None
     response = httpx.post(url, json=json, headers=headers, timeout=timeout)
     response.raise_for_status()

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -132,7 +132,6 @@ class C2Array(blosc2.Operand):
         if path.startswith('/'):
             raise ValueError("The path should start with a root name, not a slash")
         self.path = path
-        root, _ = path.split('/', 1)
 
         if not urlbase.endswith('/'):
             urlbase += '/'
@@ -146,6 +145,7 @@ class C2Array(blosc2.Operand):
         except httpx.HTTPStatusError:
             # Subscribe to root and try again. It is less latency to subscribe directly
             # than to check for the subscription.
+            root, _ = self.path.split('/', 1)
             subscribe(root, self.urlbase, self.auth_cookie)
             try:
                 self.meta = info(self.path, self.urlbase,

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -127,7 +127,7 @@ def slice_to_string(slice_):
 
 
 class C2Array(blosc2.Operand):
-    def __init__(self, path, /, urlbase, auth_cookie=None):
+    def __init__(self, path, /, urlbase=None, auth_cookie=None):
         """Create an instance of a remote NDArray.
 
         Parameters
@@ -149,9 +149,10 @@ class C2Array(blosc2.Operand):
             raise ValueError("The path should start with a root name, not a slash")
         self.path = path
 
-        if not urlbase.endswith('/'):
+        if urlbase and not urlbase.endswith('/'):
             urlbase += '/'
         self.urlbase = urlbase
+
         self.auth_cookie = auth_cookie
 
         # Try to 'open' the remote path
@@ -215,7 +216,7 @@ class C2Array(blosc2.Operand):
 
 
 class URLPath:
-    def __init__(self, path, /, urlbase, auth_cookie=None):
+    def __init__(self, path, /, urlbase=None, auth_cookie=None):
         """
         Create an instance of a remote data file (aka :ref:`C2Array <C2Array>`) urlpath.
         This is meant to be used in the :func:`blosc2.open` function.

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -28,46 +28,11 @@ _subscriber_data = {
 """Caterva2 subscriber data saved by context manager."""
 
 
-def _sub_param_ctxmgr(param, value):
-    global _subscriber_data
-    try:
-        old_sub_data = _subscriber_data
-        new_sub_data = old_sub_data.copy()  # inherit old values
-        new_sub_data[param] = value
-        _subscriber_data = new_sub_data
-        yield
-    finally:
-        _subscriber_data = old_sub_data
-
-
 @contextmanager
-def c2sub_auth_cookie(auth_cookie: str | None):
+def c2context(*, urlbase: (str | None) = None,
+              auth_cookie: (str | None) = None):
     """
-    Context manager that adds `auth_cookie` to Caterva2 subscriber requests.
-
-    The cookie should have been previously obtained from the subscriber.
-
-    Please note that this manager is reentrant but not concurrency-safe.
-
-    Parameters
-    ----------
-    auth_cookie: str | None
-        A cookie that will be used when an individual C2Array instance has no
-        authorization cookie set.  Use ``None`` to disable the cookie set by a
-        previous context manager.
-
-    Yields
-    ------
-    out: None
-
-    """
-    return _sub_param_ctxmgr('auth_cookie', auth_cookie)
-
-
-@contextmanager
-def c2sub_urlbase(urlbase: str | None):
-    """
-    Context manager that adds `urlbase` to Caterva2 subscriber requests.
+    Context manager that sets parameters in Caterva2 subscriber requests.
 
     Please note that this manager is reentrant but not concurrency-safe.
 
@@ -78,13 +43,29 @@ def c2sub_urlbase(urlbase: str | None):
         no subscriber URL base set.  Use ``None`` to disable the base set by a
         previous context manager (and default to the value in the
         ``BLOSC_C2URLBASE`` environment variable, if set).
+    auth_cookie: str | None
+        A cookie that will be used when an individual C2Array instance has no
+        authorization cookie set.  It should have been previously obtained
+        from the subscriber.  Use ``None`` to disable the cookie set by a
+        previous context manager.
 
     Yields
     ------
     out: None
 
     """
-    return _sub_param_ctxmgr('urlbase', urlbase)
+    global _subscriber_data
+    try:
+        old_sub_data = _subscriber_data
+        new_sub_data = old_sub_data.copy()  # inherit old values
+        if urlbase is not None:
+            new_sub_data['urlbase'] = urlbase
+        if auth_cookie is not None:
+            new_sub_data['auth_cookie'] = auth_cookie
+        _subscriber_data = new_sub_data
+        yield
+    finally:
+        _subscriber_data = old_sub_data
 
 
 def _xget(url, params=None, headers=None, auth_cookie=None, timeout=15):

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -34,6 +34,9 @@ def c2context(*, urlbase: (str | None) = None,
     """
     Context manager that sets parameters in Caterva2 subscriber requests.
 
+    Parameters not specified or set to ``None`` simply inherit the value set
+    by the previous context manager, if any.
+
     Please note that this manager is reentrant but not concurrency-safe.
 
     Parameters

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -42,7 +42,9 @@ def c2subscriber_auth_cookie(auth_cookie):
     global _subscriber_data
     try:
         old_sub_data = _subscriber_data
-        _subscriber_data = {'auth_cookie': auth_cookie}
+        new_sub_data = old_sub_data.copy()  # inherit old values
+        new_sub_data['auth_cookie'] = auth_cookie
+        _subscriber_data = new_sub_data
         yield
     finally:
         _subscriber_data = old_sub_data

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -41,7 +41,7 @@ def _sub_param_ctxmgr(param, value):
 
 
 @contextmanager
-def c2subscriber_auth_cookie(auth_cookie: str | None):
+def c2sub_auth_cookie(auth_cookie: str | None):
     """
     Context manager that adds `auth_cookie` to Caterva2 subscriber requests.
 
@@ -63,7 +63,7 @@ def c2subscriber_auth_cookie(auth_cookie: str | None):
 
 
 @contextmanager
-def c2subscriber_urlbase(urlbase: str | None):
+def c2sub_urlbase(urlbase: str | None):
     """
     Context manager that adds `urlbase` to Caterva2 subscriber requests.
 

--- a/blosc2/lazyexpr.py
+++ b/blosc2/lazyexpr.py
@@ -1350,7 +1350,6 @@ class LazyExpr(LazyArray):
                 operands[key] = {
                     "path": str(value.path),
                     "urlbase": value.urlbase,
-                    "auth_cookie": value.auth_cookie,
                 }
                 continue
             if not hasattr(value, "schunk"):
@@ -1525,7 +1524,6 @@ def _open_lazyarray(array):
             operands_dict[key] = blosc2.C2Array(
                 pathlib.Path(value["path"]).as_posix(),
                 urlbase=value["urlbase"],
-                auth_cookie=value["auth_cookie"],
             )
         else:
             raise ValueError("Error when retrieving the operands")

--- a/doc/reference/c2array.rst
+++ b/doc/reference/c2array.rst
@@ -40,3 +40,14 @@ URLPath class
     :toctree: autofiles/URLPath
 
     __init__
+
+Context managers
+----------------
+
+.. currentmodule:: blosc2
+
+.. autosummary::
+    :toctree: autofiles/c2array
+
+    c2sub_urlbase
+    c2sub_auth_cookie

--- a/doc/reference/c2array.rst
+++ b/doc/reference/c2array.rst
@@ -49,5 +49,4 @@ Context managers
 .. autosummary::
     :toctree: autofiles/c2array
 
-    c2sub_urlbase
-    c2sub_auth_cookie
+    c2context

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -33,7 +33,7 @@ DIR = "expr/"
         # AUTH_COOKIE,
     ]
 )
-def auth_cookie(request):
+def sub_auth_ctxt(request):
     cookie = request.param
     with blosc2.c2array.subscriber_auth_cookie(cookie):
         yield cookie
@@ -70,7 +70,7 @@ def get_arrays(shape, chunks_blocks):
         (False, False),
     ],
 )
-def test_simple(chunks_blocks, auth_cookie):
+def test_simple(chunks_blocks, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
 
@@ -86,7 +86,7 @@ def test_simple(chunks_blocks, auth_cookie):
     np.testing.assert_allclose(res[:], nres)
 
 
-def test_simple_getitem(auth_cookie):
+def test_simple_getitem(sub_auth_ctxt):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -110,7 +110,7 @@ def test_simple_getitem(auth_cookie):
         (False, False),
     ],
 )
-def test_ixxx(chunks_blocks, auth_cookie):
+def test_ixxx(chunks_blocks, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     expr = a1**3 + a2**2 + a3**3 - a4 + 3
@@ -122,7 +122,7 @@ def test_ixxx(chunks_blocks, auth_cookie):
     np.testing.assert_allclose(res[:], nres)
 
 
-def test_complex(auth_cookie):
+def test_complex(sub_auth_ctxt):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -151,7 +151,7 @@ def test_complex(auth_cookie):
         (False, False),
     ],
 )
-def test_mix_operands(chunks_blocks, auth_cookie):
+def test_mix_operands(chunks_blocks, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     b1 = blosc2.asarray(na1, chunks=a1.chunks, blocks=a1.blocks)
@@ -187,7 +187,7 @@ def test_mix_operands(chunks_blocks, auth_cookie):
 
 
 # Tests related with save method
-def test_save(auth_cookie):
+def test_save(sub_auth_ctxt):
     shape = (60, 60)
     tol = 1e-17
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, (False, True))
@@ -231,7 +231,7 @@ def broadcast_shape(request):
 
 
 @pytest.fixture
-def broadcast_fixture(broadcast_shape, auth_cookie):
+def broadcast_fixture(broadcast_shape, sub_auth_ctxt):
     shape1, shape2 = broadcast_shape
     dtype = np.float64
     na1 = np.linspace(0, 1, np.prod(shape1), dtype=dtype).reshape(shape1)

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -35,7 +35,7 @@ DIR = "expr/"
 )
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.subscriber_auth_cookie(cookie):
+    with blosc2.c2array.c2subscriber_auth_cookie(cookie):
         yield cookie
 
 

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -34,19 +34,21 @@ DIR = "expr/"
     ]
 )
 def auth_cookie(request):
-    return request.param
+    cookie = request.param
+    with blosc2.c2array.subscriber_auth_cookie(cookie):
+        yield cookie
 
 
-def get_arrays(shape, chunks_blocks, auth_cookie):
+def get_arrays(shape, chunks_blocks):
     dtype = np.float64
     nelems = np.prod(shape)
     na1 = np.linspace(0, 10, nelems, dtype=dtype).reshape(shape)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a1 = blosc2.C2Array(path, urlbase=URLBASE)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a2-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    a2 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a2 = blosc2.C2Array(path, urlbase=URLBASE)
     # Let other operands be local, on-disk NDArray copies
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a3-{shape}d.b2nd"
     a3 = blosc2.asarray(a2, urlpath=urlpath, mode="w")
@@ -70,7 +72,7 @@ def get_arrays(shape, chunks_blocks, auth_cookie):
 )
 def test_simple(chunks_blocks, auth_cookie):
     shape = (60, 60)
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks, auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
 
     # Slice
     sl = slice(10)
@@ -87,7 +89,7 @@ def test_simple(chunks_blocks, auth_cookie):
 def test_simple_getitem(auth_cookie):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks, auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     expr = a1 + a2 - a3 * a4
     nres = ne.evaluate("na1 + na2 - na3 * na4")
 
@@ -110,7 +112,7 @@ def test_simple_getitem(auth_cookie):
 )
 def test_ixxx(chunks_blocks, auth_cookie):
     shape = (60, 60)
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks, auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     expr = a1**3 + a2**2 + a3**3 - a4 + 3
     expr += 5  # __iadd__
     expr /= 7  # __itruediv__
@@ -123,7 +125,7 @@ def test_ixxx(chunks_blocks, auth_cookie):
 def test_complex(auth_cookie):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks, auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     expr = blosc2.tan(a1) * blosc2.sin(a2) + (blosc2.sqrt(a4) * 2)
     expr += 2
     nres = ne.evaluate("tan(na1) * sin(na2) + (sqrt(na4) * 2) + 2")
@@ -151,7 +153,7 @@ def test_complex(auth_cookie):
 )
 def test_mix_operands(chunks_blocks, auth_cookie):
     shape = (60, 60)
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks, auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     b1 = blosc2.asarray(na1, chunks=a1.chunks, blocks=a1.blocks)
     b3 = blosc2.asarray(na3, chunks=a3.chunks, blocks=a3.blocks)
 
@@ -188,7 +190,7 @@ def test_mix_operands(chunks_blocks, auth_cookie):
 def test_save(auth_cookie):
     shape = (60, 60)
     tol = 1e-17
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, (False, True), auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, (False, True))
 
     expr = a1 * a2 + a3 - a4 * 3
     nres = ne.evaluate("na1 * na2 + na3 - na4 * 3")
@@ -236,10 +238,10 @@ def broadcast_fixture(broadcast_shape, auth_cookie):
     na2 = np.linspace(1, 2, np.prod(shape2), dtype=dtype).reshape(shape2)
     urlpath = f"ds-0-1-linspace-{dtype.__name__}-b1-{shape1}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    b1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    b1 = blosc2.C2Array(path, urlbase=URLBASE)
     urlpath = f"ds-1-2-linspace-{dtype.__name__}-b2-{shape2}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    b2 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    b2 = blosc2.C2Array(path, urlbase=URLBASE)
 
     return b1, b2, na1, na2
 

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -39,16 +39,22 @@ def sub_auth_ctxt(request):
         yield cookie
 
 
+@pytest.fixture
+def sub_urlbase_ctxt():
+    with blosc2.c2array.c2subscriber_urlbase(URLBASE):
+        yield URLBASE
+
+
 def get_arrays(shape, chunks_blocks):
     dtype = np.float64
     nelems = np.prod(shape)
     na1 = np.linspace(0, 10, nelems, dtype=dtype).reshape(shape)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    a1 = blosc2.C2Array(path, urlbase=URLBASE)
+    a1 = blosc2.C2Array(path)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a2-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    a2 = blosc2.C2Array(path, urlbase=URLBASE)
+    a2 = blosc2.C2Array(path)
     # Let other operands be local, on-disk NDArray copies
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a3-{shape}d.b2nd"
     a3 = blosc2.asarray(a2, urlpath=urlpath, mode="w")
@@ -70,7 +76,7 @@ def get_arrays(shape, chunks_blocks):
         (False, False),
     ],
 )
-def test_simple(chunks_blocks, sub_auth_ctxt):
+def test_simple(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
 
@@ -86,7 +92,7 @@ def test_simple(chunks_blocks, sub_auth_ctxt):
     np.testing.assert_allclose(res[:], nres)
 
 
-def test_simple_getitem(sub_auth_ctxt):
+def test_simple_getitem(sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -110,7 +116,7 @@ def test_simple_getitem(sub_auth_ctxt):
         (False, False),
     ],
 )
-def test_ixxx(chunks_blocks, sub_auth_ctxt):
+def test_ixxx(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     expr = a1**3 + a2**2 + a3**3 - a4 + 3
@@ -122,7 +128,7 @@ def test_ixxx(chunks_blocks, sub_auth_ctxt):
     np.testing.assert_allclose(res[:], nres)
 
 
-def test_complex(sub_auth_ctxt):
+def test_complex(sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -151,7 +157,7 @@ def test_complex(sub_auth_ctxt):
         (False, False),
     ],
 )
-def test_mix_operands(chunks_blocks, sub_auth_ctxt):
+def test_mix_operands(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     b1 = blosc2.asarray(na1, chunks=a1.chunks, blocks=a1.blocks)
@@ -187,7 +193,7 @@ def test_mix_operands(chunks_blocks, sub_auth_ctxt):
 
 
 # Tests related with save method
-def test_save(sub_auth_ctxt):
+def test_save(sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (60, 60)
     tol = 1e-17
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, (False, True))
@@ -231,17 +237,17 @@ def broadcast_shape(request):
 
 
 @pytest.fixture
-def broadcast_fixture(broadcast_shape, sub_auth_ctxt):
+def broadcast_fixture(broadcast_shape, sub_urlbase_ctxt, sub_auth_ctxt):
     shape1, shape2 = broadcast_shape
     dtype = np.float64
     na1 = np.linspace(0, 1, np.prod(shape1), dtype=dtype).reshape(shape1)
     na2 = np.linspace(1, 2, np.prod(shape2), dtype=dtype).reshape(shape2)
     urlpath = f"ds-0-1-linspace-{dtype.__name__}-b1-{shape1}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    b1 = blosc2.C2Array(path, urlbase=URLBASE)
+    b1 = blosc2.C2Array(path)
     urlpath = f"ds-1-2-linspace-{dtype.__name__}-b2-{shape2}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    b2 = blosc2.C2Array(path, urlbase=URLBASE)
+    b2 = blosc2.C2Array(path)
 
     return b1, b2, na1, na2
 

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -35,13 +35,13 @@ DIR = "expr/"
 )
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.c2subscriber_auth_cookie(cookie):
+    with blosc2.c2array.c2sub_auth_cookie(cookie):
         yield cookie
 
 
 @pytest.fixture
 def sub_urlbase_ctxt():
-    with blosc2.c2array.c2subscriber_urlbase(URLBASE):
+    with blosc2.c2array.c2sub_urlbase(URLBASE):
         yield URLBASE
 
 

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -33,16 +33,11 @@ DIR = "expr/"
         # AUTH_COOKIE,
     ]
 )
-def sub_auth_ctxt(request):
+def sub_context(request):
     cookie = request.param
-    with blosc2.c2sub_auth_cookie(cookie):
-        yield cookie
-
-
-@pytest.fixture
-def sub_urlbase_ctxt():
-    with blosc2.c2sub_urlbase(URLBASE):
-        yield URLBASE
+    c2params = dict(urlbase=URLBASE, auth_cookie=cookie)
+    with blosc2.c2context(**c2params):
+        yield c2params
 
 
 def get_arrays(shape, chunks_blocks):
@@ -76,7 +71,7 @@ def get_arrays(shape, chunks_blocks):
         (False, False),
     ],
 )
-def test_simple(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
+def test_simple(chunks_blocks, sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
 
@@ -92,7 +87,7 @@ def test_simple(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
     np.testing.assert_allclose(res[:], nres)
 
 
-def test_simple_getitem(sub_urlbase_ctxt, sub_auth_ctxt):
+def test_simple_getitem(sub_context):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -116,7 +111,7 @@ def test_simple_getitem(sub_urlbase_ctxt, sub_auth_ctxt):
         (False, False),
     ],
 )
-def test_ixxx(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
+def test_ixxx(chunks_blocks, sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     expr = a1**3 + a2**2 + a3**3 - a4 + 3
@@ -128,7 +123,7 @@ def test_ixxx(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
     np.testing.assert_allclose(res[:], nres)
 
 
-def test_complex(sub_urlbase_ctxt, sub_auth_ctxt):
+def test_complex(sub_context):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -157,7 +152,7 @@ def test_complex(sub_urlbase_ctxt, sub_auth_ctxt):
         (False, False),
     ],
 )
-def test_mix_operands(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
+def test_mix_operands(chunks_blocks, sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     b1 = blosc2.asarray(na1, chunks=a1.chunks, blocks=a1.blocks)
@@ -193,7 +188,7 @@ def test_mix_operands(chunks_blocks, sub_urlbase_ctxt, sub_auth_ctxt):
 
 
 # Tests related with save method
-def test_save(sub_urlbase_ctxt, sub_auth_ctxt):
+def test_save(sub_context):
     shape = (60, 60)
     tol = 1e-17
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, (False, True))
@@ -237,7 +232,7 @@ def broadcast_shape(request):
 
 
 @pytest.fixture
-def broadcast_fixture(broadcast_shape, sub_urlbase_ctxt, sub_auth_ctxt):
+def broadcast_fixture(broadcast_shape, sub_context):
     shape1, shape2 = broadcast_shape
     dtype = np.float64
     na1 = np.linspace(0, 1, np.prod(shape1), dtype=dtype).reshape(shape1)

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -35,13 +35,13 @@ DIR = "expr/"
 )
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.c2sub_auth_cookie(cookie):
+    with blosc2.c2sub_auth_cookie(cookie):
         yield cookie
 
 
 @pytest.fixture
 def sub_urlbase_ctxt():
-    with blosc2.c2array.c2sub_urlbase(URLBASE):
+    with blosc2.c2sub_urlbase(URLBASE):
         yield URLBASE
 
 

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -31,7 +31,7 @@ DIR = 'expr/'
     None,
     # AUTH_COOKIE,
 ])
-def auth_cookie(request):
+def sub_auth_ctxt(request):
     cookie = request.param
     with blosc2.c2array.subscriber_auth_cookie(cookie):
         yield cookie
@@ -62,7 +62,7 @@ def get_arrays(shape, chunks_blocks):
 
 
 @pytest.mark.parametrize("reduce_op", ["sum", pytest.param("all", marks=pytest.mark.heavy)])
-def test_reduce_bool(reduce_op, auth_cookie):
+def test_reduce_bool(reduce_op, sub_auth_ctxt):
     shape = (NITEMS_SMALL, )
     chunks_blocks = 'default'
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -90,7 +90,7 @@ def test_reduce_bool(reduce_op, auth_cookie):
 @pytest.mark.parametrize("axis", [1])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("dtype_out", [np.int16])
-def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, auth_cookie):
+def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and np.isscalar(axis) and len(a1.shape) >= axis:
@@ -138,7 +138,7 @@ def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, auth
                                        pytest.param("var", marks=pytest.mark.heavy),
                                        ])
 @pytest.mark.parametrize("axis", [0])
-def test_reduce_expr_arr(chunks_blocks, axis, reduce_op, auth_cookie):
+def test_reduce_expr_arr(chunks_blocks, axis, reduce_op, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and len(a1.shape) >= axis:

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -33,13 +33,13 @@ DIR = 'expr/'
 ])
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.c2sub_auth_cookie(cookie):
+    with blosc2.c2sub_auth_cookie(cookie):
         yield cookie
 
 
 @pytest.fixture
 def sub_urlbase_ctxt():
-    with blosc2.c2array.c2sub_urlbase(URLBASE):
+    with blosc2.c2sub_urlbase(URLBASE):
         yield URLBASE
 
 

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -33,13 +33,13 @@ DIR = 'expr/'
 ])
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.c2subscriber_auth_cookie(cookie):
+    with blosc2.c2array.c2sub_auth_cookie(cookie):
         yield cookie
 
 
 @pytest.fixture
 def sub_urlbase_ctxt():
-    with blosc2.c2array.c2subscriber_urlbase(URLBASE):
+    with blosc2.c2array.c2sub_urlbase(URLBASE):
         yield URLBASE
 
 

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -37,23 +37,29 @@ def sub_auth_ctxt(request):
         yield cookie
 
 
+@pytest.fixture
+def sub_urlbase_ctxt():
+    with blosc2.c2array.c2subscriber_urlbase(URLBASE):
+        yield URLBASE
+
+
 def get_arrays(shape, chunks_blocks):
     dtype = np.float64
     nelems = np.prod(shape)
     na1 = np.linspace(0, 10, nelems, dtype=dtype).reshape(shape)
     urlpath = f'ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd'
     path = pathlib.Path(f'{ROOT}/{DIR + urlpath}').as_posix()
-    a1 = blosc2.C2Array(path, urlbase=URLBASE)
+    a1 = blosc2.C2Array(path)
     urlpath = f'ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a2-{shape}d.b2nd'
     path = pathlib.Path(f'{ROOT}/{DIR + urlpath}').as_posix()
-    a2 = blosc2.C2Array(path, urlbase=URLBASE)
+    a2 = blosc2.C2Array(path)
     # Let other operands have chunks1 and blocks1
     urlpath = f'ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a3-{shape}d.b2nd'
     path = pathlib.Path(f'{ROOT}/{DIR + urlpath}').as_posix()
-    a3 = blosc2.C2Array(path, urlbase=URLBASE)
+    a3 = blosc2.C2Array(path)
     urlpath = f'ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a4-{shape}d.b2nd'
     path = pathlib.Path(f'{ROOT}/{DIR + urlpath}').as_posix()
-    a4 = blosc2.C2Array(path, urlbase=URLBASE)
+    a4 = blosc2.C2Array(path)
     assert isinstance(a1, blosc2.C2Array)
     assert isinstance(a2, blosc2.C2Array)
     assert isinstance(a3, blosc2.C2Array)
@@ -62,7 +68,7 @@ def get_arrays(shape, chunks_blocks):
 
 
 @pytest.mark.parametrize("reduce_op", ["sum", pytest.param("all", marks=pytest.mark.heavy)])
-def test_reduce_bool(reduce_op, sub_auth_ctxt):
+def test_reduce_bool(reduce_op, sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (NITEMS_SMALL, )
     chunks_blocks = 'default'
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -90,7 +96,8 @@ def test_reduce_bool(reduce_op, sub_auth_ctxt):
 @pytest.mark.parametrize("axis", [1])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("dtype_out", [np.int16])
-def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, sub_auth_ctxt):
+def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op,
+                       sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and np.isscalar(axis) and len(a1.shape) >= axis:
@@ -138,7 +145,8 @@ def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, sub_
                                        pytest.param("var", marks=pytest.mark.heavy),
                                        ])
 @pytest.mark.parametrize("axis", [0])
-def test_reduce_expr_arr(chunks_blocks, axis, reduce_op, sub_auth_ctxt):
+def test_reduce_expr_arr(chunks_blocks, axis, reduce_op,
+                         sub_urlbase_ctxt, sub_auth_ctxt):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and len(a1.shape) >= axis:

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -33,7 +33,7 @@ DIR = 'expr/'
 ])
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.subscriber_auth_cookie(cookie):
+    with blosc2.c2array.c2subscriber_auth_cookie(cookie):
         yield cookie
 
 

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -32,26 +32,28 @@ DIR = 'expr/'
     # AUTH_COOKIE,
 ])
 def auth_cookie(request):
-    return request.param
+    cookie = request.param
+    with blosc2.c2array.subscriber_auth_cookie(cookie):
+        yield cookie
 
 
-def get_arrays(shape, chunks_blocks, auth_cookie):
+def get_arrays(shape, chunks_blocks):
     dtype = np.float64
     nelems = np.prod(shape)
     na1 = np.linspace(0, 10, nelems, dtype=dtype).reshape(shape)
     urlpath = f'ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd'
     path = pathlib.Path(f'{ROOT}/{DIR + urlpath}').as_posix()
-    a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a1 = blosc2.C2Array(path, urlbase=URLBASE)
     urlpath = f'ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a2-{shape}d.b2nd'
     path = pathlib.Path(f'{ROOT}/{DIR + urlpath}').as_posix()
-    a2 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a2 = blosc2.C2Array(path, urlbase=URLBASE)
     # Let other operands have chunks1 and blocks1
     urlpath = f'ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a3-{shape}d.b2nd'
     path = pathlib.Path(f'{ROOT}/{DIR + urlpath}').as_posix()
-    a3 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a3 = blosc2.C2Array(path, urlbase=URLBASE)
     urlpath = f'ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a4-{shape}d.b2nd'
     path = pathlib.Path(f'{ROOT}/{DIR + urlpath}').as_posix()
-    a4 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a4 = blosc2.C2Array(path, urlbase=URLBASE)
     assert isinstance(a1, blosc2.C2Array)
     assert isinstance(a2, blosc2.C2Array)
     assert isinstance(a3, blosc2.C2Array)
@@ -63,7 +65,7 @@ def get_arrays(shape, chunks_blocks, auth_cookie):
 def test_reduce_bool(reduce_op, auth_cookie):
     shape = (NITEMS_SMALL, )
     chunks_blocks = 'default'
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks, auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     expr = a1 + a2 > a3 * a4
     nres = ne.evaluate("na1 + na2 > na3 * na4")
     res = getattr(expr, reduce_op)()
@@ -90,7 +92,7 @@ def test_reduce_bool(reduce_op, auth_cookie):
 @pytest.mark.parametrize("dtype_out", [np.int16])
 def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, auth_cookie):
     shape = (60, 60)
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks, auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and np.isscalar(axis) and len(a1.shape) >= axis:
         return
     if type(axis) == tuple and len(a1.shape) < len(axis):
@@ -138,7 +140,7 @@ def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, auth
 @pytest.mark.parametrize("axis", [0])
 def test_reduce_expr_arr(chunks_blocks, axis, reduce_op, auth_cookie):
     shape = (60, 60)
-    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks, auth_cookie)
+    a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and len(a1.shape) >= axis:
         return
     expr = a1 + a2 - a3 * a4

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -31,16 +31,11 @@ DIR = 'expr/'
     None,
     # AUTH_COOKIE,
 ])
-def sub_auth_ctxt(request):
+def sub_context(request):
     cookie = request.param
-    with blosc2.c2sub_auth_cookie(cookie):
-        yield cookie
-
-
-@pytest.fixture
-def sub_urlbase_ctxt():
-    with blosc2.c2sub_urlbase(URLBASE):
-        yield URLBASE
+    c2params = dict(urlbase=URLBASE, auth_cookie=cookie)
+    with blosc2.c2context(**c2params):
+        yield c2params
 
 
 def get_arrays(shape, chunks_blocks):
@@ -68,7 +63,7 @@ def get_arrays(shape, chunks_blocks):
 
 
 @pytest.mark.parametrize("reduce_op", ["sum", pytest.param("all", marks=pytest.mark.heavy)])
-def test_reduce_bool(reduce_op, sub_urlbase_ctxt, sub_auth_ctxt):
+def test_reduce_bool(reduce_op, sub_context):
     shape = (NITEMS_SMALL, )
     chunks_blocks = 'default'
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -96,8 +91,7 @@ def test_reduce_bool(reduce_op, sub_urlbase_ctxt, sub_auth_ctxt):
 @pytest.mark.parametrize("axis", [1])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("dtype_out", [np.int16])
-def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op,
-                       sub_urlbase_ctxt, sub_auth_ctxt):
+def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and np.isscalar(axis) and len(a1.shape) >= axis:
@@ -145,8 +139,7 @@ def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op,
                                        pytest.param("var", marks=pytest.mark.heavy),
                                        ])
 @pytest.mark.parametrize("axis", [0])
-def test_reduce_expr_arr(chunks_blocks, axis, reduce_op,
-                         sub_urlbase_ctxt, sub_auth_ctxt):
+def test_reduce_expr_arr(chunks_blocks, axis, reduce_op, sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and len(a1.shape) >= axis:

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -37,7 +37,7 @@ def udf1p(inputs_tuple, output, offset):
 )
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.subscriber_auth_cookie(cookie):
+    with blosc2.c2array.c2subscriber_auth_cookie(cookie):
         yield cookie
 
 

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -35,16 +35,11 @@ def udf1p(inputs_tuple, output, offset):
         # AUTH_COOKIE,
     ]
 )
-def sub_auth_ctxt(request):
+def sub_context(request):
     cookie = request.param
-    with blosc2.c2sub_auth_cookie(cookie):
-        yield cookie
-
-
-@pytest.fixture
-def sub_urlbase_ctxt():
-    with blosc2.c2sub_urlbase(URLBASE):
-        yield URLBASE
+    c2params = dict(urlbase=URLBASE, auth_cookie=cookie)
+    with blosc2.c2context(**c2params):
+        yield c2params
 
 
 @pytest.mark.parametrize("chunked_eval", [True, False])
@@ -58,7 +53,7 @@ def sub_urlbase_ctxt():
         ),
     ],
 )
-def test_1p(chunks, blocks, chunked_eval, sub_urlbase_ctxt, sub_auth_ctxt):
+def test_1p(chunks, blocks, chunked_eval, sub_context):
     dtype = np.float64
     shape = (60, 60)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-(True, False)-a1-{shape}d.b2nd"
@@ -95,8 +90,7 @@ def udf2p(inputs_tuple, output, offset):
         pytest.param((53, 20), (10, 13), (slice(3, 8), slice(9, 12)), None, False),
     ],
 )
-def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval,
-                 sub_urlbase_ctxt, sub_auth_ctxt):
+def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval, sub_context):
     dtype = np.float64
     shape = (60, 60)
     blosc2.remove_urlpath(urlpath)

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -35,7 +35,7 @@ def udf1p(inputs_tuple, output, offset):
         # AUTH_COOKIE,
     ]
 )
-def auth_cookie(request):
+def sub_auth_ctxt(request):
     cookie = request.param
     with blosc2.c2array.subscriber_auth_cookie(cookie):
         yield cookie
@@ -52,7 +52,7 @@ def auth_cookie(request):
         ),
     ],
 )
-def test_1p(chunks, blocks, chunked_eval, auth_cookie):
+def test_1p(chunks, blocks, chunked_eval, sub_auth_ctxt):
     dtype = np.float64
     shape = (60, 60)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-(True, False)-a1-{shape}d.b2nd"
@@ -89,7 +89,7 @@ def udf2p(inputs_tuple, output, offset):
         pytest.param((53, 20), (10, 13), (slice(3, 8), slice(9, 12)), None, False),
     ],
 )
-def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval, auth_cookie):
+def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval, sub_auth_ctxt):
     dtype = np.float64
     shape = (60, 60)
     blosc2.remove_urlpath(urlpath)

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -36,7 +36,9 @@ def udf1p(inputs_tuple, output, offset):
     ]
 )
 def auth_cookie(request):
-    return request.param
+    cookie = request.param
+    with blosc2.c2array.subscriber_auth_cookie(cookie):
+        yield cookie
 
 
 @pytest.mark.parametrize("chunked_eval", [True, False])
@@ -55,7 +57,7 @@ def test_1p(chunks, blocks, chunked_eval, auth_cookie):
     shape = (60, 60)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-(True, False)-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    a = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a = blosc2.C2Array(path, urlbase=URLBASE)
     npa = a[:]
     npc = npa + 1
 
@@ -94,11 +96,11 @@ def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval, auth
 
     urlpath_a = f"ds-0-10-linspace-{dtype.__name__}-(True, False)-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath_a}").as_posix()
-    a = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a = blosc2.C2Array(path, urlbase=URLBASE)
 
     urlpath_b = f"ds-0-10-linspace-{dtype.__name__}-(False, False)-a3-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath_b}").as_posix()
-    b = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    b = blosc2.C2Array(path, urlbase=URLBASE)
     npa = a[:]
     npb = b[:]
     npc = npa**2 + npb**2 + 2 * npa * npb + 1

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -37,13 +37,13 @@ def udf1p(inputs_tuple, output, offset):
 )
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.c2subscriber_auth_cookie(cookie):
+    with blosc2.c2array.c2sub_auth_cookie(cookie):
         yield cookie
 
 
 @pytest.fixture
 def sub_urlbase_ctxt():
-    with blosc2.c2array.c2subscriber_urlbase(URLBASE):
+    with blosc2.c2array.c2sub_urlbase(URLBASE):
         yield URLBASE
 
 

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -41,6 +41,12 @@ def sub_auth_ctxt(request):
         yield cookie
 
 
+@pytest.fixture
+def sub_urlbase_ctxt():
+    with blosc2.c2array.c2subscriber_urlbase(URLBASE):
+        yield URLBASE
+
+
 @pytest.mark.parametrize("chunked_eval", [True, False])
 @pytest.mark.parametrize(
     "chunks, blocks",
@@ -52,12 +58,12 @@ def sub_auth_ctxt(request):
         ),
     ],
 )
-def test_1p(chunks, blocks, chunked_eval, sub_auth_ctxt):
+def test_1p(chunks, blocks, chunked_eval, sub_urlbase_ctxt, sub_auth_ctxt):
     dtype = np.float64
     shape = (60, 60)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-(True, False)-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath}").as_posix()
-    a = blosc2.C2Array(path, urlbase=URLBASE)
+    a = blosc2.C2Array(path)
     npa = a[:]
     npc = npa + 1
 
@@ -89,18 +95,19 @@ def udf2p(inputs_tuple, output, offset):
         pytest.param((53, 20), (10, 13), (slice(3, 8), slice(9, 12)), None, False),
     ],
 )
-def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval, sub_auth_ctxt):
+def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval,
+                 sub_urlbase_ctxt, sub_auth_ctxt):
     dtype = np.float64
     shape = (60, 60)
     blosc2.remove_urlpath(urlpath)
 
     urlpath_a = f"ds-0-10-linspace-{dtype.__name__}-(True, False)-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath_a}").as_posix()
-    a = blosc2.C2Array(path, urlbase=URLBASE)
+    a = blosc2.C2Array(path)
 
     urlpath_b = f"ds-0-10-linspace-{dtype.__name__}-(False, False)-a3-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + urlpath_b}").as_posix()
-    b = blosc2.C2Array(path, urlbase=URLBASE)
+    b = blosc2.C2Array(path)
     npa = a[:]
     npb = b[:]
     npc = npa**2 + npb**2 + 2 * npa * npb + 1

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -37,13 +37,13 @@ def udf1p(inputs_tuple, output, offset):
 )
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.c2sub_auth_cookie(cookie):
+    with blosc2.c2sub_auth_cookie(cookie):
         yield cookie
 
 
 @pytest.fixture
 def sub_urlbase_ctxt():
-    with blosc2.c2array.c2sub_urlbase(URLBASE):
+    with blosc2.c2sub_urlbase(URLBASE):
         yield URLBASE
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -169,7 +169,9 @@ DIR = "expr/"
     ]
 )
 def auth_cookie(request):
-    return request.param
+    cookie = request.param
+    with blosc2.c2array.subscriber_auth_cookie(cookie):
+        yield cookie
 
 
 def test_open_c2array(auth_cookie):
@@ -178,8 +180,8 @@ def test_open_c2array(auth_cookie):
     chunks_blocks = "default"
     path = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + path}").as_posix()
-    a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=auth_cookie)
-    urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=auth_cookie)
+    a1 = blosc2.C2Array(path, urlbase=URLBASE)
+    urlpath = blosc2.URLPath(path, urlbase=URLBASE)
     a_open = blosc2.open(urlpath, mode="r", offset=0)
     np.testing.assert_allclose(a1[:], a_open[:])
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -199,15 +199,17 @@ def test_open_c2array(sub_auth_ctxt):
         _ = blosc2.open(urlpath, mode="r", offset=0, cparams={})
 
 
-def test_open_c2array_cookie(sub_auth_cookie):
+def test_open_c2array_cookie(sub_auth_cookie):  # instance cookie prevails
     dtype = np.float64
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     path = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + path}").as_posix()
-    urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
 
     with blosc2.c2array.c2subscriber_auth_cookie('wrong-cookie'):
-        _ = blosc2.open(urlpath, mode="r", offset=0)  # instance cookie prevails
+        a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
+        urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
+        a_open = blosc2.open(urlpath, mode="r", offset=0)
+        np.testing.assert_allclose(a1[:], a_open[:])
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -168,13 +168,13 @@ DIR = "expr/"
         # AUTH_COOKIE,
     ]
 )
-def auth_cookie(request):
+def sub_auth_ctxt(request):
     cookie = request.param
     with blosc2.c2array.subscriber_auth_cookie(cookie):
         yield cookie
 
 
-def test_open_c2array(auth_cookie):
+def test_open_c2array(sub_auth_ctxt):
     dtype = np.float64
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -178,14 +178,20 @@ def sub_auth_ctxt(sub_auth_cookie):
         yield sub_auth_cookie
 
 
-def test_open_c2array(sub_auth_ctxt):
+@pytest.fixture
+def sub_urlbase_ctxt():
+    with blosc2.c2array.c2subscriber_urlbase(URLBASE):
+        yield URLBASE
+
+
+def test_open_c2array(sub_urlbase_ctxt, sub_auth_ctxt):
     dtype = np.float64
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     path = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + path}").as_posix()
-    a1 = blosc2.C2Array(path, urlbase=URLBASE)
-    urlpath = blosc2.URLPath(path, urlbase=URLBASE)
+    a1 = blosc2.C2Array(path)
+    urlpath = blosc2.URLPath(path)
     a_open = blosc2.open(urlpath, mode="r", offset=0)
     np.testing.assert_allclose(a1[:], a_open[:])
 
@@ -199,17 +205,18 @@ def test_open_c2array(sub_auth_ctxt):
         _ = blosc2.open(urlpath, mode="r", offset=0, cparams={})
 
 
-def test_open_c2array_cookie(sub_auth_cookie):  # instance cookie prevails
+def test_open_c2array_args(sub_auth_cookie):  # instance args prevail
     dtype = np.float64
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     path = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + path}").as_posix()
 
-    with blosc2.c2array.c2subscriber_auth_cookie('wrong-cookie'):
-        a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
-        urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
-        a_open = blosc2.open(urlpath, mode="r", offset=0)
-        np.testing.assert_allclose(a1[:], a_open[:])
+    with blosc2.c2array.c2subscriber_urlbase('https://wrong.example.com/'):
+        with blosc2.c2array.c2subscriber_auth_cookie('wrong-cookie'):
+            a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
+            urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
+            a_open = blosc2.open(urlpath, mode="r", offset=0)
+            np.testing.assert_allclose(a1[:], a_open[:])
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -174,13 +174,13 @@ def sub_auth_cookie(request):
 
 @pytest.fixture
 def sub_auth_ctxt(sub_auth_cookie):
-    with blosc2.c2array.c2subscriber_auth_cookie(sub_auth_cookie):
+    with blosc2.c2array.c2sub_auth_cookie(sub_auth_cookie):
         yield sub_auth_cookie
 
 
 @pytest.fixture
 def sub_urlbase_ctxt():
-    with blosc2.c2array.c2subscriber_urlbase(URLBASE):
+    with blosc2.c2array.c2sub_urlbase(URLBASE):
         yield URLBASE
 
 
@@ -212,8 +212,8 @@ def test_open_c2array_args(sub_auth_cookie):  # instance args prevail
     path = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + path}").as_posix()
 
-    with blosc2.c2array.c2subscriber_urlbase('https://wrong.example.com/'):
-        with blosc2.c2array.c2subscriber_auth_cookie('wrong-cookie'):
+    with blosc2.c2array.c2sub_urlbase('https://wrong.example.com/'):
+        with blosc2.c2array.c2sub_auth_cookie('wrong-cookie'):
             a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
             urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
             a_open = blosc2.open(urlpath, mode="r", offset=0)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -173,18 +173,13 @@ def sub_auth_cookie(request):
 
 
 @pytest.fixture
-def sub_auth_ctxt(sub_auth_cookie):
-    with blosc2.c2sub_auth_cookie(sub_auth_cookie):
-        yield sub_auth_cookie
+def sub_context(sub_auth_cookie):
+    c2params = dict(urlbase=URLBASE, auth_cookie=sub_auth_cookie)
+    with blosc2.c2context(**c2params):
+        yield c2params
 
 
-@pytest.fixture
-def sub_urlbase_ctxt():
-    with blosc2.c2sub_urlbase(URLBASE):
-        yield URLBASE
-
-
-def test_open_c2array(sub_urlbase_ctxt, sub_auth_ctxt):
+def test_open_c2array(sub_context):
     dtype = np.float64
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
@@ -212,11 +207,11 @@ def test_open_c2array_args(sub_auth_cookie):  # instance args prevail
     path = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + path}").as_posix()
 
-    with blosc2.c2sub_urlbase('https://wrong.example.com/'):
-        with blosc2.c2sub_auth_cookie('wrong-cookie'):
-            a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
-            urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
-            a_open = blosc2.open(urlpath, mode="r", offset=0)
-            np.testing.assert_allclose(a1[:], a_open[:])
+    with blosc2.c2context(urlbase='https://wrong.example.com/',
+                          auth_cookie='wrong-cookie'):
+        a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
+        urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
+        a_open = blosc2.open(urlpath, mode="r", offset=0)
+        np.testing.assert_allclose(a1[:], a_open[:])
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -170,7 +170,7 @@ DIR = "expr/"
 )
 def sub_auth_ctxt(request):
     cookie = request.param
-    with blosc2.c2array.subscriber_auth_cookie(cookie):
+    with blosc2.c2array.c2subscriber_auth_cookie(cookie):
         yield cookie
 
 

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -174,13 +174,13 @@ def sub_auth_cookie(request):
 
 @pytest.fixture
 def sub_auth_ctxt(sub_auth_cookie):
-    with blosc2.c2array.c2sub_auth_cookie(sub_auth_cookie):
+    with blosc2.c2sub_auth_cookie(sub_auth_cookie):
         yield sub_auth_cookie
 
 
 @pytest.fixture
 def sub_urlbase_ctxt():
-    with blosc2.c2array.c2sub_urlbase(URLBASE):
+    with blosc2.c2sub_urlbase(URLBASE):
         yield URLBASE
 
 
@@ -212,8 +212,8 @@ def test_open_c2array_args(sub_auth_cookie):  # instance args prevail
     path = f"ds-0-10-linspace-{dtype.__name__}-{chunks_blocks}-a1-{shape}d.b2nd"
     path = pathlib.Path(f"{ROOT}/{DIR + path}").as_posix()
 
-    with blosc2.c2array.c2sub_urlbase('https://wrong.example.com/'):
-        with blosc2.c2array.c2sub_auth_cookie('wrong-cookie'):
+    with blosc2.c2sub_urlbase('https://wrong.example.com/'):
+        with blosc2.c2sub_auth_cookie('wrong-cookie'):
             a1 = blosc2.C2Array(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
             urlpath = blosc2.URLPath(path, urlbase=URLBASE, auth_cookie=sub_auth_cookie)
             a_open = blosc2.open(urlpath, mode="r", offset=0)


### PR DESCRIPTION
This adds the context manager `c2context` which allow setting a default value for the Caterva2 subscriber URL base and authorization cookie, to be used when a particular instance of `C2Array` does not have a set one. Note that the subscriber URL base is now optional both in `URLPath` and `C2Array.__init__`.

Context managers may be invoked arbitrarily inside one another and their values will stack, inheriting those set by the previous ones. Concurrent entering and exiting of the context managers is not supported, though, as they use a private global variable in the `blosc2.c2array` module.

Also, when no subscriber URL base is set in the `C2Array` instance nor via the context manager, code defaults to querying the `BLOSC_C2URLBASE` environment variable. If no default URL base is set anywhere, a `RuntimeError` is raised when performing an operation.

Additionally, lazy expressions no longer write/read the authorization cookie to/from storage on save/open, as it makes no sense to keep a value which is to exprire in a short time.

Finally, the derivative attributes `root` and `filepath` have been removed from `C2Array`; split `path` instead if needed.