### PR TITLE
Login support for Caterva2 context manager

### DIFF
--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -109,10 +109,6 @@ def _sub_url(urlbase, path):
             else f"{urlbase}/{path}")
 
 
-def _sub_api_url(urlbase, apipath):
-    return _sub_url(urlbase, f"api/{apipath}")
-
-
 def login(username, password, urlbase):
     url = _sub_url(urlbase, "auth/jwt/login")
     creds = dict(username=username, password=password)
@@ -122,19 +118,19 @@ def login(username, password, urlbase):
 
 
 def info(path, urlbase, params=None, headers=None, model=None, auth_token=None):
-    url = _sub_api_url(urlbase, f"info/{path}")
+    url = _sub_url(urlbase, f"api/info/{path}")
     response = _xget(url, params, headers, auth_token)
     json = response.json()
     return json if model is None else model(**json)
 
 
 def subscribe(root, urlbase, auth_token):
-    url = _sub_api_url(urlbase, f"subscribe/{root}")
+    url = _sub_url(urlbase, f"api/subscribe/{root}")
     return _xpost(url, auth_token=auth_token)
 
 
 def fetch_data(path, urlbase, params, auth_token=None):
-    url = _sub_api_url(urlbase, f"fetch/{path}")
+    url = _sub_url(urlbase, f"api/fetch/{path}")
     response = _xget(url, params=params, auth_token=auth_token)
     data = response.content
     try:

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -45,11 +45,11 @@ def c2context(*, urlbase: (str | None) = None,
 
     Parameters
     ----------
-    urlbase: str | None
+    urlbase : str | None
         A URL base that will be used when an individual C2Array instance has
         no subscriber URL base set.  Use the ``BLOSC_C2URLBASE`` environment
         variable if set as a last resort default.
-    auth_token: str | None
+    auth_token : str | None
         A token that will be used when an individual C2Array instance has no
         authorization token set.  It should have been previously obtained from
         the subscriber.

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -41,6 +41,12 @@ def c2context(*, urlbase: (str | None) = None,
     below) if supported by that parameter.  Parameters set to the empty string
     are not to be used in requests (with no default either).
 
+    If the subscriber requires authorization for requests, you may either
+    provide `auth_token` (which you should have obtained previously from the
+    subscriber), or both `username` and `password` to get that token by first
+    logging in to the subscriber.  The token will be reused until explicitly
+    reset or requested again in a latter context manager invocation.
+
     Please note that this manager is reentrant but not concurrency-safe.
 
     Parameters
@@ -49,10 +55,15 @@ def c2context(*, urlbase: (str | None) = None,
         A URL base that will be used when an individual C2Array instance has
         no subscriber URL base set.  Use the ``BLOSC_C2URLBASE`` environment
         variable if set as a last resort default.
+    username : str | None
+        A name to be used in credentials to login to the subscriber and get an
+        authorization token from it.
+    password : str | None
+        A secret to be used in credentials to login to the subscriber and get
+        an authorization token from it.
     auth_token : str | None
         A token that will be used when an individual C2Array instance has no
-        authorization token set.  It should have been previously obtained from
-        the subscriber.
+        authorization token set.
 
     Yields
     ------

--- a/blosc2/c2array.py
+++ b/blosc2/c2array.py
@@ -21,6 +21,12 @@ import blosc2
 C2SUB_URLBASE_ENVVAR = 'BLOSC_C2URLBASE'
 """Environment variable with a default Caterva2 subscriber URL base."""
 
+C2SUB_USERNAME_ENVVAR = 'BLOSC_C2USERNAME'
+"""Environment variable with a default Caterva2 subscriber user name."""
+
+C2SUB_PASSWORD_ENVVAR = 'BLOSC_C2PASSWORD'
+"""Environment variable with a default Caterva2 subscriber password."""
+
 _subscriber_data = {
     'urlbase': os.environ.get(C2SUB_URLBASE_ENVVAR),
     'auth_token': '',
@@ -57,10 +63,12 @@ def c2context(*, urlbase: (str | None) = None,
         variable if set as a last resort default.
     username : str | None
         A name to be used in credentials to login to the subscriber and get an
-        authorization token from it.
+        authorization token from it.  Use the ``BLOSC_C2USERNAME`` environment
+        variable if set as a last resort default.
     password : str | None
         A secret to be used in credentials to login to the subscriber and get
-        an authorization token from it.
+        an authorization token from it.  Use the ``BLOSC_C2PASSWORD``
+        environment variable if set as a last resort default.
     auth_token : str | None
         A token that will be used when an individual C2Array instance has no
         authorization token set.
@@ -73,6 +81,9 @@ def c2context(*, urlbase: (str | None) = None,
     global _subscriber_data
 
     # Perform login to get an authorization token.
+    if not auth_token:
+        username = username or os.environ.get(C2SUB_USERNAME_ENVVAR)
+        password = password or os.environ.get(C2SUB_PASSWORD_ENVVAR)
     if username or password:
         if auth_token:
             raise ValueError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,3 +16,13 @@ def setup_session():
     # This code will be executed before the test suite
     print()
     blosc2.print_versions()
+
+
+@pytest.fixture(scope="session")
+def sub_context():
+    # You may use the URL and credentials for an already existing user
+    # in a different Caterva2 subscriber.
+    c2params = dict(urlbase="https://demo.caterva2.net/",
+                    username=None, password=None)
+    with blosc2.c2context(**c2params):
+        yield c2params

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,7 +19,7 @@ def setup_session():
 
 
 @pytest.fixture(scope="session")
-def sub_context():
+def c2sub_context():
     # You may use the URL and credentials for an already existing user
     # in a different Caterva2 subscriber.
     c2params = dict(urlbase="https://demo.caterva2.net/",

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -49,7 +49,7 @@ def get_arrays(shape, chunks_blocks):
         (False, False),
     ],
 )
-def test_simple(chunks_blocks, sub_context):
+def test_simple(chunks_blocks, c2sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
 
@@ -65,7 +65,7 @@ def test_simple(chunks_blocks, sub_context):
     np.testing.assert_allclose(res[:], nres)
 
 
-def test_simple_getitem(sub_context):
+def test_simple_getitem(c2sub_context):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -89,7 +89,7 @@ def test_simple_getitem(sub_context):
         (False, False),
     ],
 )
-def test_ixxx(chunks_blocks, sub_context):
+def test_ixxx(chunks_blocks, c2sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     expr = a1**3 + a2**2 + a3**3 - a4 + 3
@@ -101,7 +101,7 @@ def test_ixxx(chunks_blocks, sub_context):
     np.testing.assert_allclose(res[:], nres)
 
 
-def test_complex(sub_context):
+def test_complex(c2sub_context):
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -130,7 +130,7 @@ def test_complex(sub_context):
         (False, False),
     ],
 )
-def test_mix_operands(chunks_blocks, sub_context):
+def test_mix_operands(chunks_blocks, c2sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     b1 = blosc2.asarray(na1, chunks=a1.chunks, blocks=a1.blocks)
@@ -166,7 +166,7 @@ def test_mix_operands(chunks_blocks, sub_context):
 
 
 # Tests related with save method
-def test_save(sub_context):
+def test_save(c2sub_context):
     shape = (60, 60)
     tol = 1e-17
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, (False, True))
@@ -210,7 +210,7 @@ def broadcast_shape(request):
 
 
 @pytest.fixture
-def broadcast_fixture(broadcast_shape, sub_context):
+def broadcast_fixture(broadcast_shape, c2sub_context):
     shape1, shape2 = broadcast_shape
     dtype = np.float64
     na1 = np.linspace(0, 1, np.prod(shape1), dtype=dtype).reshape(shape1)

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -14,16 +14,8 @@ import pytest
 import blosc2
 
 NITEMS_SMALL = 1_000
-
-C2PARAMS = dict(urlbase="https://demo.caterva2.net/", username=None, password=None)
 ROOT = "b2tests"
 DIR = "expr/"
-
-
-@pytest.fixture(scope="session")
-def sub_context():
-    with blosc2.c2context(**C2PARAMS):
-        yield C2PARAMS
 
 
 def get_arrays(shape, chunks_blocks):

--- a/tests/ndarray/test_c2array_expr.py
+++ b/tests/ndarray/test_c2array_expr.py
@@ -15,29 +15,15 @@ import blosc2
 
 NITEMS_SMALL = 1_000
 
-# URLBASE = 'http://localhost:8002/'
-URLBASE = "https://demo.caterva2.net/"
+C2PARAMS = dict(urlbase="https://demo.caterva2.net/", username=None, password=None)
 ROOT = "b2tests"
 DIR = "expr/"
 
-# import httpx
-# resp = httpx.post(f'{URLBASE}auth/jwt/login',
-#                   data=dict(username='user@example.com', password='foobar'))
-# resp.raise_for_status()
-# AUTH_TOKEN = '='.join(list(resp.cookies.items())[0])
 
-
-@pytest.fixture(
-    params=[
-        None,
-        # AUTH_TOKEN,
-    ]
-)
-def sub_context(request):
-    token = request.param
-    c2params = dict(urlbase=URLBASE, auth_token=token)
-    with blosc2.c2context(**c2params):
-        yield c2params
+@pytest.fixture(scope="session")
+def sub_context():
+    with blosc2.c2context(**C2PARAMS):
+        yield C2PARAMS
 
 
 def get_arrays(shape, chunks_blocks):

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -15,27 +15,15 @@ import blosc2
 
 NITEMS_SMALL = 1_000
 
-# URLBASE = 'http://localhost:8002/'
-URLBASE = 'https://demo.caterva2.net/'
+C2PARAMS = dict(urlbase="https://demo.caterva2.net/", username=None, password=None)
 ROOT = 'b2tests'
 DIR = 'expr/'
 
-# import httpx
-# resp = httpx.post(f'{URLBASE}auth/jwt/login',
-#                   data=dict(username='user@example.com', password='foobar'))
-# resp.raise_for_status()
-# AUTH_TOKEN = '='.join(list(resp.cookies.items())[0])
 
-
-@pytest.fixture(params=[
-    None,
-    # AUTH_TOKEN,
-])
-def sub_context(request):
-    token = request.param
-    c2params = dict(urlbase=URLBASE, auth_token=token)
-    with blosc2.c2context(**c2params):
-        yield c2params
+@pytest.fixture(scope="session")
+def sub_context():
+    with blosc2.c2context(**C2PARAMS):
+        yield C2PARAMS
 
 
 def get_arrays(shape, chunks_blocks):

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -43,7 +43,7 @@ def get_arrays(shape, chunks_blocks):
 
 
 @pytest.mark.parametrize("reduce_op", ["sum", pytest.param("all", marks=pytest.mark.heavy)])
-def test_reduce_bool(reduce_op, sub_context):
+def test_reduce_bool(reduce_op, c2sub_context):
     shape = (NITEMS_SMALL, )
     chunks_blocks = 'default'
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
@@ -71,7 +71,7 @@ def test_reduce_bool(reduce_op, sub_context):
 @pytest.mark.parametrize("axis", [1])
 @pytest.mark.parametrize("keepdims", [True, False])
 @pytest.mark.parametrize("dtype_out", [np.int16])
-def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, sub_context):
+def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, c2sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and np.isscalar(axis) and len(a1.shape) >= axis:
@@ -119,7 +119,7 @@ def test_reduce_params(chunks_blocks, axis, keepdims, dtype_out, reduce_op, sub_
                                        pytest.param("var", marks=pytest.mark.heavy),
                                        ])
 @pytest.mark.parametrize("axis", [0])
