### PR TITLE
Fetch content

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-      with:
-        submodules: 'recursive'
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/cibuildwheels.yml
+++ b/.github/workflows/cibuildwheels.yml
@@ -47,7 +47,6 @@ jobs:
           # Fetch all history for all branches and tags
           # (important for guessing the correct version with setuptools_scm)
           fetch-depth: 0
-          submodules: 'recursive'
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -95,7 +94,6 @@ jobs:
           # Fetch all history for all branches and tags
           # (important for guessing the correct version with setuptools_scm)
           fetch-depth: 0
-          submodules: 'recursive'
 
       - uses: actions/setup-python@v5
         name: Setup Python ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,12 +20,14 @@ parts/
 sdist/
 var/
 wheels/
+wheelhouse/
 pip-wheel-metadata/
 share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
 MANIFEST
+src/blosc2/_version.py
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "blosc2/c-blosc2"]
-	path = c-blosc2
-	url = https://github.com/Blosc/c-blosc2.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,14 @@ else()
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
     # we want the binaries of the C-Blosc2 library to go into the wheels
     set(BLOSC_INSTALL ON)
-    add_subdirectory(${PROJECT_SOURCE_DIR}/c-blosc2)
-    include_directories("${PROJECT_SOURCE_DIR}/c-blosc2/include")
+    include(FetchContent)
+    FetchContent_Declare(blosc2
+        GIT_REPOSITORY https://github.com/Blosc/c-blosc2
+        GIT_TAG b179abf1132dfa5a263b2ebceb6ef7a3c2890c64
+    )
+    FetchContent_MakeAvailable(blosc2)
+    FetchContent_GetProperties(blosc2)
+    include_directories("${blosc2_SOURCE_DIR}/include")
     target_link_libraries(blosc2_ext PRIVATE blosc2_static)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,6 @@ else()
         GIT_TAG b179abf1132dfa5a263b2ebceb6ef7a3c2890c64
     )
     FetchContent_MakeAvailable(blosc2)
-    FetchContent_GetProperties(blosc2)
     include_directories("${blosc2_SOURCE_DIR}/include")
     target_link_libraries(blosc2_ext PRIVATE blosc2_static)
 endif()

--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ Building from sources
 
 .. code-block:: console
 
-    git clone --recursive https://github.com/Blosc/python-blosc2/
+    git clone https://github.com/Blosc/python-blosc2/
     cd python-blosc2
     pip install .   # add -e for editable mode
 

--- a/RELEASING.rst
+++ b/RELEASING.rst
@@ -8,15 +8,15 @@ Preliminaries
   to figure it out based on git tags:
   https://scikit-build-core.readthedocs.io/en/latest/configuration.html#dynamic-metadata
 
-* Make sure that the c-blosc2 submodule is updated to the latest version (or a specific
-  version that will be documented in the ``RELEASE_NOTES.md``)::
+* Make sure that the c-blosc2 repository is updated to the latest version (or a specific
+  version that will be documented in the ``RELEASE_NOTES.md``). In `CMakeLists.txt` edit::
 
-    cd c-blosc2
-    git pull
-    git checkout <desired tag>
-    cd ../..
-    git commit -m "Update C-Blosc2 sources to <desired tag>" c-blosc2
-    git push
+    FetchContent_Declare(blosc2
+        GIT_REPOSITORY https://github.com/Blosc/c-blosc2
+        GIT_TAG b179abf1132dfa5a263b2ebceb6ef7a3c2890c64
+    )
+
+  to point to the desired commit/tag in the c-blosc2 repo.
 
 * Make sure that the current main branch is passing the tests in continuous integration.
 

--- a/doc/getting_started/installation.rst
+++ b/doc/getting_started/installation.rst
@@ -15,7 +15,7 @@ Source code
 
 .. code-block:: console
 
-    git clone --recursive https://github.com/Blosc/python-blosc2/
+    git clone https://github.com/Blosc/python-blosc2/
     cd python-blosc2
     pip install -e .[test]
 


### PR DESCRIPTION
Do not use c-blosc2 as a submodule anymore and use the `FetchContent` feature of CMake instead.  Suggested by @LecrisUT .