### PR TITLE
Filter and sort fields

### DIFF
--- a/examples/ndarray/filter_sort_fields.py
+++ b/examples/ndarray/filter_sort_fields.py
@@ -33,27 +33,31 @@ arr = blosc2.asarray(nsa)
 
 t0 = time()
 # Using plain sort in combination with filter
-farr = arr["b >= c"].sort("c").compute()
+# farr = arr["b >= c"].sort("c").compute()
 # You add indices() to get the indices of the sorted array
-# farr = arr["b >= c"].sort("c").indices().compute()
+farr = arr["b >= c"].sort("c").indices().compute()
 # You can also use __getitem__ to get numpy arrays as result
 # farr = arr["b >= c"].sort("c")[:]
 # farr = arr["b >= c"].sort("c").indices()[:]
 print(f"Time to filter: {time() - t0:.3f} s")
 print(f"farr: {farr[:10]}")
 if farr.dtype == np.dtype("int64"):
-    print(f"sorted (numpy):\n {nsa[farr[:10]]}")
-    print(f"sorted (blosc2):\n {arr[farr[:10]]}")  # also works, but more efficient
+    print(f"sorted (blosc2):\n {arr[farr[:10]]}")
 
 print(f"len(farr): {len(farr)}, len(arr): {len(arr)}")
 print(f"type of farr: {farr.dtype}, type of arr: {arr.dtype}")
 
 if isinstance(farr, np.ndarray):
+    print(f"nbytes of farr: {farr.nbytes / 2 ** 20:.2f}MB")
     # We cannot proceed anymore
     sys.exit(1)
 
 print(f"cratio of farr: {farr.schunk.cratio:.2f}, cratio of arr: {arr.schunk.cratio:.2f}")
-print(f"nbytes of farr: {farr.schunk.nbytes}, nbytes of arr: {arr.schunk.nbytes}")
-print(f"cbytes of farr: {farr.schunk.cbytes}, cbytes of arr: {arr.schunk.cbytes}")
+print(
+    f"nbytes of farr: {farr.schunk.nbytes / 2**20:.2f}MB, nbytes of arr: {arr.schunk.nbytes / 2**20:.2f}MB"
+)
+print(
+    f"cbytes of farr: {farr.schunk.cbytes / 2**20:.2f}MB, cbytes of arr: {arr.schunk.cbytes / 2**20:.2f}MB"
+)
 print(f"cparams of farr: {farr.cparams}, cparams of arr: {arr.cparams}")
 print(f"chunks of farr: {farr.chunks}, chunks of arr: {arr.chunks}")

--- a/examples/ndarray/filter_sort_fields.py
+++ b/examples/ndarray/filter_sort_fields.py
@@ -9,13 +9,14 @@
 # Filter and sort fields in a structured array
 # Note that this only works for 1D arrays
 
+import sys
 from time import time
 
 import numpy as np
 
 import blosc2
 
-N = 1_000
+N = 1_000_000
 
 # arr = blosc2.open("/Users/faltet/Downloads/ds-1d-fields.b2nd")
 # Create a numpy structured array with 3 fields and N elements
@@ -31,14 +32,26 @@ nsa["c"][:] = rng.random(N)
 arr = blosc2.asarray(nsa)
 
 t0 = time()
-farr = arr["b >= c"].indices().sort("c").compute()
+# Using plain sort in combination with filter
+farr = arr["b >= c"].sort("c").compute()
+# You add indices() to get the indices of the sorted array
+# farr = arr["b >= c"].sort("c").indices().compute()
+# You can also use __getitem__ to get numpy arrays as result
+# farr = arr["b >= c"].sort("c")[:]
+# farr = arr["b >= c"].sort("c").indices()[:]
 print(f"Time to filter: {time() - t0:.3f} s")
 print(f"farr: {farr[:10]}")
-print(f"sorted (numpy):\n {nsa[farr[:10]]}")
-print(f"sorted (blosc2):\n {arr[farr[:10]]}")  # also works, but more efficient
+if farr.dtype == np.dtype("int64"):
+    print(f"sorted (numpy):\n {nsa[farr[:10]]}")
+    print(f"sorted (blosc2):\n {arr[farr[:10]]}")  # also works, but more efficient
 
 print(f"len(farr): {len(farr)}, len(arr): {len(arr)}")
 print(f"type of farr: {farr.dtype}, type of arr: {arr.dtype}")
