### PR TITLE
Add type annotations

### DIFF
--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -2486,7 +2486,6 @@ cdef class NDArray:
             new_shape_[i] = s
         _check_rc(b2nd_resize(self.array, new_shape_, NULL),
                   "Error while resizing the array")
-        return self
 
     def squeeze(self):
         _check_rc(b2nd_squeeze(self.array), "Error while performing the squeeze")

--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -647,7 +647,7 @@ def set_nthreads(nthreads):
         return rc
 
 def set_blocksize(size_t blocksize=0):
-    return blosc1_set_blocksize(blocksize)
+    blosc1_set_blocksize(blocksize)
 
 def clib_info(codec):
     cdef char* clib

--- a/src/blosc2/c2array.py
+++ b/src/blosc2/c2array.py
@@ -34,7 +34,7 @@ def c2context(
     username: (str | None) = None,
     password: (str | None) = None,
     auth_token: (str | None) = None,
-):
+) -> None:
     """
     Context manager that sets parameters in Caterva2 subscriber requests.
 
@@ -180,7 +180,7 @@ def slice_to_string(slice_):
 
 
 class C2Array(blosc2.Operand):
-    def __init__(self, path, /, urlbase=None, auth_token=None):
+    def __init__(self, path: str, /, urlbase: str = None, auth_token: str = None):
         """Create an instance of a remote NDArray.
 
         Parameters
@@ -239,7 +239,7 @@ class C2Array(blosc2.Operand):
         slice_ = slice_to_string(slice_)
         return fetch_data(self.path, self.urlbase, {"slice_": slice_}, auth_token=self.auth_token)
 
-    def get_chunk(self, nchunk: int):
+    def get_chunk(self, nchunk: int) -> bytes:
         """
         Get the compressed unidimensional chunk of a :ref:`C2Array`.
 
@@ -259,28 +259,28 @@ class C2Array(blosc2.Operand):
         return response.content
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int]:
         """The shape of the remote array"""
         return tuple(self.meta["shape"])
 
     @property
-    def chunks(self):
+    def chunks(self) -> tuple[int]:
         """The chunks of the remote array"""
         return tuple(self.meta["chunks"])
 
     @property
-    def blocks(self):
+    def blocks(self) -> tuple[int]:
         """The blocks of the remote array"""
         return tuple(self.meta["blocks"])
 
     @property
-    def dtype(self):
+    def dtype(self) -> np.dtype:
         """The dtype of the remote array"""
         return np.dtype(self.meta["dtype"])
 
 
 class URLPath:
-    def __init__(self, path, /, urlbase=None, auth_token=None):
+    def __init__(self, path: str, /, urlbase: str = None, auth_token: str = None):
         """
         Create an instance of a remote data file (aka :ref:`C2Array <C2Array>`) urlpath.
         This is meant to be used in the :func:`blosc2.open` function.

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -13,7 +13,7 @@ import os
 import pathlib
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from enum import Enum
 from pathlib import Path
 from queue import Empty, Queue
@@ -61,7 +61,7 @@ class LazyArrayEnum(Enum):
 
 class LazyArray(ABC):
     @abstractmethod
-    def eval(self, item, **kwargs):
+    def eval(self, item: slice | list[slice] = None, **kwargs: dict) -> blosc2.NDArray:
         """
         Return a :ref:`NDArray` containing the evaluation of the :ref:`LazyArray`.
 
@@ -90,7 +90,7 @@ class LazyArray(ABC):
         pass
 
     @abstractmethod
-    def __getitem__(self, item):
+    def __getitem__(self, item: int | slice | Sequence[slice]) -> blosc2.NDArray:
         """
         Return a NumPy.ndarray containing the evaluation of the :ref:`LazyArray`.
 
@@ -107,7 +107,7 @@ class LazyArray(ABC):
         pass
 
     @abstractmethod
-    def save(self, **kwargs):
+    def save(self, **kwargs: dict) -> None:
         """
         Save the :ref:`LazyArray` on disk.
 
@@ -133,7 +133,7 @@ class LazyArray(ABC):
 
     @property
     @abstractmethod
-    def dtype(self):
+    def dtype(self) -> np.dtype:
         """
         Get the data type of the :ref:`LazyArray`.
 
@@ -146,7 +146,7 @@ class LazyArray(ABC):
 
     @property
     @abstractmethod
-    def shape(self):
+    def shape(self) -> tuple[int]:
         """
         Get the shape of the :ref:`LazyArray`.
 
@@ -159,7 +159,7 @@ class LazyArray(ABC):
 
     @property
     @abstractmethod
-    def info(self):
+    def info(self) -> InfoReporter:
         """
         Get information about the :ref:`LazyArray`.
 
@@ -1873,7 +1873,8 @@ def _open_lazyarray(array):
     return expr
 
 
