### PR TITLE
Type inference that is closer to NumPy

### DIFF
--- a/examples/ndarray/reduce_and_enlarge.py
+++ b/examples/ndarray/reduce_and_enlarge.py
@@ -14,12 +14,14 @@
 # In particular, note how re-opening a stored expression can adapt to
 # changes in the operands.
 
+import numpy as np
+
 import blosc2
 
 # Create arrays with specific dimensions
 a = blosc2.full((2, 3, 4), 1, urlpath="a.b2nd", mode="w")  # 3D array with dimensions (2, 3, 4)
 b = blosc2.full((2, 4), 2, urlpath="b.b2nd", mode="w")  # 2D array with dimensions (2, 4)
-c = blosc2.full(4, 3, urlpath="c.b2nd", mode="w")  # 1D array with dimensions (4,)
+c = blosc2.full(4, 3, dtype=np.int8, urlpath="c.b2nd", mode="w")  # 1D array with dimensions (4,)
 
 print("Array a:", a[:])
 print("Array b:", b[:])
@@ -28,11 +30,18 @@ print("Array c:", c[:])
 # Define an expression using the arrays above
 # expression = "a.sum() + b * c"
 # expression = "a.sum(axis=1) + b * c"
-expression = "sum(a, axis=1) + b * c"
+# expression = "sum(a, axis=1) + b * c + 0"
+expression = "c + np.int8(0)"
+# expression = "sum(a, axis=1) + b * sin(c)"
 # Define the operands for the expression
-operands = {"a": a, "b": b, "c": c}
+# operands = {"a": a, "b": b, "c": c}
+operands = {"c": c}
 # Create a lazy expression
+print("expression:", expression, type(expression), operands["c"].dtype)
 lazy_expression = blosc2.lazyexpr(expression, operands)
+print(lazy_expression.shape, lazy_expression.dtype)  # Print the shape of the lazy expression
+# lazy_expression = blosc2.lazyexpr(expression)
+print(lazy_expression[:])  # Evaluate and print the result of the lazy expression (should be a 2x4 arr)
 
 # Store and reload the expressions
 url_path = "my_expr.b2nd"  # Define the path for the file
@@ -41,15 +50,5 @@ lazy_expression.save(urlpath=url_path, mode="w")  # Save the lazy expression to 
 url_path = "my_expr.b2nd"  # Define the path for the file
 lazy_expression = blosc2.open(urlpath=url_path)  # Open the saved file
 print(lazy_expression)  # Print the lazy expression
-print(lazy_expression.shape)  # Print the shape of the lazy expression
+print(lazy_expression.shape, lazy_expression.dtype)  # Print the shape of the lazy expression
 print(lazy_expression[:])  # Evaluate and print the result of the lazy expression (should be a 2x4 arr)
