### PR TITLE
Enforce ruff/flake8-simplify rule SIM401

### DIFF
--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -224,7 +224,7 @@ blosclib_version = f"{VERSION_STRING} ({VERSION_DATE})"
 The blosc2 version + date.
 """
 # Internal Blosc threading
-nthreads = ncores = cpu_info["count"] if "count" in cpu_info else 1
+nthreads = ncores = cpu_info.get("count", 1)
 """Number of threads to be used in compression/decompression.
 """
 # Protection against too many threads


### PR DESCRIPTION
SIM401 Use `self.get(..., ...)` instead of an `if` block