### PR TITLE
Enforce some ruff/tryceratops rules (TRY)

### DIFF
--- a/blosc2/lazyexpr.py
+++ b/blosc2/lazyexpr.py
@@ -1439,7 +1439,7 @@ class LazyUDF(LazyArray):
         if isinstance(dparams, dict):
             dparams["nthreads"] = 1
         else:
-            raise ValueError("dparams should be a dictionary")
+            raise TypeError("dparams should be a dictionary")
         kwargs_getitem["dparams"] = dparams
 
         self.res_getitem = blosc2.empty(self._shape, self._dtype, **kwargs_getitem)
@@ -1561,7 +1561,7 @@ def _open_lazyarray(array):
                 urlbase=value["urlbase"],
             )
         else:
-            raise ValueError("Error when retrieving the operands")
+            raise TypeError("Error when retrieving the operands")
 
     expr = lazyarray["expression"]
     globals = {}

--- a/blosc2/ndarray.py
+++ b/blosc2/ndarray.py
@@ -548,7 +548,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         This always clear the last read data (if any).
         """
         if not isinstance(value, bool):
-            raise ValueError("keep_last_read should be a boolean")
+            raise TypeError("keep_last_read should be a boolean")
         # Reset last read data
         self._last_read.clear()
         self._keep_last_read = value
@@ -1704,7 +1704,7 @@ def contains(
         A lazy expression that can be evaluated.
     """
     if not isinstance(value, str | bytes | NDArray):
-        raise ValueError("value should be a string, bytes or a NDArray!")
+        raise TypeError("value should be a string, bytes or a NDArray!")
     return blosc2.LazyExpr(new_op=(ndarr, "contains", value))
 
 
@@ -1769,7 +1769,7 @@ def _check_shape(shape):
     if isinstance(shape, int | np.integer):
         shape = (shape,)
     elif not isinstance(shape, tuple | list):
-        raise ValueError("shape should be a tuple or a list!")
+        raise TypeError("shape should be a tuple or a list!")
     return shape
 
 
@@ -2176,13 +2176,13 @@ class NDField(Operand):
             The corresponding :ref:`NDField`.
         """
         if not isinstance(ndarr, NDArray):
-            raise ValueError("ndarr should be a NDArray!")
+            raise TypeError("ndarr should be a NDArray!")
         if not isinstance(field, str):
-            raise ValueError("field should be a string!")
+            raise TypeError("field should be a string!")
         if ndarr.dtype.fields is None:
-            raise ValueError("NDArray does not have a structured dtype!")
+            raise TypeError("NDArray does not have a structured dtype!")
         if field not in ndarr.dtype.fields:
-            raise ValueError(f"Field {field} not found in the dtype of the NDArray")
+            raise TypeError(f"Field {field} not found in the dtype of the NDArray")
         # Store immutable properties
         self.ndarr = ndarr
         self.chunks = ndarr.chunks
@@ -2231,7 +2231,7 @@ class NDField(Operand):
             return key.where(self)
 
         if isinstance(key, str):
-            raise ValueError("This array is an NDField; use a structured NDArray for bool expressions")
+            raise TypeError("This array is an NDField; use a structured NDArray for bool expressions")
 
         # Check if the key is in the last read cache
         inmutable_key = make_key_hashable(key)

--- a/blosc2/schunk.py
+++ b/blosc2/schunk.py
@@ -428,7 +428,7 @@ class SChunk(blosc2_ext.SChunk):
 
         """
         if not isinstance(special_value, SpecialValue):
-            raise ValueError("special_value must be a SpecialValue instance")
+            raise TypeError("special_value must be a SpecialValue instance")
         nchunks = super().fill_special(nitems, special_value.value)
         if nchunks < 0:
             raise RuntimeError("Unable to fill with special values")


### PR DESCRIPTION
This is a breaking change: `TypeError` is raised instead of `ValueError`.