+
+if isinstance(farr, np.ndarray):
+    # We cannot proceed anymore
+    sys.exit(1)
+
 print(f"cratio of farr: {farr.schunk.cratio:.2f}, cratio of arr: {arr.schunk.cratio:.2f}")
 print(f"nbytes of farr: {farr.schunk.nbytes}, nbytes of arr: {arr.schunk.nbytes}")
 print(f"cbytes of farr: {farr.schunk.cbytes}, cbytes of arr: {arr.schunk.cbytes}")

--- a/examples/ndarray/filter_sort_fields.py
+++ b/examples/ndarray/filter_sort_fields.py
@@ -1,0 +1,59 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+# Filter and sort fields in a structured array
+
+from time import time
+
+import numpy as np
+
+import blosc2
+
+N = 1_000
+
+# arr = blosc2.open("/Users/faltet/Downloads/ds-1d-fields.b2nd")
+# Create a numpy structured array with 3 fields and N elements
+dt = np.dtype([("a", "i4"), ("b", "f4"), ("c", "f8")])
+nsa = np.empty((N,), dtype=dt)
+# Make this work with a 2D array
+# nsa = np.empty((N,N), dtype=dt)
+nsa["a"][:] = np.arange(N, dtype="i4")
+nsa["b"][:] = np.linspace(0, 1, N, dtype="f4")
+rng = np.random.default_rng(42)  # to get reproducible results
+nsa["c"][:] = rng.random(N)
+
+arr = blosc2.asarray(nsa)
+
+t0 = time()
+farr = (
+    arr["b >= c"]
+    .indices()
+    .sort("c")
+    .compute(
+        cparams={
+            "codec": blosc2.Codec.LZ4,
+            "clevel": 1,
+            # 'use_dict': False,
+            # 'filters': [blosc2.Filter.SHUFFLE],
+            # 'splitmode': blosc2.SplitMode.ALWAYS_SPLIT,
+        }
+    )
+)
+print(f"Time to filter: {time() - t0:.3f} s")
+print(f"farr: {farr[:10]}")
+print(f"sorted: {arr[:][farr[:10]]}")
+# print(f"sorted: {arr[farr[:10]]}")  # TODO
+
+# print(f"len(farr): {len(farr)}, len(arr): {len(arr)}")
+print(f"shape of farr: {farr.shape}, shape of arr: {arr.shape}")
+print(f"type of farr: {farr.dtype}, type of arr: {arr.dtype}")
+print(f"cratio of farr: {farr.schunk.cratio:.2f}, cratio of arr: {arr.schunk.cratio:.2f}")
+print(f"nbytes of farr: {farr.schunk.nbytes}, nbytes of arr: {arr.schunk.nbytes}")
+print(f"cbytes of farr: {farr.schunk.cbytes}, cbytes of arr: {arr.schunk.cbytes}")
+print(f"cparams of farr: {farr.cparams}, cparams of arr: {arr.cparams}")
+print(f"chunks of farr: {farr.chunks}, chunks of arr: {arr.chunks}")

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -904,6 +904,8 @@ def compute_start_index(shape, slice_obj):
     for dim, sl in reversed(list(enumerate(slice_obj))):
         if isinstance(sl, slice):
             start = sl.start if sl.start is not None else 0
+        elif sl is Ellipsis:
+            start = 0
         else:
             start = sl
 
@@ -2170,9 +2172,14 @@ class LazyExpr(LazyArray):
             # We still need to apply the index in result
             x = self._where_args["_where_x"]
             result = x[result]  # always a numpy array; TODO: optimize this for _getitem not in kwargs
-        if "_getitem" not in kwargs and not isinstance(result, blosc2.NDArray):
+        if (
+            "_getitem" not in kwargs
+            and "_output" not in kwargs
+            and "_reduce_args" not in kwargs
+            and not isinstance(result, blosc2.NDArray)
+        ):
             # Get rid of all the extra kwargs that are not accepted by blosc2.asarray
