### PR TITLE
Deprecated rules have been removed from ruff 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,15 +113,12 @@ extend-select = [
 ]
 ignore = [
     "B028",
-    "PT004",  # deprecated
-    "PT005",  # deprecated
     "PT011",
     "RET505",
     "RET508",
     "RUF005",
     "RUF015",
     "SIM108",
-    "UP027",  # deprecated
     "UP038",  # https://github.com/astral-sh/ruff/issues/7871
 ]
 


### PR DESCRIPTION
> ### [Removal of six deprecated rules](https://astral.sh/blog/ruff-v0.8.0#removal-of-six-deprecated-rules)
> 
> Six rules have been removed in this release. We realized that the changes they were asking users to make to their code were either unnecessary or outright undesirable:
> * [`missing-type-self`](https://docs.astral.sh/ruff/rules/missing-type-self/) (`ANN101`) and [`missing-type-cls`](https://docs.astral.sh/ruff/rules/missing-type-cls/) (`ANN102`) have both been removed from our [`flake8-annotations`](https://docs.astral.sh/ruff/rules/#flake8-annotations-ann) category. Both have been deprecated since [Ruff 0.2.0](https://astral.sh/blog/ruff-v0.2.0).
> * [`pytest-missing-fixture-name-underscore`](https://docs.astral.sh/ruff/rules/pytest-missing-fixture-name-underscore/) (PT004) and [pytest-incorrect-fixture-name-underscore](https://docs.astral.sh/ruff/rules/pytest-incorrect-fixture-name-underscore/) (`PT005`) have both been removed from our [`flake8-pytest-style`](https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt) category. Both have been deprecated since [Ruff 0.6.0](https://astral.sh/blog/ruff-v0.6.0).
> * [`unpacked-list-comprehension`](https://docs.astral.sh/ruff/rules/unpacked-list-comprehension/) (`UP027`) has been removed from our [`pyupgrade`](https://docs.astral.sh/ruff/rules/#pyupgrade-up) category. It's been deprecated since [Ruff 0.6.0](https://astral.sh/blog/ruff-v0.6.0)
> * [`E999`](https://docs.astral.sh/ruff/rules/syntax-error/), deprecated in [Ruff 0.5.0](https://astral.sh/blog/ruff-v0.5.0#changes-to-e999-and-reporting-of-syntax-errors), has been removed as an error code. Syntax errors are now always reported and cannot be suppressed.