-def lazyudf(func, inputs, dtype, chunked_eval=True, **kwargs):
+def lazyudf(func: Callable[[tuple, np.ndarray, tuple[int]], None], inputs: tuple | list,
+            dtype: np.dtype, chunked_eval: bool = True, **kwargs: dict) -> LazyUDF:
     """
     Get a LazyUDF from a python user-defined function.
 
@@ -1908,7 +1909,8 @@ def lazyudf(func, inputs, dtype, chunked_eval=True, **kwargs):
     return LazyUDF(func, inputs, dtype, chunked_eval, **kwargs)
 
 
-def lazyexpr(expression, operands=None, out=None, where=None):
+def lazyexpr(expression: str | bytes | LazyExpr, operands: dict = None,
+             out: blosc2.NDArray | np.ndarray = None, where: tuple | list = None) -> LazyExpr:
     """
     Get a LazyExpr from an expression.
 

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -5,6 +5,9 @@
 # This source code is licensed under a BSD-style license (found in the
 # LICENSE file in the root directory of this source tree)
 #######################################################################
+# Avoid checking the name of type annotations at run time
+from __future__ import annotations
+
 import asyncio
 import concurrent.futures
 import copy
@@ -13,10 +16,14 @@ import os
 import pathlib
 import threading
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Sequence
 from enum import Enum
 from pathlib import Path
 from queue import Empty, Queue
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
 
 import ndindex
 import numexpr as ne
@@ -541,7 +548,7 @@ def fill_chunk_operands(
 
 
 def fast_eval(
-    expression: str | Callable, operands: dict, getitem: bool, **kwargs
+    expression: str | Callable[[tuple, np.ndarray, tuple[int]], None], operands: dict, getitem: bool, **kwargs
 ) -> blosc2.NDArray | np.ndarray:
     """Evaluate the expression in chunks of operands using a fast path.
 
@@ -652,7 +659,7 @@ def fast_eval(
 
 
 def slices_eval(
-    expression: str | Callable, operands: dict, getitem: bool, _slice=None, **kwargs
+    expression: str | Callable[[tuple, np.ndarray, tuple[int]], None], operands: dict, getitem: bool, _slice=None, **kwargs
 ) -> blosc2.NDArray | np.ndarray:
     """Evaluate the expression in chunks of operands.
 
@@ -827,7 +834,7 @@ def slices_eval(
 
 
 def reduce_slices(
-    expression: str | Callable, operands: dict, reduce_args, _slice=None, **kwargs
+    expression: str | Callable[[tuple, np.ndarray, tuple[int]], None], operands: dict, reduce_args, _slice=None, **kwargs
 ) -> blosc2.NDArray | np.ndarray:
     """Evaluate the expression in chunks of operands.
 
@@ -1062,7 +1069,7 @@ def convert_none_out(dtype, reduce_op, reduced_shape):
     return out
 
 
-def chunked_eval(expression: str | Callable, operands: dict, item=None, **kwargs):
+def chunked_eval(expression: str | Callable[[tuple, np.ndarray, tuple[int]], None], operands: dict, item=None, **kwargs):
     """
     Evaluate the expression in chunks of operands.
 

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -883,12 +883,12 @@ class NDArray(blosc2_ext.NDArray, Operand):
         """
         return self._schunk.blocksize
 
-    def __getitem__(self, key: int | slice | Sequence[slice] | blosc2.LazyExpr) -> np.ndarray | blosc2.LazyExpr:
+    def __getitem__(self, key: int | slice | Sequence[slice] | blosc2.LazyExpr | str) -> np.ndarray | blosc2.LazyExpr:
         """Get a (multidimensional) slice as specified in key.
 
         Parameters
         ----------
-        key: int, slice, sequence of slices or LazyExpr
+        key: int, slice, sequence of slices, LazyExpr or str
             The slice(s) to be retrieved. Note that step parameter is not honored yet
             in slices. If a LazyExpr is provided, the expression is supposed to be of boolean
             type and the result will be the values of this array where the expression is True.
@@ -1144,7 +1144,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         """
         return super().to_cframe()
 
-    def copy(self, dtype: np.dtype = None, **kwargs: dict):
+    def copy(self, dtype: np.dtype = None, **kwargs: dict) -> NDArray:
         """Create a copy of an array with same parameters.
 
         Parameters
@@ -1376,7 +1376,7 @@ def tan(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            Angle, in radians.
+        Angle, in radians.
 
     Returns
     -------
@@ -1411,7 +1411,7 @@ def sqrt(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blos
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1445,7 +1445,7 @@ def sinh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blos
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1513,7 +1513,7 @@ def tanh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blos
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -2001,7 +2001,7 @@ def real(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blos
     Returns
     -------
     out: :ref:`LazyExpr`
-            A lazy expression that can be evaluated.
+        A lazy expression that can be evaluated.
 
     References
     ----------

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -601,74 +601,74 @@ def all(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int |
 class Operand:
     """Base class for all operands in expressions."""
 
-    def __neg__(self):
+    def __neg__(self) -> blosc2.LazyExpr:
         return blosc2.LazyExpr(new_op=(0, "-", self))
 
-    def __and__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __and__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "&", value))
 
-    def __add__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __add__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "+", value))
 
-    def __iadd__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __iadd__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "+", value))
 
