### PR TITLE
flake8 is not used any more

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 109
-max-complexity = 10
-exclude =
-    dist

--- a/bench/fill_special.py
+++ b/bench/fill_special.py
@@ -30,6 +30,7 @@ def create_schunk(data=None):
     # Create the empty SChunk
     return blosc2.SChunk(data=data, urlpath=urlpath, cparams={"typesize": dtype.itemsize})
 
+
 t0 = time()
 schunk = create_schunk(data=np.full(nelem, np.pi, dtype))
 t = (time() - t0) * 1000.

--- a/bench/io.py
+++ b/bench/io.py
@@ -14,6 +14,7 @@ import numpy as np
 
 CUBE_SIDE = 128
 
+
 class MmapBenchmarking:
     def __init__(self, io_type: str, blosc_mode: str) -> None:
         self.io_type = io_type

--- a/bench/ndarray/eval_expr_numba.py
+++ b/bench/ndarray/eval_expr_numba.py
@@ -48,6 +48,7 @@ b2vardict = {"x": x, "y": y, "z": z, "blosc2": blosc2}
 
 print(f"shape: {x.shape}, chunks: {x.chunks}, blocks: {x.blocks}, cratio: {x.schunk.cratio:.2f}")
 
+
 # Define the functions to evaluate the expressions
 # First the pure numba+numpy version
 @nb.jit(parallel=True, cache=True)

--- a/bench/ndarray/reduce_expr.py
+++ b/bench/ndarray/reduce_expr.py
@@ -62,7 +62,7 @@ for axis in laxis:
     c = eval(b2expr, b2vardict)
     t0 = time()
     d = c.compute()
-    d = d.sum(axis=axis)  #, dtype=npres.dtype)
+    d = d.sum(axis=axis)  # , dtype=npres.dtype)
     print("LazyExpr+eval took %.3f s" % (time() - t0))
     # Check
     np.testing.assert_allclose(d[()], npres, rtol=rtol, atol=atol)
@@ -71,4 +71,3 @@ for axis in laxis:
     # print("LazyExpr+getitem took %.3f s" % (time() - t0))
     # # Check
     # np.testing.assert_allclose(d[:], npres, rtol=rtol, atol=atol)
-


### PR DESCRIPTION
We may need a ruff equivalent to `max-complexity = 10`.