-def test_reduce_expr_arr(chunks_blocks, axis, reduce_op, sub_context):
+def test_reduce_expr_arr(chunks_blocks, axis, reduce_op, c2sub_context):
     shape = (60, 60)
     a1, a2, a3, a4, na1, na2, na3, na4 = get_arrays(shape, chunks_blocks)
     if axis is not None and len(a1.shape) >= axis:

--- a/tests/ndarray/test_c2array_reductions.py
+++ b/tests/ndarray/test_c2array_reductions.py
@@ -14,16 +14,8 @@ import pytest
 import blosc2
 
 NITEMS_SMALL = 1_000
-
-C2PARAMS = dict(urlbase="https://demo.caterva2.net/", username=None, password=None)
 ROOT = 'b2tests'
 DIR = 'expr/'
-
-
-@pytest.fixture(scope="session")
-def sub_context():
-    with blosc2.c2context(**C2PARAMS):
-        yield C2PARAMS
 
 
 def get_arrays(shape, chunks_blocks):

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -12,16 +12,9 @@ import pytest
 
 import blosc2
 
-# URLBASE = 'http://localhost:8002/'
-URLBASE = "https://demo.caterva2.net/"
+C2PARAMS = dict(urlbase="https://demo.caterva2.net/", username=None, password=None)
 ROOT = "b2tests"
 DIR = "expr/"
