### PR TITLE
blosc2.evaluate()

### DIFF
--- a/doc/reference/index.rst
+++ b/doc/reference/index.rst
@@ -8,5 +8,5 @@ API Reference
     save_load
     storage
     array_operations
-    decorators
+    utilities
     low_level

--- a/doc/reference/lazyarray.rst
+++ b/doc/reference/lazyarray.rst
@@ -48,19 +48,8 @@ This object follows the `LazyArray`_ API for computation and storage.
 
     lazyexpr
 
+
 .. _LazyUDF:
-
-Utilities
-~~~~~~~~~
-
-A series of utilities are provided to work with LazyExpr objects.
-
-.. autosummary::
-    :toctree: autofiles/lazyarray
-    :nosignatures:
-
-    validate_expr
-    get_expr_operands
 
 LazyUDF
 -------
@@ -74,3 +63,17 @@ This object follows the `LazyArray`_ API for computation, although storage is no
     :nosignatures:
 
     lazyudf
+
+
+Utilities
+---------
+
+A series of utilities are provided to work with LazyExpr objects.
+
+.. autosummary::
+    :toctree: autofiles/lazyarray
+    :nosignatures:
+
+    evaluate
+    get_expr_operands
+    validate_expr

--- a/doc/reference/lazyarray.rst
+++ b/doc/reference/lazyarray.rst
@@ -63,17 +63,3 @@ This object follows the `LazyArray`_ API for computation, although storage is no
     :nosignatures:
 
     lazyudf
-
-
-Utilities
----------
-
-A series of utilities are provided to work with LazyExpr objects.
-
-.. autosummary::
-    :toctree: autofiles/lazyarray
-    :nosignatures:
-
-    evaluate
-    get_expr_operands
-    validate_expr

--- a/doc/reference/low_level.rst
+++ b/doc/reference/low_level.rst
@@ -1,5 +1,7 @@
-Low level API
-=============
+Compression Utilities
+=====================
+
+Although using NDArray/SChunk objects is the recommended way to work with Blosc2 data, there are some utilities that allow you to work with Blosc2 data in a more low-level way.  This is useful when you need to work with data that is not stored in NDArray/SChunk objects, or when you need to work with data that is stored in a different format.
 
 This API is meant to be compatible with the existing python-blosc API. There could be some parameters that are called differently, but other than that, they are largely compatible.  In addition, there are some new functions that are not present in the original python-blosc API that are mainly meant to overcome the 2 GB limit that the original API had.
 

--- a/doc/reference/utilities.rst
+++ b/doc/reference/utilities.rst
@@ -1,0 +1,24 @@
+Expression Utilities
+====================
+
+A series of utilities are provided to work with expressions in a more convenient way.
+
+Functions
+---------
+
+.. autosummary::
+   :toctree: autofiles/utilities
+   :nosignatures:
+
+    blosc2.evaluate
+    blosc2.get_expr_operands
+    blosc2.validate_expr
+
+Decorators
+----------
+
+.. autosummary::
+   :toctree: autofiles/utilities
+   :nosignatures:
+
+    blosc2.jit

--- a/src/blosc2/__init__.py
+++ b/src/blosc2/__init__.py
@@ -247,6 +247,7 @@ from .lazyexpr import (
     _open_lazyarray,
     get_expr_operands,
     validate_expr,
+    evaluate,
 )
 from .proxy import Proxy, ProxySource, ProxyNDSource, ProxyNDField, SimpleProxy, jit
 