-    def __radd__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __radd__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(value, "+", self))
 
-    def __sub__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __sub__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "-", value))
 
-    def __isub__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __isub__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "-", value))
 
-    def __rsub__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __rsub__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(value, "-", self))
 
-    def __mul__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __mul__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "*", value))
 
-    def __imul__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __imul__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "*", value))
 
-    def __rmul__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __rmul__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(value, "*", self))
 
-    def __truediv__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __truediv__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "/", value))
 
-    def __itruediv__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __itruediv__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "/", value))
 
-    def __rtruediv__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __rtruediv__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(value, "/", self))
 
-    def __lt__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __lt__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "<", value))
 
-    def __le__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __le__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "<=", value))
 
-    def __gt__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __gt__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, ">", value))
 
-    def __ge__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __ge__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, ">=", value))
 
@@ -678,19 +678,19 @@ class Operand:
             return self is value
         return blosc2.LazyExpr(new_op=(self, "==", value))
 
-    def __ne__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __ne__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "!=", value))
 
-    def __pow__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __pow__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "**", value))
 
-    def __ipow__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __ipow__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "**", value))
 
-    def __rpow__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /):
+    def __rpow__(self, value: int | float | NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(value, "**", self))
 
@@ -715,7 +715,7 @@ class Operand:
         return expr.var(axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims, **kwargs)
 
     @is_documented_by(prod)
-    def prod(self, axis=None, dtype=None, out=None, keepdims=False, **kwargs):
+    def prod(self, axis=None, dtype=None, keepdims=False, **kwargs):
         expr = blosc2.LazyExpr(new_op=(self, None, None))
         return expr.prod(axis=axis, dtype=dtype, keepdims=keepdims, **kwargs)
 
@@ -754,7 +754,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
                 self._fields[field] = NDField(self, field)
 
     @property
-    def fields(self):
+    def fields(self) -> dict:
         """
         Dictionary with the fields of the structured array.
 
@@ -781,12 +781,12 @@ class NDArray(blosc2_ext.NDArray, Operand):
         return self._fields
 
     @property
-    def keep_last_read(self):
+    def keep_last_read(self) -> bool:
         """Indicates whether the last read data should be kept in memory."""
         return self._keep_last_read
 
     @keep_last_read.setter
-    def keep_last_read(self, value: bool):
+    def keep_last_read(self, value: bool) -> None:
         """Set whether the last read data should be kept in memory.
 
         This always clear the last read data (if any).
@@ -835,7 +835,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         return InfoReporter(self)
 
     @property
-    def info_items(self):
+    def info_items(self) -> list:
         items = []
         items += [("type", f"{self.__class__.__name__}")]
         items += [("shape", self.shape)]
@@ -848,7 +848,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         return items
 
     @property
-    def schunk(self):
+    def schunk(self) -> blosc2.SChunk:
         """
         The :ref:`SChunk <SChunk>` reference of the :ref:`NDArray`.
         All the attributes from the :ref:`SChunk <SChunk>` can be accessed through
@@ -861,7 +861,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         return self._schunk
 
     @property
-    def blocksize(self):
+    def blocksize(self) -> int:
         """The block size (in bytes) for this container.
 
         This is a shortcut to
@@ -1194,7 +1194,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
 
         return super().copy(dtype, **kwargs)
 
-    def resize(self, newshape: tuple | list):
+    def resize(self, newshape: tuple | list) -> None:
         """Change the shape of the array by growing or shrinking one or more dimensions.
 
         Parameters
@@ -1202,6 +1202,10 @@ class NDArray(blosc2_ext.NDArray, Operand):
         newshape : tuple or list
             The new shape of the array. It should have the same dimensions
             as :paramref:`self`.
+
+        Returns
+        -------
+        out: None
 
         Notes
         -----
@@ -1219,12 +1223,12 @@ class NDArray(blosc2_ext.NDArray, Operand):
         >>> b = blosc2.asarray(a)
         >>> newshape = [50, 10]
         >>> # Extend first dimension, shrink second dimension
-        >>> _ = b.resize(newshape)
+        >>> b.resize(newshape)
         >>> b.shape
         (50, 10)
         """
         blosc2_ext.check_access_mode(self.schunk.urlpath, self.schunk.mode)
-        return super().resize(newshape)
+        super().resize(newshape)
 
     def slice(self, key: int | slice | Sequence[slice], **kwargs: dict) -> NDArray:
         """Get a (multidimensional) slice as a new :ref:`NDArray`.
@@ -1280,8 +1284,12 @@ class NDArray(blosc2_ext.NDArray, Operand):
 
         return ndslice
 
-    def squeeze(self):
+    def squeeze(self) -> None:
         """Remove the 1's in array's shape.
+
+        Returns
+        -------
+        out: None
 
         Examples
         --------
