### PR TITLE
Read ahead

### DIFF
--- a/blosc2/__init__.py
+++ b/blosc2/__init__.py
@@ -12,6 +12,8 @@
 
 from enum import Enum
 
+import numexpr
+
 
 class Codec(Enum):
     """
@@ -232,6 +234,9 @@ nthreads = min(nthreads, 32)
 # Experiments say that, when using a large number of threads, it is better to not use them all
 nthreads -= nthreads // 8
 set_nthreads(nthreads)
+
+# Set the number of threads for NumExpr
+numexpr.set_num_threads(nthreads)
 
 # Defaults for compression params
 cparams_dflts = {

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1331,9 +1331,9 @@ def compute_chunks_blocks(
             max_blocksize = blosc2.cpu_info["l1_cache_size"] // 2
         if 'clevel' in cparams and cparams['clevel'] == 0:
             # Experiments show that, when no compression is used, it is not a good idea
-            # to exceed 256 KB for the blocksize because speed suffers too much during
-            # evaluations.
-            blocksize = 2**18
+            # to exceed half of L2 for the blocksize because speed suffers too much
+            # during evaluations.
+            blocksize = blosc2.cpu_info["l2_cache_size"] // 2
         elif blocksize > max_blocksize:
             blocksize = max_blocksize
 

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1325,7 +1325,7 @@ def compute_chunks_blocks(
         # to exceed 128 KB for the blocksize.
         # Even Intel/AMD machines with 1MB/2MB usually have better performance with 128 KB
         # when evaluating expressions and other operations.
-        if cparams['clevel'] == 0:
+        if 'clevel' in cparams and cparams['clevel'] == 0:
             blocksize = 2**17
         # For Apple Silicon, experiments say to use half of the L1 cache size
         if platform.system() == 'Darwin' and 'arm' in platform.machine():

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1324,16 +1324,16 @@ def compute_chunks_blocks(
         # Maximum blocksize calculation
         max_blocksize = blocksize
         if platform.machine() == 'x86_64':
-            # For modern Intel archs, experiments say to use half of the L2 cache size
+            # For modern Intel/AMD archs, experiments say to use half of the L2 cache size
             max_blocksize = blosc2.cpu_info["l2_cache_size"] // 2
         elif platform.system() == 'Darwin' and 'arm' in platform.machine():
             # For Apple Silicon, experiments say to use half of the L1 cache size
             max_blocksize = blosc2.cpu_info["l1_cache_size"] // 2
         if 'clevel' in cparams and cparams['clevel'] == 0:
             # Experiments show that, when no compression is used, it is not a good idea
-            # to exceed 128 KB for the blocksize because speed suffers too much during
+            # to exceed 256 KB for the blocksize because speed suffers too much during
             # evaluations.
-            blocksize = 2**17
+            blocksize = 2**18
         elif blocksize > max_blocksize:
             blocksize = max_blocksize
 

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1331,9 +1331,9 @@ def compute_chunks_blocks(
             max_blocksize = blosc2.cpu_info["l1_cache_size"] // 2
         if 'clevel' in cparams and cparams['clevel'] == 0:
             # Experiments show that, when no compression is used, it is not a good idea
-            # to exceed half of L2 for the blocksize because speed suffers too much
-            # during evaluations.
-            blocksize = blosc2.cpu_info["l2_cache_size"] // 2
+            # to exceed half of private cache for the blocksize because speed suffers
+            # too much during evaluations.
+            blocksize = max_blocksize
         elif blocksize > max_blocksize:
             blocksize = max_blocksize
 

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1321,15 +1321,21 @@ def compute_chunks_blocks(
         cparams2["tuner"] = blosc2.Tuner.STUNE
         src = blosc2.compress2(np.zeros(nitems, dtype=f"V{itemsize}"), **cparams2)
         _, _, blocksize = blosc2.get_cbuffer_sizes(src)
-        # Experiments show that, when no compression is used, it is not a good idea
-        # to exceed 128 KB for the blocksize.
-        # Even Intel/AMD machines with 1MB/2MB usually have better performance with 128 KB
-        # when evaluating expressions and other operations.
+        # Maximum blocksize calculation
+        max_blocksize = blocksize
+        if platform.machine() == 'x86_64':
+            # For modern Intel archs, experiments say to use half of the L2 cache size
+            max_blocksize = blosc2.cpu_info["l2_cache_size"] // 2
+        elif platform.system() == 'Darwin' and 'arm' in platform.machine():
+            # For Apple Silicon, experiments say to use half of the L1 cache size
+            max_blocksize = blosc2.cpu_info["l1_cache_size"] // 2
         if 'clevel' in cparams and cparams['clevel'] == 0:
+            # Experiments show that, when no compression is used, it is not a good idea
+            # to exceed 128 KB for the blocksize because speed suffers too much during
+            # evaluations.
             blocksize = 2**17
-        # For Apple Silicon, experiments say to use half of the L1 cache size
-        if platform.system() == 'Darwin' and 'arm' in platform.machine():
-            blocksize = blosc2.cpu_info["l1_cache_size"] // 2
+        elif blocksize > max_blocksize:
+            blocksize = max_blocksize
 
         cparams2["tuner"] = aux_tuner
     else:

--- a/blosc2/core.py
+++ b/blosc2/core.py
@@ -1321,11 +1321,12 @@ def compute_chunks_blocks(
         cparams2["tuner"] = blosc2.Tuner.STUNE
         src = blosc2.compress2(np.zeros(nitems, dtype=f"V{itemsize}"), **cparams2)
         _, _, blocksize = blosc2.get_cbuffer_sizes(src)
-        # Experiments show that it is not a good idea to exceed 128 KB for the blocksize.
+        # Experiments show that, when no compression is used, it is not a good idea
+        # to exceed 128 KB for the blocksize.
         # Even Intel/AMD machines with 1MB/2MB usually have better performance with 128 KB
         # when evaluating expressions and other operations.
-        # Also, use 128 KB when no compression is used, as it is a good tradeoff for most cases.
-        blocksize = 2**17
+        if cparams['clevel'] == 0:
+            blocksize = 2**17
         # For Apple Silicon, experiments say to use half of the L1 cache size
         if platform.system() == 'Darwin' and 'arm' in platform.machine():
             blocksize = blosc2.cpu_info["l1_cache_size"] // 2

--- a/blosc2/lazyexpr.py
+++ b/blosc2/lazyexpr.py
@@ -426,7 +426,9 @@ def fill_chunk_operands(operands, shape, slice_, chunks_, full_chunk, nchunk, ch
         # Run the asynchronous file reading function from a synchronous context
         chunks = next(iter_chunks)
         for i, (key, value) in enumerate(operands.items()):
-            if key in chunk_operands:
+            if 0 and key in chunk_operands:
+                # Disabling this optimization, as sometimes it gives a segfault
+                # TODO: investigate why
                 # We already have a buffer for this operand
                 blosc2.decompress2(chunks[i], dst=chunk_operands[key])
             else:

--- a/blosc2/lazyexpr.py
+++ b/blosc2/lazyexpr.py
@@ -5,13 +5,17 @@
 # This source code is licensed under a BSD-style license (found in the
 # LICENSE file in the root directory of this source tree)
 #######################################################################
+import asyncio
+import concurrent.futures
 import copy
 import math
 import pathlib
+import threading
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from enum import Enum
 from pathlib import Path
+from queue import Empty, Queue
 
 import ndindex
 import numexpr as ne
@@ -351,11 +355,86 @@ def do_slices_intersect(slice1, slice2):
     return True
 
 
+async def async_read_chunks(arrs, queue):
+    loop = asyncio.get_event_loop()
+    nchunks = arrs[0].schunk.nchunks
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        for nchunk in range(nchunks):
+            futures = [
+                (index, loop.run_in_executor(executor, arr.schunk.get_chunk, nchunk))
+                for index, arr in enumerate(arrs)
+            ]
+            chunks = await asyncio.gather(*(future for index, future in futures))
+            chunks_sorted = [chunk for index, chunk in
+                             sorted(zip([index for index, _ in futures], chunks, strict=True))]
+            queue.put((nchunk, chunks_sorted))  # Use non-async queue.put()
+            # print(f"Length of the queue: {queue.qsize()}, nchunk: {nchunk}")
+            assert queue.qsize() <= 5  # Check that the queue size is bounded
+
+    queue.put(None)  # Signal the end of the chunks
+
+
+def async_read_chunks_thread(arrs, queue):
+    asyncio.run(async_read_chunks(arrs, queue))
+
+def sync_read_chunks(arrs):
+    queue_size = 3  # maximum number of chunks in the queue
+    queue = Queue(maxsize=queue_size)
+
+    # Start the async file reading in a separate thread
+    thread = threading.Thread(target=async_read_chunks_thread, args=(arrs, queue))
+    thread.start()
+
+    # Read the chunks synchronously from the queue
+    while True:
+        try:
+            chunks = queue.get(timeout=1)  # Wait for the next chunk
+            # print(f"chunks: {len(chunks)} {chunks[0]}")
+            if chunks is None:  # End of chunks
+                break
+            yield chunks
+        except Empty:
+            continue
+
+def read_nchunk(arrs):
+    for nchunk_, chunks in sync_read_chunks(arrs):
+        yield chunks
+
+iter_chunks = None
+
 def fill_chunk_operands(operands, shape, slice_, chunks_, full_chunk, nchunk, chunk_operands):
     """Get the chunk operands for the expression evaluation.
 
     This function offers a fast path for full chunks and a slow path for the rest.
     """
+    global iter_chunks
+
+    # Check that all operands are NDArray for fast path
+    all_ndarray = all(isinstance(value, blosc2.NDArray) and value.shape != ()
+                      for value in operands.values())
+    # Check that there is some NDArray that is persisted in the disk
+    any_persisted = any((isinstance(value, blosc2.NDArray) and
+                         value.shape != () and
+                         value.schunk.urlpath is not None)
+                        for value in operands.values())
+    if all_ndarray and any_persisted:
+        # print("fast path")
+        if nchunk == 0:
+            # Initialize the iterator for reading the chunks
+            iter_chunks = read_nchunk(list(value for value in operands.values()))
+        # Run the asynchronous file reading function from a synchronous context
+        chunks = next(iter_chunks)
+        for i, (key, value) in enumerate(operands.items()):
+            if key in chunk_operands:
+                # We already have a buffer for this operand
+                blosc2.decompress2(chunks[i], dst=chunk_operands[key])
+            else:
+                buff = blosc2.decompress2(chunks[i])
+                bsize = value.dtype.itemsize * math.prod(chunks_)
+                chunk_operands[key] = np.frombuffer(buff[:bsize], dtype=value.dtype).reshape(chunks_)
+        return
+
     for key, value in operands.items():
         if np.isscalar(value):
             chunk_operands[key] = value


### PR DESCRIPTION
This allows to perform read-ahead of operands on disk while doing operations.  This can dramatically accelerate out-of-core computations up to 2x (!).