--- a/src/blosc2/core.py
+++ b/src/blosc2/core.py
@@ -120,6 +120,10 @@ def compress(
     instead of the python-blosc API variables like `blosc.SHUFFLE` for :paramref:`filter`
     or strings like "blosclz" for :paramref:`codec`.
 
+    This function only can deal with data < 2 GB.  If you want to compress
+    larger buffers, you should use the :class:`~blosc2.SChunk` class or, if you want to save
+    large arrays/tensors, the :func:`~blosc2.pack_tensor` function can be handier.
+
     Examples
     --------
     >>> import array, sys
@@ -128,6 +132,12 @@ def compress(
     >>> c_bytesobj = blosc2.compress(a_bytesobj, typesize=4)
     >>> len(c_bytesobj) < len(a_bytesobj)
     True
+
+    See also
+    --------
+    :func:`~blosc2.decompress`
+    :func:`~blosc2.pack_tensor`
+    :class:`~blosc2.SChunk`
     """
     len_src = len(src)
     if hasattr(src, "itemsize"):
@@ -633,7 +643,6 @@ def pack_tensor(
 
     Notes
     -----
-
     In case you pass a TensorFlow/PyTorch tensor, the tensor will be converted to a NumPy array
     before being packed. The tensor will be restored to its original form when unpacked.
 
@@ -1486,6 +1495,27 @@ def compress2(src: object, **kwargs: dict) -> str | bytes:
         If the data cannot be compressed into `dst`.
         If an internal error occurs, likely due to an
         invalid parameter.
+
+    Notes
+    -----
+    This function only can deal with data < 2 GB.  If you want to compress
+    larger buffers, you should use the :class:`~blosc2.SChunk` class or, if you want to save
+    large arrays/tensors, the :func:`~blosc2.pack_tensor` function can be handier.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> data = np.arange(1e6, dtype=np.float32)
+    >>> cparams = blosc2.CParams()
+    >>> compressed_data = blosc2.compress2(data, cparams=cparams)
+    >>> print(f"Compressed data length: {len(compressed_data)} bytes")
+    Compressed data length: 14129 bytes
+
+    See also
+    --------
+    :func:`~blosc2.decompress2`
+    :func:`~blosc2.pack_tensor`
+    :class:`~blosc2.SChunk`
     """
     if kwargs is not None and "cparams" in kwargs:
         if len(kwargs) > 1:

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -2984,6 +2984,56 @@ def _open_lazyarray(array):
     return new_expr
 
 
+# Mimim numexpr's evaluate function
+def evaluate(ex, local_dict=None, global_dict=None):
+    """
+    Evaluate a string expression using the Blosc2 compute engine.
+
+    This is a drop-in replacement for numexpr.evaluate, but using the Blosc2
+    compute engine.  This allows for:
+
+    1) Use more functionality (e.g. reductions) than numexpr.
+    2) Use both NumPy arrays and Blosc2 NDArrays in the same expression.
+
+    As NDArrays can be on-disk, the expression can be evaluated without loading
+    the whole array into memory (i.e. using an out-of-core approach).
+
+    Parameters
+    ----------
+    ex: str
+        The expression to evaluate.
+    local_dict: dict, optional
+        The local dictionary to use when looking for operands in the expression.
+        If not provided, the local dictionary of the caller will be used.
+    global_dict: dict, optional
+        The global dictionary to use when looking for operands in the expression.
+        If not provided, the global dictionary of the caller will be used.
+
+    Returns
+    -------
+    out: NumPy array
+        A NumPy array is returned.
+
+    Examples
+    --------
+    >>> import blosc2
+    >>> import numpy as np
+    >>> dtype = np.float64
+    >>> shape = [3, 3]
+    >>> size = shape[0] * shape[1]
+    >>> a = np.linspace(0, 5, num=size, dtype=dtype).reshape(shape)
+    >>> b = blosc2.linspace(0, 5, num=size, dtype=dtype, shape=shape)
+    >>> expr = 'a * b + 2'
+    >>> out = blosc2.evaluate(expr)
+    >>> out
+    [[ 2.        2.390625  3.5625  ]
+    [ 5.515625  8.25     11.765625]
+    [16.0625   21.140625 27.      ]]
+    """
+    lexpr = lazyexpr(ex, local_dict=local_dict, global_dict=global_dict)
+    return lexpr[:]
+
+
 if __name__ == "__main__":
     from time import time
 

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -897,7 +897,9 @@ def fast_eval(  # noqa: C901
         The output array.
     """
     out = kwargs.pop("_output", None)
-    optimization = kwargs.pop("_optimization", "aggressive")
+    ne_args: dict = kwargs.pop("_ne_args", {})
+    if ne_args is None:
+        ne_args = {}
     dtype = kwargs.pop("dtype", None)
     where: dict | None = kwargs.pop("_where_args", None)
     if isinstance(out, blosc2.NDArray):
@@ -963,12 +965,12 @@ def fast_eval(  # noqa: C901
             expression(tuple(chunk_operands.values()), result, offset=offset)
         else:
             if where is None:
-                result = ne.evaluate(expression, chunk_operands, optimization=optimization)
+                result = ne.evaluate(expression, chunk_operands, **ne_args)
             else:
                 # Apply the where condition (in result)
                 if len(where) == 2:
                     new_expr = f"where({expression}, _where_x, _where_y)"
-                    result = ne.evaluate(new_expr, chunk_operands, optimization=optimization)
+                    result = ne.evaluate(new_expr, chunk_operands, **ne_args)
                 else:
                     # We do not support one or zero operands in the fast path yet
                     raise ValueError("Fast path: the where condition must be a tuple with two elements")
@@ -1069,7 +1071,9 @@ def slices_eval(  # noqa: C901
         The output array.
     """
     out: blosc2.NDArray | None = kwargs.pop("_output", None)
-    optimization = kwargs.pop("_optimization", "aggressive")
+    ne_args: dict = kwargs.pop("_ne_args", {})
+    if ne_args is None:
+        ne_args = {}
     chunks = kwargs.get("chunks")
     where: dict | None = kwargs.pop("_where_args", None)
     _indices = kwargs.pop("_indices", False)
@@ -1188,7 +1192,7 @@ def slices_eval(  # noqa: C901
             continue
 
         if where is None:
-            result = ne.evaluate(expression, chunk_operands, optimization=optimization)
+            result = ne.evaluate(expression, chunk_operands, **ne_args)
         else:
             # Apply the where condition (in result)
             if len(where) == 2:
@@ -1197,9 +1201,9 @@ def slices_eval(  # noqa: C901
                 # result = np.where(result, x, y)
                 # numexpr is a bit faster than np.where, and we can fuse operations in this case
                 new_expr = f"where({expression}, _where_x, _where_y)"
-                result = ne.evaluate(new_expr, chunk_operands, optimization=optimization)
+                result = ne.evaluate(new_expr, chunk_operands, **ne_args)
             elif len(where) == 1:
-                result = ne.evaluate(expression, chunk_operands, optimization=optimization)
+                result = ne.evaluate(expression, chunk_operands, **ne_args)
                 if _indices or _order:
                     # Return indices only makes sense when the where condition is a tuple with one element
                     # and result is a boolean array
@@ -1334,7 +1338,9 @@ def reduce_slices(  # noqa: C901
         The resulting output array.
     """
     out = kwargs.pop("_output", None)
-    optimization = kwargs.pop("_optimization", "aggressive")
+    ne_args: dict = kwargs.pop("_ne_args", {})
+    if ne_args is None:
+        ne_args = {}
     where: dict | None = kwargs.pop("_where_args", None)
     reduce_op = reduce_args.pop("op")
     axis = reduce_args["axis"]
@@ -1471,14 +1477,14 @@ def reduce_slices(  # noqa: C901
                 # We don't have an actual expression, so avoid a copy
                 result = chunk_operands["o0"]
             else:
-                result = ne.evaluate(expression, chunk_operands, optimization=optimization)
+                result = ne.evaluate(expression, chunk_operands, **ne_args)
         else:
             # Apply the where condition (in result)
             if len(where) == 2:
                 new_expr = f"where({expression}, _where_x, _where_y)"
-                result = ne.evaluate(new_expr, chunk_operands, optimization=optimization)
+                result = ne.evaluate(new_expr, chunk_operands, **ne_args)
             elif len(where) == 1:
-                result = ne.evaluate(expression, chunk_operands, optimization=optimization)
+                result = ne.evaluate(expression, chunk_operands, **ne_args)
                 x = chunk_operands["_where_x"]
                 result = x[result]
             else:
@@ -1582,8 +1588,8 @@ def chunked_eval(  # noqa: C901
             Default is False.
         _output: NDArray or np.ndarray, optional
             The output array to store the result.
-        _optimization: str, optional
-            The optimization level to use.  Default is 'aggressive'.
+        _ne_args: dict, optional
+            Additional arguments to be passed to `numexpr.evaluate()` function.
         _where_args: dict, optional
             Additional arguments for conditional evaluation.
     """
@@ -2407,10 +2413,12 @@ class LazyExpr(LazyArray):
         # When NumPy ufuncs are called, the user may add an `out` parameter to kwargs
         if "out" in kwargs:
             kwargs["_output"] = kwargs.pop("out")
-        if "optimization" in kwargs:
-            kwargs["_optimization"] = kwargs.pop("optimization")
         if hasattr(self, "_output"):
             kwargs["_output"] = self._output
+        if "ne_args" in kwargs:
+            kwargs["_ne_args"] = kwargs.pop("ne_args")
+        if hasattr(self, "_ne_args"):
+            kwargs["_ne_args"] = self._ne_args
         if hasattr(self, "_where_args"):
             kwargs["_where_args"] = self._where_args
         kwargs["dtype"] = self.dtype
@@ -2430,7 +2438,7 @@ class LazyExpr(LazyArray):
             and not isinstance(result, blosc2.NDArray)
         ):
             # Get rid of all the extra kwargs that are not accepted by blosc2.asarray
-            kwargs_not_accepted = {"_where_args", "_indices", "_order", "dtype"}
+            kwargs_not_accepted = {"_where_args", "_indices", "_order", "_ne_args", "dtype"}
             kwargs = {key: value for key, value in kwargs.items() if key not in kwargs_not_accepted}
             result = blosc2.asarray(result, **kwargs)
         return result
@@ -2548,7 +2556,7 @@ class LazyExpr(LazyArray):
         }
 
     @classmethod
-    def _new_expr(cls, expression, operands, guess, out=None, where=None, optimization="aggressive"):
+    def _new_expr(cls, expression, operands, guess, out=None, where=None, ne_args=None):
         # Validate the expression
         validate_expr(expression)
         if guess:
@@ -2588,7 +2596,7 @@ class LazyExpr(LazyArray):
             new_expr._output = out
         if where is not None:
             new_expr._where_args = where
-        new_expr._optimization = optimization
+        new_expr._ne_args = ne_args
         return new_expr
 
 
@@ -2875,7 +2883,7 @@ def lazyexpr(
     where: tuple | list | None = None,
     local_dict: dict | None = None,
     global_dict: dict | None = None,
-    optimization: str = "aggressive",
+    ne_args: dict | None = None,
     _frame_depth: int = 2,
 ) -> LazyExpr:
     """
@@ -2902,10 +2910,8 @@ def lazyexpr(
     global_dict: dict, optional
         The global dictionary to use when looking for operands in the expression.
         If not provided, the global dictionary of the caller will be used.
-    optimization: str, optional
-        The optimization level to use when evaluating the expression. Possible
-        values are "aggressive" and "moderate".  The default value is "aggressive".
-        This parameter has the same meaning as in `numexpr.evaluate()`.
+    ne_args: dict, optional
+        Additional arguments to be passed to `numexpr.evaluate()` function.
     _frame_depth: int, optional
         The depth of the frame to use when looking for operands in the expression.
         The default value is 2.
@@ -2946,16 +2952,14 @@ def lazyexpr(
             expression.operands.update(operands)
         if out is not None:
             expression._output = out
-        expression._optimization = optimization
+        expression._ne_args = ne_args
         if where is not None:
             where_args = {"_where_x": where[0], "_where_y": where[1]}
             expression._where_args = where_args
         return expression
     elif isinstance(expression, blosc2.NDArray):
         operands = {"o0": expression}
-        return LazyExpr._new_expr(
-            "o0", operands, guess=False, out=out, where=where, optimization=optimization
-        )
+        return LazyExpr._new_expr("o0", operands, guess=False, out=out, where=where, ne_args=ne_args)
 
     if operands is None:
         # Try to get operands from variables in the stack
@@ -2972,9 +2976,7 @@ def lazyexpr(
             # _new_expr will take care of the constructor, but needs an empty dict in operands
             operands = {}
 
-    return LazyExpr._new_expr(
-        expression, operands, guess=True, out=out, where=where, optimization=optimization
-    )
+    return LazyExpr._new_expr(expression, operands, guess=True, out=out, where=where, ne_args=ne_args)
 
 
 def _open_lazyarray(array):
@@ -3011,11 +3013,13 @@ def _open_lazyarray(array):
 
 
 # Mimim numexpr's evaluate function
-def evaluate(ex: str,
-             local_dict: dict = None,
-             global_dict: dict = None,
-             out: blosc2.NDArray | numpy.ndarray = None,
-             optimization="aggressive"):
+def evaluate(
+    ex: str,
+    local_dict: dict | None = None,
+    global_dict: dict | None = None,
+    out: np.ndarray | blosc2.NDArray = None,
+    ne_args: dict | None = None,
+) -> np.ndarray | blosc2.NDArray:
     """
     Evaluate a string expression using the Blosc2 compute engine.
 
@@ -3040,16 +3044,15 @@ def evaluate(ex: str,
         If not provided, the global dictionary of the caller will be used.
     out: NDArray or NumPy array, optional
         The output array where the result will be stored. If not provided,
-        a new array will be created and returned.
-    optimization: str, optional
-        The optimization level to use when evaluating the expression. Possible
-        values are "aggressive", "moderate" and "none"; the default value is
-        "aggressive".  This parameter is the same as in `numexpr.evaluate()`.
+        a new NumPy array will be created and returned.
+    ne_args: dict, optional
+        Additional arguments to be passed to `numexpr.evaluate()` function.
 
     Returns
     -------
-    out: NumPy array
-        A NumPy array is returned.
+    out: NumPy or NDArray
+        The result of the expression evaluation.  If out is provided, the result
+        will be stored in out and returned at the same time.
 
     Examples
     --------
@@ -3067,9 +3070,14 @@ def evaluate(ex: str,
     [ 5.515625  8.25     11.765625]
     [16.0625   21.140625 27.      ]]
     """
-    lexpr = lazyexpr(ex, local_dict=local_dict, global_dict=global_dict,
-                     out=out, optimization=optimization, _frame_depth=3)
-    return lexpr[:]
+    lexpr = lazyexpr(
+        ex, local_dict=local_dict, global_dict=global_dict, out=out, ne_args=ne_args, _frame_depth=3
+    )
+    if out is not None:
+        # The user specified an output array
+        return lexpr.compute()
+    # The user did not specify an output array, so return a NumPy array
+    return lexpr[()]
 
 
 if __name__ == "__main__":

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -3018,7 +3018,7 @@ def evaluate(
     local_dict: dict | None = None,
     global_dict: dict | None = None,
     out: np.ndarray | blosc2.NDArray = None,
-    kwargs: dict | None = None,
+    **kwargs: Any,
 ) -> np.ndarray | blosc2.NDArray:
     """
     Evaluate a string expression using the Blosc2 compute engine.
@@ -3027,7 +3027,8 @@ def evaluate(
     Blosc2 compute engine.  This allows for:
 
     1) Use more functionality (e.g. reductions) than numexpr.
-    2) Use both NumPy arrays and Blosc2 NDArrays in the same expression.
+    2) Follow casting rules of NumPy more closely.
+    3) Use both NumPy arrays and Blosc2 NDArrays in the same expression.
 
     As NDArrays can be on-disk, the expression can be evaluated without loading
     the whole array into memory (i.e. using an out-of-core approach).
@@ -3045,7 +3046,7 @@ def evaluate(
     out: NDArray or NumPy array, optional
         The output array where the result will be stored. If not provided,
         a new NumPy array will be created and returned.
-    kwargs: dict, optional
+    kwargs: Any, optional
         Additional arguments to be passed to `numexpr.evaluate()` function.
 
     Returns

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -460,7 +460,7 @@ def compute_smaller_slice(larger_shape, smaller_shape, larger_slice):
 validation_patterns = [
     r"[\;\[\:]",  # Flow control characters
     r"(^|[^\w])__[\w]+__($|[^\w])",  # Dunder methods
-    r"\.\b(?!real|imag|(\d*[eE]?[+-]?\d+)|\d*j\b|(sum|prod|min|max|std|mean|var|any|all|where)"
+    r"\.\b(?!real|imag|(\d*[eE]?[+-]?\d+)|(\d*[eE]?[+-]?\d+j)|\d*j\b|(sum|prod|min|max|std|mean|var|any|all|where)"
     r"\s*\([^)]*\)|[a-zA-Z_]\w*\s*\([^)]*\))",  # Attribute patterns
 ]
 

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -3018,7 +3018,7 @@ def evaluate(
     local_dict: dict | None = None,
     global_dict: dict | None = None,
     out: np.ndarray | blosc2.NDArray = None,
-    ne_args: dict | None = None,
+    kwargs: dict | None = None,
 ) -> np.ndarray | blosc2.NDArray:
     """
     Evaluate a string expression using the Blosc2 compute engine.
@@ -3045,7 +3045,7 @@ def evaluate(
     out: NDArray or NumPy array, optional
         The output array where the result will be stored. If not provided,
         a new NumPy array will be created and returned.
-    ne_args: dict, optional
+    kwargs: dict, optional
         Additional arguments to be passed to `numexpr.evaluate()` function.
 
     Returns
@@ -3071,7 +3071,7 @@ def evaluate(
     [16.0625   21.140625 27.      ]]
     """
     lexpr = lazyexpr(
-        ex, local_dict=local_dict, global_dict=global_dict, out=out, ne_args=ne_args, _frame_depth=3
+        ex, local_dict=local_dict, global_dict=global_dict, out=out, ne_args=kwargs, _frame_depth=3
     )
     if out is not None:
         # The user specified an output array

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -3023,8 +3023,8 @@ def evaluate(
     """
     Evaluate a string expression using the Blosc2 compute engine.
 
-    This is a drop-in replacement for numexpr.evaluate, but using the Blosc2
-    compute engine.  This allows for:
+    This is a drop-in replacement for `numexpr.evaluate()`, but using the
+    Blosc2 compute engine.  This allows for:
 
     1) Use more functionality (e.g. reductions) than numexpr.
     2) Use both NumPy arrays and Blosc2 NDArrays in the same expression.

--- a/tests/ndarray/test_evaluate.py
+++ b/tests/ndarray/test_evaluate.py
@@ -51,7 +51,7 @@ def test_expr_out(sample_data):
 
 def test_expr_optimization(sample_data):
     a, b, c, shape = sample_data
-    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", ne_args={"optimization": "none"})
+    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", kwargs={"optimization": "none"})
     d_numexpr = ne.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", optimization="none")
     np.testing.assert_equal(d_blosc2, d_numexpr)
 

--- a/tests/ndarray/test_evaluate.py
+++ b/tests/ndarray/test_evaluate.py
@@ -51,7 +51,7 @@ def test_expr_out(sample_data):
 
 def test_expr_optimization(sample_data):
     a, b, c, shape = sample_data
-    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", kwargs={"optimization": "none"})
+    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", optimization="none")
     d_numexpr = ne.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", optimization="none")
     np.testing.assert_equal(d_blosc2, d_numexpr)
 

--- a/tests/ndarray/test_evaluate.py
+++ b/tests/ndarray/test_evaluate.py
@@ -6,8 +6,8 @@
 # LICENSE file in the root directory of this source tree)
 #######################################################################
 
-import numpy as np
 import numexpr as ne
+import numpy as np
 import pytest
 
 import blosc2
@@ -16,14 +16,7 @@ import blosc2
 
 # Define the parameters
 test_params = [
-    (
-        (10, 100),
-        (
-            10,
-            100,
-        ),
-        "float32",
-    ),
+    ((10, 100), (10, 100), "float32"),
     ((10, 100), (100,), "float64"),  # using broadcasting
 ]
 
@@ -48,7 +41,7 @@ def test_expr(sample_data):
 def test_expr_out(sample_data):
     a, b, c, shape = sample_data
     # Testing with an out param
-    out = blosc2.zeros(shape, dtype=np.bool_)
+    out = blosc2.zeros(shape, dtype="bool")
     d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", out=out)
     out2 = np.zeros(shape, dtype=np.bool_)
     d_numexpr = ne.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", out=out2)
@@ -58,7 +51,7 @@ def test_expr_out(sample_data):
 
 def test_expr_optimization(sample_data):
     a, b, c, shape = sample_data
-    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", optimization="none")
+    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", ne_args={"optimization": "none"})
     d_numexpr = ne.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", optimization="none")
     np.testing.assert_equal(d_blosc2, d_numexpr)
 
@@ -69,7 +62,9 @@ def test_expr_optimization(sample_data):
 def test_reduc(sample_data):
     a, b, c, shape = sample_data
     d_blosc2 = blosc2.evaluate("sum(((a**3 + sin(a * 2)) < c) & (b > 0), axis=1)")
-    a = a[:]; b = b[:]; c = c[:]   # ensure that all operands are numpy arrays
+    a = a[:]
+    b = b[:]
+    c = c[:]  # ensure that all operands are numpy arrays
     d_numpy = np.sum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=1)
     np.testing.assert_equal(d_blosc2, d_numpy)
 
@@ -82,11 +77,12 @@ def test_reduc_out(sample_data):
     d_blosc2 = blosc2.evaluate("sum(((a**3 + sin(a * 2)) < c) & (b > 0), axis=1)", out=out)
     out2 = out[:]
     d_blosc2_ = blosc2.evaluate("sum(((a**3 + sin(a * 2)) < c) & (b > 0), axis=1, out=out2)")
-    a = a[:]; b = b[:]; c = c[:]   # ensure that all operands are numpy arrays
+    a = a[:]
+    b = b[:]
+    c = c[:]  # ensure that all operands are numpy arrays
     out3 = out[:]
     d_numpy = np.sum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=1, out=out3)
     np.testing.assert_equal(d_blosc2, d_numpy)
     np.testing.assert_equal(d_blosc2_, d_numpy)
     np.testing.assert_equal(out, out2)
     np.testing.assert_equal(out, out3)
-Å

--- a/tests/ndarray/test_evaluate.py
+++ b/tests/ndarray/test_evaluate.py
@@ -1,0 +1,92 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+import numpy as np
+import numexpr as ne
+import pytest
+
+import blosc2
+
+###### General expressions
+
+# Define the parameters
+test_params = [
+    (
+        (10, 100),
+        (
+            10,
+            100,
+        ),
+        "float32",
+    ),
+    ((10, 100), (100,), "float64"),  # using broadcasting
+]
+
+
+@pytest.fixture(params=test_params)
+def sample_data(request):
+    shape, cshape, dtype = request.param
+    # The jit decorator can work with any numpy or NDArray params in functions
+    a = blosc2.linspace(0, 1, shape[0] * shape[1], dtype=dtype, shape=shape)
+    b = np.linspace(1, 2, shape[0] * shape[1], dtype=dtype).reshape(shape)
+    c = blosc2.linspace(-10, 10, cshape[0], dtype=dtype, shape=cshape)
+    return a, b, c, shape
+
+
+def test_expr(sample_data):
+    a, b, c, shape = sample_data
+    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)")
+    d_numexpr = ne.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)")
+    np.testing.assert_equal(d_blosc2, d_numexpr)
+
+
+def test_expr_out(sample_data):
+    a, b, c, shape = sample_data
+    # Testing with an out param
+    out = blosc2.zeros(shape, dtype=np.bool_)
+    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", out=out)
+    out2 = np.zeros(shape, dtype=np.bool_)
+    d_numexpr = ne.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", out=out2)
+    np.testing.assert_equal(d_blosc2, d_numexpr)
+    np.testing.assert_equal(out, out2)
+
+
+def test_expr_optimization(sample_data):
+    a, b, c, shape = sample_data
+    d_blosc2 = blosc2.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", optimization="none")
+    d_numexpr = ne.evaluate("((a**3 + sin(a * 2)) < c) & (b > 0)", optimization="none")
+    np.testing.assert_equal(d_blosc2, d_numexpr)
+
+
+###### Reductions
+
+
+def test_reduc(sample_data):
+    a, b, c, shape = sample_data
+    d_blosc2 = blosc2.evaluate("sum(((a**3 + sin(a * 2)) < c) & (b > 0), axis=1)")
+    a = a[:]; b = b[:]; c = c[:]   # ensure that all operands are numpy arrays
+    d_numpy = np.sum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=1)
+    np.testing.assert_equal(d_blosc2, d_numpy)
+
+
+def test_reduc_out(sample_data):
+    a, b, c, shape = sample_data
+    # Testing with an out param
+    out = blosc2.zeros(shape[0], dtype=np.int64)
+    # Both versions below should work
+    d_blosc2 = blosc2.evaluate("sum(((a**3 + sin(a * 2)) < c) & (b > 0), axis=1)", out=out)
+    out2 = out[:]
+    d_blosc2_ = blosc2.evaluate("sum(((a**3 + sin(a * 2)) < c) & (b > 0), axis=1, out=out2)")
+    a = a[:]; b = b[:]; c = c[:]   # ensure that all operands are numpy arrays
+    out3 = out[:]
+    d_numpy = np.sum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=1, out=out3)
+    np.testing.assert_equal(d_blosc2, d_numpy)
+    np.testing.assert_equal(d_blosc2_, d_numpy)
+    np.testing.assert_equal(out, out2)
+    np.testing.assert_equal(out, out3)
+Å

--- a/tests/ndarray/test_jit.py
+++ b/tests/ndarray/test_jit.py
@@ -34,7 +34,7 @@ def sample_data(request):
     a = blosc2.linspace(0, 1, shape[0] * shape[1], dtype=dtype, shape=shape)
     b = np.linspace(1, 2, shape[0] * shape[1], dtype=dtype).reshape(shape)
     c = blosc2.linspace(-10, 10, cshape[0], dtype=dtype, shape=cshape)
-    return a, b, c, shape, cshape, dtype
+    return a, b, c, shape
 
 
 def expr_nojit(a, b, c):
@@ -47,14 +47,14 @@ def expr_jit(a, b, c):
 
 
 def test_expr(sample_data):
-    a, b, c, shape, cshape, dtype = sample_data
+    a, b, c, shape = sample_data
     d_jit = expr_jit(a, b, c)
     d_nojit = expr_nojit(a, b, c)
     np.testing.assert_equal(d_jit[...], d_nojit[...])
 
 
 def test_expr_out(sample_data):
-    a, b, c, shape, cshape, dtype = sample_data
+    a, b, c, shape = sample_data
     d_nojit = expr_nojit(a, b, c)
 
     # Testing jit decorator with an out param
@@ -70,7 +70,7 @@ def test_expr_out(sample_data):
 
 
 def test_expr_kwargs(sample_data):
-    a, b, c, shape, cshape, dtype = sample_data
+    a, b, c, shape = sample_data
     d_nojit = expr_nojit(a, b, c)
 
     # Testing jit decorator with kwargs
@@ -108,7 +108,7 @@ def reduc_jit(a, b, c):
 
 
 def test_reduc(sample_data):
-    a, b, c, shape, cshape, dtype = sample_data
+    a, b, c, shape = sample_data
 
     d_jit = reduc_jit(a, b, c)
     d_nojit = reduc_nojit(a, b, c)
@@ -117,7 +117,7 @@ def test_reduc(sample_data):
 
 
 def test_reduc_out(sample_data):
-    a, b, c, shape, cshape, dtype = sample_data
+    a, b, c, shape = sample_data
     d_nojit = reduc_nojit(a, b, c)
 
     # Testing jit decorator with an out param via the reduction function
@@ -134,7 +134,7 @@ def test_reduc_out(sample_data):
 
 
 def test_reduc_mean_out(sample_data):
-    a, b, c, shape, cshape, dtype = sample_data
+    a, b, c, shape = sample_data
     d_nojit = reduc_mean_nojit(a, b, c)
 
     # Testing jit decorator with an out param via the reduction function
@@ -150,7 +150,7 @@ def test_reduc_mean_out(sample_data):
 
 
 def test_reduc_kwargs(sample_data):
-    a, b, c, shape, cshape, dtype = sample_data
+    a, b, c, shape = sample_data
     d_nojit = reduc_nojit(a, b, c)
 
     # Testing jit decorator with kwargs via an out param in the reduction function
@@ -169,7 +169,7 @@ def test_reduc_kwargs(sample_data):
 
 
 def test_reduc_std_kwargs(sample_data):
-    a, b, c, shape, cshape, dtype = sample_data
+    a, b, c, shape = sample_data
     d_nojit = reduc_std_nojit(a, b, c)
 
     # Testing jit decorator with kwargs via an out param in the reduction function

--- a/tests/ndarray/test_jit.py
+++ b/tests/ndarray/test_jit.py
@@ -15,14 +15,7 @@ import blosc2
 
 # Define the parameters
 test_params = [
-    (
-        (10, 100),
-        (
-            10,
-            100,
-        ),
-        "float32",
-    ),
+    ((10, 100), (10, 100), "float32"),
     ((10, 100), (100,), "float64"),  # using broadcasting
 ]
 


### PR DESCRIPTION
This emulates `numexpr.evaluate()`, but with the next improvements:

1) Use more functionality (e.g. reductions) than numexpr.
2) Follow casting rules of NumPy more closely.
3) Use both NumPy arrays and Blosc2 NDArrays in the same expression.

As NDArrays can be on-disk, the expression can be evaluated without loading
the whole array into memory (i.e. using an out-of-core approach).