-            kwargs_not_accepted = {"_output", "_where_args", "_indices", "_order", "dtype"}
+            kwargs_not_accepted = {"_where_args", "_indices", "_order", "dtype"}
             kwargs = {key: value for key, value in kwargs.items() if key not in kwargs_not_accepted}
             result = blosc2.asarray(result, **kwargs)
         return result

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -952,6 +952,8 @@ def slices_eval(  # noqa: C901
     chunks = kwargs.get("chunks")
     where: dict | None = kwargs.pop("_where_args", None)
     _indices = kwargs.pop("_indices", False)
+    if _indices and (not where or len(where) != 1):
+        raise NotImplementedError("Indices can only be used with one where condition")
     _order = kwargs.pop("_order", None)
     if _order is not None and not isinstance(_order, list):
         # Always use a list for _order
@@ -2150,10 +2152,14 @@ class LazyExpr(LazyArray):
             return chunked_eval(self.expression, self.operands, item, **kwargs)
 
     def indices(self):
+        if self.dtype != np.void:
+            raise NotImplementedError("indices() can only be used with structured arrays")
         self._indices = True
         return self
 
     def sort(self, order: str | list[str] | None = None) -> blosc2.LazyArray:
+        if self.dtype != np.void:
+            raise NotImplementedError("sort() can only be used with structured arrays")
         self._order = order
         return self
 

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1049,9 +1049,9 @@ def slices_eval(  # noqa: C901
                     # and result is a boolean array
                     x = chunk_operands["_where_x"]
                     if len(x.shape) > 1:
-                        raise ValueError("The indices() and order() are only supported for 1D arrays")
+                        raise ValueError("indices() and sort() only support 1D arrays")
                     if result.dtype != np.bool_:
-                        raise ValueError("The indices() and order() only support bool conditions")
+                        raise ValueError("indices() and sort() only support bool conditions")
                     indices = np.arange(leninputs, leninputs + len_chunk, dtype=np.int64).reshape(
                         slice_shape
                     )

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -2152,13 +2152,13 @@ class LazyExpr(LazyArray):
             return chunked_eval(self.expression, self.operands, item, **kwargs)
 
     def indices(self):
-        if self.dtype != np.void:
+        if self.dtype.fields is None:
             raise NotImplementedError("indices() can only be used with structured arrays")
         self._indices = True
         return self
 
     def sort(self, order: str | list[str] | None = None) -> blosc2.LazyArray:
-        if self.dtype != np.void:
+        if self.dtype.fields is None:
             raise NotImplementedError("sort() can only be used with structured arrays")
         self._order = order
         return self

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1125,9 +1125,9 @@ class NDArray(blosc2_ext.NDArray, Operand):
             elif isinstance(key, NDArray):
                 key = key[:]
             if key.dtype != np.intp:
-                raise ValueError("The key should be an array of integers")
+                raise ValueError("The key should be a list or array of integers")
             if key.ndim != 1:
-                raise ValueError("The key should be a 1D array")
+                raise ValueError("Only keys meant as indices for 1D arrays are supported for now")
             return extract_values(self, key)
         else:
             # The more general case (this is quite slow)

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1119,9 +1119,11 @@ class NDArray(blosc2_ext.NDArray, Operand):
             # This can be processed in a fast way already
             start, stop, step = get_ndarray_start_stop(self.ndim, key, self.shape)
             shape = tuple(sp - st for st, sp in zip(start, stop, strict=True))
-        elif isinstance(key, (list, np.ndarray)):
+        elif isinstance(key, (list, np.ndarray, NDArray)):
             if isinstance(key, list):
                 key = np.array(key, dtype=np.intp)
+            elif isinstance(key, NDArray):
+                key = key[:]
             if key.dtype != np.intp:
                 raise ValueError("The key should be an array of integers")
             if key.ndim != 1:

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1057,3 +1057,23 @@ def test_dtype_infer(dtype1, dtype2, scalar):
     res = expr[()]
     np.testing.assert_allclose(res, nres)
     assert res.dtype == nres.dtype
+
+
+def test_indices():
+    shape = (20,)
+    na = np.arange(shape[0])
+    a = blosc2.asarray(na)
+    expr = a > 1
+    # TODO: Implement the indices method for LazyExpr more generally
+    with pytest.raises(NotImplementedError):
+        expr.indices().compute()
+
+
+def test_sort():
+    shape = (20,)
+    na = np.arange(shape[0])
+    a = blosc2.asarray(na)
+    expr = a > 1
+    # TODO: Implement the sort method for LazyExpr more generally
+    with pytest.raises(NotImplementedError):
+        expr.sort().compute()


### PR DESCRIPTION
This allows performing data filtering, as well as sorting, in structured NDArrays.  For example, given an array `sarr` with fields 'a', 'b' and 'c', the next:

```
farr = sarr["b >= c"].sort("c").indices().compute()
```

puts in `farr` the indices of the rows that fulfills that values in fields in 'b' are larger than values in 'c' (`"b >= c"` above), sorted by column 'c'.

`farr` is in turn an NDArray, so it is compressed; think of it as a compact index for other tasks.
See the new ``examples/ndarray/filter_sort_fields.py`` self-contained script.