### PR TITLE
Do not use bare `except`

### DIFF
--- a/blosc2/lazyexpr.py
+++ b/blosc2/lazyexpr.py
@@ -168,7 +168,7 @@ def convert_inputs(inputs):
         ) and not np.isscalar(obj):
             try:
                 obj = np.asarray(obj)
-            except:
+            except Exception:
                 print(
                     "Inputs not being np.ndarray, NDArray, NDField, C2Array or Python scalar objects"
                     " should be convertible to np.ndarray."


### PR DESCRIPTION
At the very least catch `Except` instead of the default `BaseExcept`, thus not catching:
- `BaseExceptionGroup`,
- `GeneratorExit`,
- `KeyboardInterrupt`,
- `SystemExit`.