### PR TITLE
Apply ruff NumPy-specific rule NPY002

### DIFF
--- a/doc/getting_started/tutorials/02.ndarray-basics.ipynb
+++ b/doc/getting_started/tutorials/02.ndarray-basics.ipynb
@@ -686,7 +686,8 @@
     }
    ],
    "source": [
-    "buffer = bytes(np.random.normal(0, 1, np.prod(shape)) * 8)\n",
+    "rng = np.random.default_rng()\n",
+    "buffer = bytes(rng.normal(size=np.prod(shape)) * 8)\n",
     "b2ndarray = blosc2.frombuffer(buffer, shape, dtype=dtype)\n",
     "print(\"Compression ratio:\", b2ndarray.schunk.cratio)\n",
     "b2ndarray[:5, :5, :5]"


### PR DESCRIPTION
NPY002 Replace legacy `np.random.normal` call with `np.random.Generator`

Fixes #241.