@@ -2643,12 +2651,12 @@ class NDField(Operand):
         return f"NDField({self.ndarr}, {self.field})"
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int]:
         """The shape of the associated :ref:`NDArray`."""
         return self.ndarr.shape
 
     @property
-    def schunk(self):
+    def schunk(self) -> blosc2.SChunk:
         """The associated :ref:`SChunk <SChunk>`."""
         return self.ndarr.schunk
 

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -798,7 +798,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         self._keep_last_read = value
 
     @property
-    def info(self):
+    def info(self) -> InfoReporter:
         """
         Print information about this array.
 

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -148,7 +148,9 @@ def _check_allowed_dtypes(
         )
 
 
-def sum(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, keepdims=False, **kwargs):
+def sum(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+        dtype: np.dtype = None, keepdims: bool = False, **kwargs: dict
+        ) -> np.ndarray | NDArray | int | float | complex | bool:
     """
     Return the sum of array elements over a given axis.
 
@@ -199,7 +201,9 @@ def sum(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, keepdi
     return ndarr.sum(axis=axis, dtype=dtype, keepdims=keepdims, **kwargs)
 
 
-def mean(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, keepdims=False, **kwargs):
+def mean(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+         dtype: np.dtype = None, keepdims: bool = False, **kwargs: dict
+         ) -> np.ndarray | NDArray | int | float | complex | bool:
     """
     Return the arithmetic mean along the specified axis.
 
@@ -244,7 +248,9 @@ def mean(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, keepd
     return ndarr.mean(axis=axis, dtype=dtype, keepdims=keepdims, **kwargs)
 
 
-def std(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, ddof=0, keepdims=False, **kwargs):
+def std(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+        dtype: np.dtype = None, ddof: int = 0, keepdims: bool = False, **kwargs: dict
+        ) -> np.ndarray | NDArray | int | float | bool:
     """
     Return the standard deviation along the specified axis.
 
@@ -260,7 +266,7 @@ def std(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, ddof=0
         default is float32; for floating point inputs, it is the same as the input dtype.
     ddof: int, optional
         Means Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
-        where N represents the number of elements. By default ddof is zero.
+        where N represents the number of elements. By default, ddof is zero.
     keepdims: bool, optional
         If this is set to True, the axes which are reduced are left in the result as
         dimensions with size one. With this option, the result will broadcast correctly
@@ -296,7 +302,9 @@ def std(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, ddof=0
     return ndarr.std(axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims, **kwargs)
 
 
-def var(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, ddof=0, keepdims=False, **kwargs):
+def var(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+        dtype: np.dtype = None, ddof: int = 0, keepdims: bool = False, **kwargs: dict
+        ) -> np.ndarray | NDArray | int | float | bool:
     """
     Return the variance along the specified axis.
 
@@ -312,7 +320,7 @@ def var(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, ddof=0
         float32; for floating point inputs, it is the same as the input dtype.
     ddof: int, optional
         Means Delta Degrees of Freedom. The divisor used in calculations is N - ddof,
-        where N represents the number of elements. By default ddof is zero.
+        where N represents the number of elements. By default, ddof is zero.
     keepdims: bool, optional
         If this is set to True, the axes which are reduced are left in the result as
         dimensions with size one. With this option, the result will broadcast correctly
@@ -349,7 +357,9 @@ def var(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, ddof=0
     return ndarr.var(axis=axis, dtype=dtype, ddof=ddof, keepdims=keepdims, **kwargs)
 
 
-def prod(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, keepdims=False, **kwargs):
+def prod(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+        dtype: np.dtype = None, keepdims: bool = False, **kwargs: dict
+         ) -> np.ndarray | NDArray | int | float | complex | bool:
     """
     Return the product of array elements over a given axis.
 
@@ -363,8 +373,9 @@ def prod(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, keepd
         it counts from the last to the first axis.
     dtype: np.dtype, optional
         The type of the returned array and of the accumulator in which the
-        elements are multiplied. The dtype of a is used by default unless a has
-        an integer dtype of less precision than the default platform integer.
+        elements are multiplied. The dtype of :paramref:`ndarr` is used by default unless
+        :paramref:`ndarr` has an integer dtype of less precision than the
+        default platform integer.
     keepdims: bool, optional
         If this is set to True, the axes which are reduced are left in the result
         as dimensions with size one. With this option, the result will broadcast
@@ -400,7 +411,9 @@ def prod(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, dtype=None, keepd
     return ndarr.prod(axis=axis, dtype=dtype, keepdims=keepdims, **kwargs)
 
 
-def min(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **kwargs):
+def min(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+        keepdims: bool = False, **kwargs: dict
+        ) -> np.ndarray | NDArray | int | float | complex | bool:
     """
     Return the minimum along a given axis.
 
@@ -414,6 +427,8 @@ def min(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **
         If this is set to True, the axes which are reduced are left in the result as
         dimensions with size one. With this option, the result will broadcast correctly
         against the input array.
+    kwargs: dict, optional
+        Keyword arguments that are supported by the :func:`empty` constructor.
 
     Returns
     -------
@@ -441,7 +456,9 @@ def min(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **
     return ndarr.min(axis=axis, keepdims=keepdims, **kwargs)
 
 
-def max(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **kwargs):
+def max(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+        keepdims: bool = False, **kwargs: dict
+        ) -> np.ndarray | NDArray | int | float | complex | bool:
     """
     Return the maximum along a given axis.
 
@@ -455,6 +472,8 @@ def max(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **
         If this is set to True, the axes which are reduced are left in the result as
         dimensions with size one. With this option, the result will broadcast correctly
         against the input array.
+    kwargs: dict, optional
+        Keyword arguments that are supported by the :func:`empty` constructor.
 
     Returns
     -------
@@ -488,7 +507,9 @@ def max(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **
     return ndarr.max(axis=axis, keepdims=keepdims, **kwargs)
 
 
-def any(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **kwargs):
+def any(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+        keepdims: bool = False, **kwargs: dict
+        ) -> np.ndarray | NDArray | bool:
     """
     Test whether any array element along a given axis evaluates to True.
 
@@ -502,6 +523,8 @@ def any(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **
         If this is set to True, the axes which are reduced are left in the result as
         dimensions with size one. With this option, the result will broadcast correctly
         against the input array.
+    kwargs: dict, optional
+        Keyword arguments that are supported by the :func:`empty` constructor.
 
     Returns
     -------
@@ -533,7 +556,9 @@ def any(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **
     return ndarr.any(axis=axis, keepdims=keepdims, **kwargs)
 
 
-def all(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **kwargs):
+def all(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, axis: int | tuple[int] = None,
+        keepdims: bool = False, **kwargs: dict
+        ) -> np.ndarray | NDArray | bool:
     """
     Test whether all array elements along a given axis evaluate to True.
 
@@ -547,6 +572,8 @@ def all(ndarr: NDArray | NDField | blosc2.C2Array, axis=None, keepdims=False, **
         If this is set to True, the axes which are reduced are left in the result as
         dimensions with size one. With this option, the result will broadcast correctly
         against the input array.
+    kwargs: dict, optional
+        Keyword arguments that are supported by the :func:`empty` constructor.
 
     Returns
     -------
@@ -856,7 +883,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         """
         return self._schunk.blocksize
 
-    def __getitem__(self, key: int | slice | Sequence[slice] | blosc2.LazyExpr | str) -> np.ndarray:
+    def __getitem__(self, key: int | slice | Sequence[slice] | blosc2.LazyExpr) -> np.ndarray | blosc2.LazyExpr:
         """Get a (multidimensional) slice as specified in key.
 
         Parameters
@@ -930,7 +957,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
 
         return nparr
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: int | slice | Sequence[slice], value: object):
         """Set a slice.
 
         Parameters
@@ -980,18 +1007,18 @@ class NDArray(blosc2_ext.NDArray, Operand):
 
         return super().set_slice(key, value)
 
-    def get_chunk(self, nchunk):
+    def get_chunk(self, nchunk: int) -> bytes:
         """Shortcut to :meth:`SChunk.get_chunk <blosc2.schunk.SChunk.get_chunk>`. This can be accessed
         through the :attr:`schunk` attribute as well.
 
         Parameters
         ----------
-        nchunk : int
-        The index of the chunk to retrieve.
+        nchunk: int
+            The index of the chunk to retrieve.
 
         Returns
         -------
-        chunk : bytes
+        chunk: bytes
             The chunk data at the specified index.
 
         See Also
@@ -1044,7 +1071,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         Examples
         --------
         >>> import blosc2
-        >>> a = blosc2.full(shape=(1000,) * 3, fill_value=9, chunks=(500,) * 3, dtype="f4")
+        >>> a = blosc2.full(shape=(1000, ) * 3, fill_value=9, chunks=(500, ) * 3, dtype="f4")
         >>> for info in a.iterchunks_info():
         ...     print(info.coords)
         (0, 0, 0)
@@ -1068,7 +1095,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
             yield ChunkInfoNDArray(nchunk, coords, cratio, special, repeated_value, lazychunk)
 
 
-    def tobytes(self):
+    def tobytes(self) -> bytes:
         """Returns a buffer with the data contents.
 
         Returns
@@ -1090,7 +1117,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         """
         return super().tobytes()
 
-    def to_cframe(self):
+    def to_cframe(self) -> bytes:
         """Get a bytes object containing the serialized :ref:`NDArray` instance.
 
         Returns
@@ -1117,7 +1144,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         """
         return super().to_cframe()
 
-    def copy(self, dtype=None, **kwargs):
+    def copy(self, dtype: np.dtype = None, **kwargs: dict):
         """Create a copy of an array with same parameters.
 
         Parameters
@@ -1167,7 +1194,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
 
         return super().copy(dtype, **kwargs)
 
-    def resize(self, newshape):
+    def resize(self, newshape: tuple | list):
         """Change the shape of the array by growing or shrinking one or more dimensions.
 
         Parameters
@@ -1199,7 +1226,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         blosc2_ext.check_access_mode(self.schunk.urlpath, self.schunk.mode)
         return super().resize(newshape)
 
-    def slice(self, key, **kwargs):
+    def slice(self, key: int | slice | Sequence[slice], **kwargs: dict) -> NDArray:
         """Get a (multidimensional) slice as a new :ref:`NDArray`.
 
         Parameters
@@ -1272,7 +1299,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         super().squeeze()
 
 
-def sin(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def sin(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Trigonometric sine, element-wise.
 
@@ -1307,7 +1334,7 @@ def sin(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "sin", None))
 
 
-def cos(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def cos(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Trigonometric cosine, element-wise.
 
@@ -1342,7 +1369,7 @@ def cos(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "cos", None))
 
 
-def tan(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def tan(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Trigonometric tangent, element-wise.
 
@@ -1377,7 +1404,7 @@ def tan(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "tan", None))
 
 
-def sqrt(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def sqrt(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Return the non-negative square-root of an array, element-wise.
 
@@ -1411,7 +1438,7 @@ def sqrt(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "sqrt", None))
 
 
-def sinh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def sinh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Hyperbolic sine, element-wise.
 
@@ -1445,14 +1472,14 @@ def sinh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "sinh", None))
 
 
-def cosh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def cosh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Hyperbolic cosine, element-wise.
 
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1479,7 +1506,7 @@ def cosh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "cosh", None))
 
 
-def tanh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def tanh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Hyperbolic tangent, element-wise.
 
@@ -1513,14 +1540,14 @@ def tanh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "tanh", None))
 
 
-def arcsin(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def arcsin(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Inverse sine, element-wise.
 
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1547,14 +1574,14 @@ def arcsin(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "arcsin", None))
 
 
-def arccos(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def arccos(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Trigonometric inverse cosine, element-wise.
 
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1581,14 +1608,14 @@ def arccos(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "arccos", None))
 
 
-def arctan(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def arctan(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Trigonometric inverse tangent, element-wise.
 
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1615,16 +1642,17 @@ def arctan(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "arctan", None))
 
 
-def arctan2(ndarr1: NDArray | NDField, ndarr2: NDArray | NDField | blosc2.C2Array, /):
+def arctan2(ndarr1: NDArray | NDField | blosc2.C2Array,
+            ndarr2: NDArray | NDField | blosc2.C2Array, /) -> blosc2.LazyExpr:
     """
     Element-wise arc tangent of ``ndarr1 / ndarr2`` choosing the quadrant correctly.
 
     Parameters
     ----------
     ndarr1: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array`
-            The input array.
+        The input array.
     ndarr2: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1655,14 +1683,14 @@ def arctan2(ndarr1: NDArray | NDField, ndarr2: NDArray | NDField | blosc2.C2Arra
     return blosc2.LazyExpr(new_op=(ndarr1, "arctan2", ndarr2))
 
 
-def arcsinh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def arcsinh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Inverse hyperbolic sine, element-wise.
 
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1689,7 +1717,7 @@ def arcsinh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "arcsinh", None))
 
 
-def arccosh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def arccosh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Inverse hyperbolic cosine, element-wise.
 
@@ -1723,7 +1751,7 @@ def arccosh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "arccosh", None))
 
 
-def arctanh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def arctanh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Inverse hyperbolic tangent, element-wise.
 
@@ -1757,14 +1785,14 @@ def arctanh(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "arctanh", None))
 
 
-def exp(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def exp(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Calculate the exponential of all elements in the input array.
 
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1791,14 +1819,14 @@ def exp(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "exp", None))
 
 
-def expm1(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def expm1(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Calculate ``exp(ndarr) - 1`` for all elements in the array.
 
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1825,7 +1853,7 @@ def expm1(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "expm1", None))
 
 
-def log(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def log(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Natural logarithm, element-wise.
 
@@ -1859,7 +1887,7 @@ def log(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "log", None))
 
 
-def log10(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def log10(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Return the base 10 logarithm of the input array, element-wise.
 
@@ -1893,7 +1921,7 @@ def log10(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "log10", None))
 
 
-def log1p(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def log1p(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Return the natural logarithm of one plus the input array, element-wise.
 
@@ -1927,7 +1955,7 @@ def log1p(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "log1p", None))
 
 
-def conj(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def conj(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Return the complex conjugate, element-wise.
 
@@ -1961,14 +1989,14 @@ def conj(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "conj", None))
 
 
-def real(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def real(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Return the real part of the complex array, element-wise.
 
     Parameters
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array` or :ref:`LazyExpr`
-            The input array.
+        The input array.
 
     Returns
     -------
@@ -1995,7 +2023,7 @@ def real(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
     return blosc2.LazyExpr(new_op=(ndarr, "real", None))
 
 
-def imag(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def imag(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Return the imaginary part of the complex array, element-wise.
 
@@ -2031,7 +2059,7 @@ def imag(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
 
 def contains(
     ndarr: NDArray | NDField | blosc2.C2Array, value: str | bytes | NDArray | NDField | blosc2.C2Array, /
-):
+) -> blosc2.LazyExpr:
     """
     Check if the array contains a string value.
 
@@ -2039,7 +2067,7 @@ def contains(
     ----------
     ndarr: :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array`
         The input array.
-    value: str or :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array`
+    value: str or bytes or :ref:`NDArray` or :ref:`NDField` or :ref:`C2Array`
         The value to be checked.
 
     Returns
@@ -2064,7 +2092,7 @@ def contains(
     return blosc2.LazyExpr(new_op=(ndarr, "contains", value))
 
 
-def abs(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /):
+def abs(ndarr: NDArray | NDField | blosc2.C2Array | blosc2.LazyExpr, /) -> blosc2.LazyExpr:
     """
     Calculate the absolute value element-wise.
 
@@ -2102,7 +2130,7 @@ def where(
     condition: blosc2.LazyExpr,
     x: NDArray | NDField | np.ndarray | int | float | complex | bool | str | bytes | None = None,
     y: NDArray | NDField | np.ndarray | int | float | complex | bool | str | bytes | None = None,
-):
+) -> blosc2.LazyExpr:
     """
     Return elements chosen from `x` or `y` depending on `condition`.
 
@@ -2110,9 +2138,9 @@ def where(
     ----------
     condition: :ref:`LazyExpr`
         Where True, yield `x`, otherwise yield `y`.
-    x: :ref:`NDArray` or :ref:`NDField` or np.ndarray or scalar
+    x: :ref:`NDArray` or :ref:`NDField` or np.ndarray or scalar or bytes
         Values from which to choose when `condition` is True.
-    y: :ref:`NDArray` or :ref:`NDField` or np.ndarray or scalar
+    y: :ref:`NDArray` or :ref:`NDField` or np.ndarray or scalar or bytes
         Values from which to choose when `condition` is False.
 
     References
@@ -2142,7 +2170,7 @@ def _check_shape(shape):
     return shape
 
 
-def empty(shape, dtype=np.uint8, **kwargs):
+def empty(shape: int | tuple | list, dtype: np.dtype = np.uint8, **kwargs: dict) -> NDArray:
     """Create an empty array.
 
     Parameters
@@ -2195,7 +2223,7 @@ def empty(shape, dtype=np.uint8, **kwargs):
     return blosc2_ext.empty(shape, chunks, blocks, dtype, **kwargs)
 
 
-def uninit(shape, dtype=np.uint8, **kwargs):
+def uninit(shape: int | tuple | list, dtype: np.dtype = np.uint8, **kwargs: dict) -> NDArray:
     """Create an array with uninitialized values.
 
     The parameters and keyword arguments are the same as for the
@@ -2228,7 +2256,7 @@ def uninit(shape, dtype=np.uint8, **kwargs):
     return blosc2_ext.uninit(shape, chunks, blocks, dtype, **kwargs)
 
 
-def nans(shape, dtype=np.float64, **kwargs):
+def nans(shape: int | tuple | list, dtype: np.dtype = np.float64, **kwargs: dict) -> NDArray:
     """Create an array with NaNs values.
 
     The parameters and keyword arguments are the same as for the
@@ -2261,7 +2289,7 @@ def nans(shape, dtype=np.float64, **kwargs):
     return blosc2_ext.nans(shape, chunks, blocks, dtype, **kwargs)
 
 
-def zeros(shape, dtype=np.uint8, **kwargs):
+def zeros(shape: int | tuple | list, dtype: np.dtype = np.uint8, **kwargs: dict) -> NDArray:
     """Create an array, with zero being used as the default value
     for uninitialized portions of the array.
 
@@ -2300,7 +2328,8 @@ def zeros(shape, dtype=np.uint8, **kwargs):
     return blosc2_ext.zeros(shape, chunks, blocks, dtype, **kwargs)
 
 
-def full(shape, fill_value, dtype=None, **kwargs):
+def full(shape: int | tuple | list, fill_value: bytes | int | float | bool, dtype: np.dtype = None,
+         **kwargs: dict) -> NDArray:
     """Create an array, with :paramref:`fill_value` being used as the default value
     for uninitialized portions of the array.
 
@@ -2313,10 +2342,10 @@ def full(shape, fill_value, dtype=None, **kwargs):
         Its size will override the `typesize`
         in the cparams in case they are passed.
     dtype: np.dtype
-         The ndarray dtype in NumPy format. By default, this will
-         be taken from the :paramref:`fill_value`.
-         This will override the `typesize`
-         in the cparams in case they are passed.
+        The ndarray dtype in NumPy format. By default, this will
+        be taken from the :paramref:`fill_value`.
+        This will override the `typesize`
+        in the cparams in case they are passed.
 
     Other Parameters
     ----------------
@@ -2399,7 +2428,7 @@ def frombuffer(
     return blosc2_ext.from_buffer(buffer, shape, chunks, blocks, dtype, **kwargs)
 
 
-def copy(array, dtype=None, **kwargs):
+def copy(array: NDArray, dtype: np.dtype = None, **kwargs: dict) -> NDArray:
     """
     This is equivalent to :meth:`NDArray.copy`
 
@@ -2529,7 +2558,9 @@ def _check_ndarray_kwargs(**kwargs):
         raise ValueError("You cannot pass chunks in cparams, use `blocks` argument instead")
 
 
-def get_slice_nchunks(schunk, key):
+def get_slice_nchunks(schunk: blosc2.SChunk,
+                      key: tuple[(int, int)] | int | slice | Sequence[slice]
+                      ) -> np.ndarray:
     """
     Get the unidimensional chunk indexes needed to get a
     slice of a :ref:`SChunk <SChunk>` or a :ref:`NDArray`.
@@ -2621,7 +2652,7 @@ class NDField(Operand):
         """The associated :ref:`SChunk <SChunk>`."""
         return self.ndarr.schunk
 
-    def __getitem__(self, key: int | slice | Sequence[slice]):
+    def __getitem__(self, key: int | slice | Sequence[slice]) -> np.ndarray:
         """
         Get a slice of :paramref:`self`.
 

--- a/src/blosc2/proxy.py
+++ b/src/blosc2/proxy.py
@@ -8,6 +8,7 @@
 from abc import ABC, abstractmethod
 
 import blosc2
+import numpy as np
 
 
 class ProxySource(ABC):
@@ -24,7 +25,7 @@ class ProxySource(ABC):
     """
 
     @abstractmethod
-    def get_chunk(self, nchunk):
+    def get_chunk(self, nchunk: int) -> bytes:
         """
         Return the compressed chunk in :paramref:`self`.
 
@@ -48,7 +49,7 @@ class Proxy(blosc2.Operand):
     which follows the :ref:`ProxySource` interface in an urlpath.
     """
 
-    def __init__(self, src, urlpath=None, **kwargs):
+    def __init__(self, src: ProxySource, urlpath: str = None, **kwargs: dict):
         """
         Create a new :ref:`Proxy` to serve like a cache to save accessed
         chunks locally.
@@ -56,7 +57,7 @@ class Proxy(blosc2.Operand):
         Parameters
         ----------
         src: :ref:`ProxySource`
-            The original container
+            The original container.
         urlpath: str, optional
             The urlpath where to save the container that will work as a cache.
 
@@ -115,7 +116,7 @@ class Proxy(blosc2.Operand):
             for key in vlmeta:
                 self._schunk_cache.vlmeta[key] = vlmeta[key]
 
-    def fetch(self, item=None):
+    def fetch(self, item: slice | list[slice] = None) -> blosc2.NDArray | blosc2.schunk.SChunk:
         """
         Get the container used as cache with the requested data updated.
 
@@ -146,7 +147,7 @@ class Proxy(blosc2.Operand):
 
         return self._cache
 
-    async def afetch(self, item=None):
+    async def afetch(self, item: slice | list[slice] = None) -> blosc2.NDArray | blosc2.schunk.SChunk:
         """
         Get the container used as cache with the requested data updated
         in an asynchronous way.
@@ -185,7 +186,7 @@ class Proxy(blosc2.Operand):
 
         return self._cache
 
-    def __getitem__(self, item):
+    def __getitem__(self, item: slice | list[slice]) -> np.ndarray:
         """
         Get a slice as a numpy.ndarray using the :ref:`Proxy`.
 
@@ -204,12 +205,12 @@ class Proxy(blosc2.Operand):
         return self._cache[item]
 
     @property
-    def dtype(self):
+    def dtype(self) -> np.dtype:
         """The dtype of :paramref:`self` or None if the data is unidimensional"""
         return self._cache.dtype if isinstance(self._cache, blosc2.NDArray) else None
 
     @property
-    def shape(self):
+    def shape(self) -> tuple[int]:
         """The shape of :paramref:`self`"""
         return self._cache.shape if isinstance(self._cache, blosc2.NDArray) else len(self._cache)
 
@@ -217,7 +218,7 @@ class Proxy(blosc2.Operand):
         return f"Proxy({self.src}, urlpath={self.urlpath})"
 
     @property
-    def vlmeta(self):
+    def vlmeta(self) -> blosc2.schunk.vlmeta:
         """
         Get the vlmeta of the cache.
 
@@ -228,7 +229,7 @@ class Proxy(blosc2.Operand):
         return self._schunk_cache.vlmeta
 
     @property
-    def fields(self):
+    def fields(self) -> dict:
         """
         Dictionary with the fields of :paramref:`self`.
 
@@ -254,7 +255,7 @@ class ProxyNDField(blosc2.Operand):
         self.shape = proxy.shape
         self.dtype = proxy.dtype
 
-    def __getitem__(self, item: slice):
+    def __getitem__(self, item: slice | list[slice]) -> np.ndarray:
         """
         Get a slice as a numpy.ndarray using the `field` in `proxy`.
 


### PR DESCRIPTION
This PR adds type annotations to the documentation. The `schunk.py` module should also be revised.