-
-# import httpx
-# resp = httpx.post(f'{URLBASE}auth/jwt/login',
-#                   data=dict(username='user@example.com', password='foobar'))
-# resp.raise_for_status()
-# AUTH_TOKEN = '='.join(list(resp.cookies.items())[0])
 
 
 def udf1p(inputs_tuple, output, offset):
@@ -29,17 +22,10 @@ def udf1p(inputs_tuple, output, offset):
     output[:] = x + 1
 
 
-@pytest.fixture(
-    params=[
-        None,
-        # AUTH_TOKEN,
-    ]
-)
-def sub_context(request):
-    token = request.param
-    c2params = dict(urlbase=URLBASE, auth_token=token)
-    with blosc2.c2context(**c2params):
-        yield c2params
+@pytest.fixture(scope="session")
+def sub_context():
+    with blosc2.c2context(**C2PARAMS):
+        yield C2PARAMS
 
 
 @pytest.mark.parametrize("chunked_eval", [True, False])

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -32,7 +32,7 @@ def udf1p(inputs_tuple, output, offset):
         ),
     ],
 )
-def test_1p(chunks, blocks, chunked_eval, sub_context):
+def test_1p(chunks, blocks, chunked_eval, c2sub_context):
     dtype = np.float64
     shape = (60, 60)
     urlpath = f"ds-0-10-linspace-{dtype.__name__}-(True, False)-a1-{shape}d.b2nd"
