### PR TITLE
Enforce ruff/mccabe rule (C90)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ extend-exclude = ["bench"]
 extend-select = [
     "B",
     "C4",
+    "C90",
     "I",
     "NPY",
     "PT",

--- a/src/blosc2/core.py
+++ b/src/blosc2/core.py
@@ -1279,7 +1279,7 @@ def compute_partition(nitems, maxshape, minpart=None):
     return partition
 
 
-def compute_chunks_blocks(
+def compute_chunks_blocks(  # noqa: C901
     shape: tuple[int] | list,
     chunks: tuple | list | None = None,
     blocks: tuple | list | None = None,

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -372,7 +372,7 @@ def validate_expr(expr: str) -> None:
             raise ValueError(f"Invalid method name: {method}")
 
 
-def validate_inputs(inputs: dict, out=None) -> tuple:
+def validate_inputs(inputs: dict, out=None) -> tuple:  # noqa: C901
     """Validate the inputs for the expression."""
     if len(inputs) == 0:
         raise ValueError(
@@ -553,7 +553,7 @@ def read_nchunk(arrs, info):
 iter_chunks = None
 
 
-def fill_chunk_operands(
+def fill_chunk_operands(  # noqa: C901
     operands, slice_, chunks_, full_chunk, aligned, nchunk, iter_disk, chunk_operands, reduc=False
 ):
     """Retrieve the chunk operands for evaluating an expression.
@@ -639,7 +639,7 @@ def fill_chunk_operands(
             chunk_operands[key] = value[slice_]
 
 
-def fast_eval(
+def fast_eval(  # noqa: C901
     expression: str | Callable[[tuple, np.ndarray, tuple[int]], None],
     operands: dict,
     getitem: bool,
@@ -754,7 +754,7 @@ def fast_eval(
     return out
 
 
-def slices_eval(
+def slices_eval(  # noqa: C901
     expression: str | Callable[[tuple, np.ndarray, tuple[int]], None],
     operands: dict,
     getitem: bool,
@@ -933,7 +933,7 @@ def slices_eval(
     return out
 
 
-def reduce_slices(
+def reduce_slices(  # noqa: C901
     expression: str | Callable[[tuple, np.ndarray, tuple[int]], None],
     operands: dict,
     reduce_args,
@@ -1178,7 +1178,7 @@ def convert_none_out(dtype, reduce_op, reduced_shape):
     return out
 
 
-def chunked_eval(
+def chunked_eval(  # noqa: C901
     expression: str | Callable[[tuple, np.ndarray, tuple[int]], None], operands: dict, item=None, **kwargs
 ):
     """
@@ -1354,7 +1354,7 @@ class LazyExpr(LazyArray):
     Once the lazy expression is created, it can be evaluated via :func:`LazyExpr.eval`.
     """
 
-    def __init__(self, new_op):
+    def __init__(self, new_op):  # noqa: C901
         if new_op is None:
             self.expression = ""
             self.operands = {}
@@ -1438,7 +1438,7 @@ class LazyExpr(LazyArray):
         # out = expr.compute(item=slice_)
         return out.schunk.get_chunk(nchunk)
 
-    def update_expr(self, new_op):
+    def update_expr(self, new_op):  # noqa: C901
         # We use a lot of the original NDArray.__eq__ as 'is', so deactivate the overloaded one
         blosc2._disable_overloaded_equal = True
         # One of the two operands are LazyExpr instances

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -2691,7 +2691,7 @@ def asarray(array: np.ndarray | blosc2.C2Array, **kwargs: dict | list) -> NDArra
     return ndarr
 
 
-def _check_ndarray_kwargs(**kwargs):
+def _check_ndarray_kwargs(**kwargs):  # noqa: C901
     if "storage" in kwargs:
         for key in kwargs:
             if key in list(blosc2.Storage.__annotations__):

--- a/src/blosc2/schunk.py
+++ b/src/blosc2/schunk.py
@@ -140,7 +140,7 @@ class Meta(Mapping):
 
 
 class SChunk(blosc2_ext.SChunk):
-    def __init__(
+    def __init__(  # noqa: C901
         self,
         chunksize: int | None = None,
         data: object = None,

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -315,7 +315,7 @@ def test_functions(function, dtype_fixture, shape_fixture):
         # ("scalar", "scalar") # Not supported by LazyExpr
     ],
 )
-def test_arctan2_pow(urlpath, shape_fixture, dtype_fixture, function, value1, value2):
+def test_arctan2_pow(urlpath, shape_fixture, dtype_fixture, function, value1, value2):  # noqa: C901
     nelems = np.prod(shape_fixture)
     if urlpath is None:
         urlpath1 = urlpath2 = urlpath_save = None

--- a/tests/test_open.py
+++ b/tests/test_open.py
@@ -39,7 +39,7 @@ import blosc2
         (True, "a", "c"),
     ],
 )
-def test_open(contiguous, urlpath, cparams, dparams, nchunks, chunk_nitems, dtype, mode, mmap_mode):
+def test_open(contiguous, urlpath, cparams, dparams, nchunks, chunk_nitems, dtype, mode, mmap_mode):  # noqa: C901
     if os.name == "nt" and mmap_mode == "c":
         pytest.skip("Cannot test mmap_mode 'c' on Windows")
 

--- a/tests/test_prefilters.py
+++ b/tests/test_prefilters.py
@@ -48,7 +48,7 @@ import blosc2
         ),
     ],
 )
-def test_fillers(
+def test_fillers(  # noqa: C901
     contiguous, urlpath, cparams, dparams, nchunks, nelem, func, op_dtype, op2_dtype, schunk_dtype, offset
 ):
     blosc2.remove_urlpath(urlpath)


### PR DESCRIPTION
Fixes #310.

Use the default value of the maximum McCabe complexity: 10

It looks like some functions became too complex after disabling flake8. How to handle that? Modify these functions? Disable `C901` for these functions?