-
-# Enlarge the arrays and re-evaluate the expression
-a.resize((3, 3, 4))
-a[2] = 3
-b.resize((3, 4))
-b[2] = 5
-lazy_expression = blosc2.open(urlpath=url_path)  # Open the saved file
-print(lazy_expression.shape)
-result = lazy_expression.compute()
-print(result[:])

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1018,8 +1018,12 @@ def reduce_slices(  # noqa: C901
     reduce_op = reduce_args.pop("op")
     axis = reduce_args["axis"]
     keepdims = reduce_args["keepdims"]
-    dtype = kwargs.pop("dtype", None)
-    # dtype = reduce_args["dtype"] if reduce_op in (ReduceOp.SUM, ReduceOp.PROD) else _dtype
+    # For sum and prod, we can specify the dtype of the output array
+    dtype = reduce_args["dtype"] if reduce_op in (ReduceOp.SUM, ReduceOp.PROD) else None
+    if dtype is None:
+        dtype = kwargs.pop("dtype", None)
+    else:
+        del kwargs["dtype"]
 
     # Compute the shape and chunks of the output array, including broadcasting
     shape = compute_broadcast_shape(operands.values())

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1755,14 +1755,16 @@ class LazyExpr(LazyArray):
     def where(self, value1=None, value2=None):
         if self.dtype != np.bool_:
             raise ValueError("where() can only be used with boolean expressions")
-        dtype = self.dtype
         # This just acts as a 'decorator' for the existing expression
         if value1 is not None and value2 is not None:
             # Guess the outcome dtype for value1 and value2
-            dtype = np.result_type(np.asarray(value1), np.asarray(value2))
+            dtype = np.result_type(value1, value2)
             args = {"_where_x": value1, "_where_y": value2}
         elif value1 is not None:
-            dtype = np.asarray(value1).dtype
+            if hasattr(value1, "dtype"):
+                dtype = value1.dtype
+            else:
+                dtype = np.asarray(value1).dtype
             args = {"_where_x": value1}
         elif value2 is not None:
             raise ValueError("where() requires value1 when using value2")

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -2042,7 +2042,6 @@ class LazyExpr(LazyArray):
 
         # Save the expression and operands in the metadata
         operands = {}
-        print(operands_)
         for key, value in operands_.items():
             if isinstance(value, blosc2.C2Array):
                 operands[key] = {

--- a/src/blosc2/proxy.py
+++ b/src/blosc2/proxy.py
@@ -512,8 +512,8 @@ class ProxyNDField(blosc2.Operand):
     def __init__(self, proxy: Proxy, field: str):
         self.proxy = proxy
         self.field = field
+        self.dtype = proxy.dtype[field]
         self.shape = proxy.shape
-        self.dtype = proxy.dtype
 
     def __getitem__(self, item: slice | list[slice]) -> np.ndarray:
         """

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -981,25 +981,25 @@ def test_get_expr_operands(expression, expected_operands):
     "scalar",
     [
         "np.int8(0)",
-        # "np.uint16(0)",
+        "np.uint16(0)",
     ],
 )
 @pytest.mark.parametrize(
     ("dtype1", "dtype2"),
     [
         (np.int8, np.int8),
-        # (np.int8, np.int16),
-        # (np.int8, np.int32),
-        # (np.int8, np.int64),
-        # (np.int8, np.float32),
-        # (np.int8, np.float64),
-        # (np.uint16, np.uint16),
-        # (np.uint16, np.uint32),
-        # (np.uint16, np.uint64),
-        # (np.uint16, np.float32),
-        # (np.uint16, np.float64),
-        # (np.float32, np.float32),
-        # (np.float32, np.float64),
+        (np.int8, np.int16),
+        (np.int8, np.int32),
+        (np.int8, np.int64),
+        (np.int8, np.float32),
+        (np.int8, np.float64),
+        (np.uint16, np.uint16),
+        (np.uint16, np.uint32),
+        (np.uint16, np.uint64),
+        (np.uint16, np.float32),
+        (np.uint16, np.float64),
+        (np.float32, np.float32),
+        (np.float32, np.float64),
     ],
 )
 def test_dtype_infer(dtype1, dtype2, scalar):

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -589,11 +589,12 @@ def test_save_unsafe():
     assert expr.expression in str(excinfo.value)
 
     # Check that an invalid expression cannot be easily saved.
-    # As this can easily be worked around, the best protection is
+    # Although, as this can easily be worked around, the best protection is
     # during loading time (tested above).
+    expr.expression_tosave = "import os; os.system('touch /tmp/unsafe')"
     with pytest.raises(ValueError) as excinfo:
         expr.save(urlpath=urlpath)
-    assert expr.expression in str(excinfo.value)
+    assert expr.expression_tosave in str(excinfo.value)
 
     for urlpath in disk_arrays:
         blosc2.remove_urlpath(urlpath)

--- a/tests/ndarray/test_lazyexpr_fields.py
+++ b/tests/ndarray/test_lazyexpr_fields.py
@@ -261,42 +261,81 @@ def test_where_reduction(array_fixture):
     np.testing.assert_allclose(res, nres)
 
 
-# This is a more complex case with where() calls combined with reductions,
+# More complex cases with where() calls combined with reductions,
 # broadcasting, reusing the result in another expression and other
-# funny stuff that is not working yet.
-def test_where_fusion(array_fixture):
+# funny stuff
+
+
+# Two where() calls
+def test_where_fusion1(array_fixture):
     sa1, sa2, nsa1, nsa2, a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
     expr = a1**2 + a2**2 > 2 * a1 * a2 + 1
     npexpr = na1**2 + na2**2 > 2 * na1 * na2 + 1
 
-    # Two where() calls
     res = expr.where(0, 1) + expr.where(0, 1)
     nres = np.where(npexpr, 0, 1) + np.where(npexpr, 0, 1)
     np.testing.assert_allclose(res[:], nres)
 
-    # Two where() calls with a reduction (and using broadcasting)
+
+# Two where() calls with a reduction (and using broadcasting)
+def test_where_fusion2(array_fixture):
+    sa1, sa2, nsa1, nsa2, a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    expr = a1**2 + a2**2 > 2 * a1 * a2 + 1
+    npexpr = na1**2 + na2**2 > 2 * na1 * na2 + 1
+
     axis = None if sa1.ndim == 1 else 1
     res = expr.where(0.5, 0.2) + expr.where(0.3, 0.6).sum(axis=axis)
     nres = np.where(npexpr, 0.5, 0.2) + np.where(npexpr, 0.3, 0.6).sum(axis=axis)
     np.testing.assert_allclose(res[:], nres)
 
-    # Reuse the result in another expression
+
+# Reuse the result in another expression
+def test_where_fusion3(array_fixture):
+    sa1, sa2, nsa1, nsa2, a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    expr = a1**2 + a2**2 > 2 * a1 * a2 + 1
+    npexpr = na1**2 + na2**2 > 2 * na1 * na2 + 1
+
+    res = expr.where(0, 1) + expr.where(0, 1)
+    nres = np.where(npexpr, 0, 1) + np.where(npexpr, 0, 1)
     res = expr.where(0, 1) + res.sum()
     nres = np.where(npexpr, 0, 1) + nres.sum()
     np.testing.assert_allclose(res[:], nres)
 
-    # Reuse the result in another expression twice
+
+# Reuse the result in another expression twice
+def test_where_fusion4(array_fixture):
+    sa1, sa2, nsa1, nsa2, a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    expr = a1**2 + a2**2 > 2 * a1 * a2 + 1
+    npexpr = na1**2 + na2**2 > 2 * na1 * na2 + 1
+
+    res = expr.where(0.1, 0.7) + expr.where(0.2, 5)
+    nres = np.where(npexpr, 0.1, 0.7) + np.where(npexpr, 0.2, 5)
     res = 2 * res + 4 * res
     nres = 2 * nres + 4 * nres
     np.testing.assert_allclose(res[:], nres)
 
-    # Reuse the result in another expression twice II
+
+# Reuse the result in another expression twice II
+def test_where_fusion5(array_fixture):
+    sa1, sa2, nsa1, nsa2, a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    expr = a1**2 + a2**2 > 2 * a1 * a2 + 1
+    npexpr = na1**2 + na2**2 > 2 * na1 * na2 + 1
+
+    res = expr.where(-1, 7) + expr.where(2, 5)
+    nres = np.where(npexpr, -1, 7) + np.where(npexpr, 2, 5)
     res = 2 * res + blosc2.sqrt(res)
     nres = 2 * nres + np.sqrt(nres)
     np.testing.assert_allclose(res[:], nres)
 
-    # TODO: this is not working yet
-    # Reuse the result in another expression twice III
-    # res = expr.where(0, 1) + res
-    # nres = np.where(npexpr, 0, 1) + nres
-    # np.testing.assert_allclose(res[:], nres)
+
+# Reuse the result in another expression twice III
+def test_where_fusion6(array_fixture):
+    sa1, sa2, nsa1, nsa2, a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    expr = a1**2 + a2**2 > 2 * a1 * a2 + 1
+    npexpr = na1**2 + na2**2 > 2 * na1 * na2 + 1
+
+    res = expr.where(-1, 1) + expr.where(2, 1)
+    nres = np.where(npexpr, -1, 1) + np.where(npexpr, 2, 1)
+    res = expr.where(6.1, 1) + res
+    nres = np.where(npexpr, 6.1, 1) + nres
+    np.testing.assert_allclose(res[:], nres)

--- a/tests/ndarray/test_lazyexpr_fields.py
+++ b/tests/ndarray/test_lazyexpr_fields.py
@@ -276,8 +276,8 @@ def test_where_fusion(array_fixture):
 
     # Two where() calls with a reduction (and using broadcasting)
     axis = None if sa1.ndim == 1 else 1
-    res = expr.where(0, 1) + expr.where(0, 1).sum(axis=axis)
-    nres = np.where(npexpr, 0, 1) + np.where(npexpr, 0, 1).sum(axis=axis)
+    res = expr.where(0.5, 0.2) + expr.where(0.3, 0.6).sum(axis=axis)
+    nres = np.where(npexpr, 0.5, 0.2) + np.where(npexpr, 0.3, 0.6).sum(axis=axis)
     np.testing.assert_allclose(res[:], nres)
 
     # Reuse the result in another expression
@@ -290,11 +290,10 @@ def test_where_fusion(array_fixture):
     nres = 2 * nres + 4 * nres
     np.testing.assert_allclose(res[:], nres)
 
-    # TODO: this is not working yet
     # Reuse the result in another expression twice II
-    # res = 2 * res + blosc2.sqrt(res)
-    # nres = 2 * nres + nres.sqrt()
-    # np.testing.assert_allclose(res[:], nres)
+    res = 2 * res + blosc2.sqrt(res)
+    nres = 2 * nres + np.sqrt(nres)
+    np.testing.assert_allclose(res[:], nres)
 
     # TODO: this is not working yet
     # Reuse the result in another expression twice III

--- a/tests/ndarray/test_setitem.py
+++ b/tests/ndarray/test_setitem.py
@@ -62,5 +62,6 @@ def test_setitem_different_dtype(shape, slices):
     nparray = np.arange(size, dtype=np.int32).reshape(shape)
     a = blosc2.empty(nparray.shape, dtype=np.float64)
 
-    with pytest.raises(ValueError):
-        a[slices] = nparray
+    a[slices] = nparray[slices]
+    nparray_ = nparray.astype(a.dtype)
+    np.testing.assert_almost_equal(a[slices], nparray_[slices])


### PR DESCRIPTION
This PR enhances the dtype inference so that it mimics now more NumPy than the numexpr one.  Although perfect adherence to NumPy casting conventions is not there yet, it is a big step forward towards better compatibility with NumPy.  In particular, support for e.g. 'a + np.int8(1)'  string expressions allows to serialize them, while keeping NumPy type inference when expression is re-opened from disk.

Most of the `np.int`, `np.float`, `np.str` and `np.bytes` casting funcs for constants are supported.