@@ -69,7 +69,7 @@ def udf2p(inputs_tuple, output, offset):
         pytest.param((53, 20), (10, 13), (slice(3, 8), slice(9, 12)), None, False),
     ],
 )
-def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval, sub_context):
+def test_getitem(chunks, blocks, slices, urlpath, contiguous, chunked_eval, c2sub_context):
     dtype = np.float64
     shape = (60, 60)
     blosc2.remove_urlpath(urlpath)

--- a/tests/ndarray/test_c2array_udf.py
+++ b/tests/ndarray/test_c2array_udf.py
@@ -12,7 +12,6 @@ import pytest
 
 import blosc2
 
-C2PARAMS = dict(urlbase="https://demo.caterva2.net/", username=None, password=None)
 ROOT = "b2tests"
 DIR = "expr/"
 
@@ -20,12 +19,6 @@ DIR = "expr/"
 def udf1p(inputs_tuple, output, offset):
     x = inputs_tuple[0]
     output[:] = x + 1
-
-
-@pytest.fixture(scope="session")
-def sub_context():
-    with blosc2.c2context(**C2PARAMS):
-        yield C2PARAMS
 
 
 @pytest.mark.parametrize("chunked_eval", [True, False])

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -152,7 +152,7 @@ ROOT = "b2tests"
 DIR = "expr/"
 
 
-def test_open_c2array(sub_context):
+def test_open_c2array(c2sub_context):
     dtype = np.float64
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
@@ -173,7 +173,7 @@ def test_open_c2array(sub_context):
         _ = blosc2.open(urlpath, mode="r", offset=0, cparams={})
 
 
-def test_open_c2array_args(sub_context):  # instance args prevail
+def test_open_c2array_args(c2sub_context):  # instance args prevail
     dtype = np.float64
     shape = (NITEMS_SMALL,)
     chunks_blocks = "default"
@@ -182,9 +182,9 @@ def test_open_c2array_args(sub_context):  # instance args prevail
 
     with blosc2.c2context(urlbase='https://wrong.example.com/',
                           auth_token='wrong-token'):
-        urlbase = sub_context['urlbase']
-        auth_token = (blosc2.c2array.login(**sub_context)
-                      if sub_context['username'] else None)
+        urlbase = c2sub_context['urlbase']
+        auth_token = (blosc2.c2array.login(**c2sub_context)
+                      if c2sub_context['username'] else None)
         a1 = blosc2.C2Array(path, urlbase=urlbase, auth_token=auth_token)
         urlpath = blosc2.URLPath(path, urlbase=urlbase, auth_token=auth_token)
         a_open = blosc2.open(urlpath, mode="r", offset=0)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -200,9 +200,13 @@ def c2sub_user():
     username = "user+%x@example.com" % rand32()
     password = hex(rand32())
 
-    resp = httpx.post(f"{urlbase}auth/register",
-                      json={'email': username, 'password': password},
-                      timeout=15)
+    for _ in range(3):
+        resp = httpx.post(f"{urlbase}auth/register",
+                          json={'email': username, 'password': password},
+                          timeout=15)
+        if resp.status_code != 400:
+            break
+        # Retry on possible username collision.
     resp.raise_for_status()
 
     c2params = dict(urlbase=urlbase, username=username, password=password)

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -148,16 +148,8 @@ def test_open_offset(offset, urlpath, mode, mmap_mode):
 
 
 NITEMS_SMALL = 1_000
-
-C2PARAMS = dict(urlbase="https://demo.caterva2.net/", username=None, password=None)
 ROOT = "b2tests"
 DIR = "expr/"
-
-
-@pytest.fixture(scope="session")
-def sub_context():
-    with blosc2.c2context(**C2PARAMS):
-        yield C2PARAMS
 
 
 def test_open_c2array(sub_context):


### PR DESCRIPTION
This extends `blosc2.c2context()` with `username` and `password` parameters. When they are provided, the context manager performs a login to the Caterva2 subscriber and uses the returned authorization token for subsequent operations. Their default values may be specified via the `BLOSC_C2USERNAME` and `BLOSC_C2PASSWORD` environment variables.

Tests fixtures have been rewritten to ease enabling authentication for relevant `C2Array` tests. A new test has been added which explicitly checks opening such an array with authentication (by creating a throwaway user at the subscriber).

Some fixes to the semantics and documentation for parameter inheritance and defaults for the context manager are included too.