### PR TITLE
Array interface

### DIFF
--- a/bench/ndarray/jit-expr.py
+++ b/bench/ndarray/jit-expr.py
@@ -23,7 +23,7 @@ chunks, blocks= None, None   # enforce automatic chunk and block sizes
 cparams = blosc2.CParams(clevel=1, codec=blosc2.Codec.LZ4)
 cparams_out = blosc2.CParams(clevel=1, codec=blosc2.Codec.LZ4)
 print("Using cparams: ", cparams)
-check_result = True
+check_result = False
 # Lossy compression
 # filters = [blosc2.Filter.TRUNC_PREC, blosc2.Filter.SHUFFLE]
 # filters_meta = [8, 0]  # keep 8 bits of precision in mantissa
@@ -150,5 +150,4 @@ cratio = out.schunk.cratio if isinstance(out, blosc2.NDArray) else 1.0
 print(f"Speedup: {tref / t1:.2f}x, out cratio: {cratio:.2f}x")
 if check_result:
     np.testing.assert_allclose(out, nout)
-
-print("All results are equal!")
+    print("All results are equal!")

--- a/bench/ndarray/jit-numpy-funcs.py
+++ b/bench/ndarray/jit-numpy-funcs.py
@@ -1,0 +1,58 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+# Examples of using the jit decorator with arbitrary NumPy functions.
+# You can find benchmarks for this example in the bench/ndarray directory
+
+import numpy as np
+from time import time
+
+import blosc2
+
+N = 3000   # working size of ~200 MB
+
+# Create some sample data
+a = blosc2.linspace(0, 1, N * N, dtype="float32", shape=(N, N))
+b = blosc2.linspace(1, 2, N * N, dtype="float32", shape=(N, N))
+c = blosc2.linspace(-10, 10, 10, dtype="float32", shape=(N,))
+
+
+# Example 1: Basic usage of the jit decorator with reduction
+@blosc2.jit
+def expr_jit(a, b, c):
+    # This function computes a cumulative sum reduction along axis 0
+    return np.cumsum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=0)
+
+# Call the function with the jit decorator
+t0 = time()
+result = expr_jit(a, b, c)
+print(f"Time for example 1: {time() - t0:.6f} s")
+
+
+# Example 2: Using the jit decorator with an out parameter for reduction
+out = np.zeros(result.shape, dtype=np.int64)
+@blosc2.jit
+def expr_jit_out(a, b, c):
+    return np.cumulative_prod(((a**3 + np.sin(a * 2)) < c) & (b > 0),
+                              axis=0, out=out, include_initial=False)
+
+# Call the function with the jit decorator and out parameter
+t0 = time()
+result_out = expr_jit_out(a, b, c)
+print(f"Time for example 2: {time() - t0:.6f} s")
+
+
+# Example 3: Using the jit decorator with a combination of NumPy functions
+@blosc2.jit
+def expr_jit_diff(a, b, c):
+    return np.diff((a**3 + np.cumsum(b * 2, axis=1) + c), axis=1)
+
+# Call the function with the jit decorator and custom parameters
+t0 = time()
+result = expr_jit_diff(a, b, c)
+print(f"Time for example 3: {time() - t0:.6f} s")

--- a/bench/ndarray/jit-numpy-funcs.py
+++ b/bench/ndarray/jit-numpy-funcs.py
@@ -6,53 +6,52 @@
 # LICENSE file in the root directory of this source tree)
 #######################################################################
 
-# Examples of using the jit decorator with arbitrary NumPy functions.
-# You can find benchmarks for this example in the bench/ndarray directory
+# Benchmarks of using the jit decorator with arbitrary NumPy functions.
 
 import numpy as np
 from time import time
 
 import blosc2
 
-N = 3000   # working size of ~200 MB
+N = 5_000   # working size of ~200 MB
 
 # Create some sample data
+t0 = time()
+na = np.linspace(0, 1, N * N, dtype="float32").reshape(N, N)
+nb = np.linspace(1, 2, N * N, dtype="float32").reshape(N, N)
+nc = np.linspace(-10, 10, N, dtype="float32")
+print(f"Time to create data (np.ndarray): {time() - t0:.3f} s")
+
+t0 = time()
 a = blosc2.linspace(0, 1, N * N, dtype="float32", shape=(N, N))
 b = blosc2.linspace(1, 2, N * N, dtype="float32", shape=(N, N))
 c = blosc2.linspace(-10, 10, 10, dtype="float32", shape=(N,))
+print(f"Time to create data (NDArray): {time() - t0:.3f} s")
+#print("a.chunks: ", a.chunks, "a.blocks: ", a.blocks)
 
+# Compare with NumPy
+def expr_numpy(a, b, c):
+    # return np.cumsum(((na**3 + np.sin(na * 2)) < nc) & (nb > 0), axis=0)
+    # The next is equally illustrative, but can achieve better speedups
+    return np.sum(((na**3 + np.sin(na * 2)) < np.cumulative_sum(nc)) & (nb > 0), axis=1)
 
-# Example 1: Basic usage of the jit decorator with reduction
 @blosc2.jit
 def expr_jit(a, b, c):
-    # This function computes a cumulative sum reduction along axis 0
-    return np.cumsum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=0)
+    # return np.cumsum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=0)
+    return np.sum(((a**3 + np.sin(a * 2)) < np.cumulative_sum(c)) & (b > 0), axis=1)
 
-# Call the function with the jit decorator
+# Call the NumPy function natively on NumPy containers
+t0 = time()
+result = expr_numpy(a, b, c)
+tref = time() - t0
+print(f"Time for native NumPy: {tref:.3f} s")
+
+# Call the function with the jit decorator, using NumPy containers
+t0 = time()
+result = expr_jit(na, nb, nc)
+print(f"Time for blosc2.jit (np.ndarray): {time() - t0:.3f} s, speedup: {tref / (time() - t0):.2f}x")
+
+# Call the function with the jit decorator, using Blosc2 containers
 t0 = time()
 result = expr_jit(a, b, c)
-print(f"Time for example 1: {time() - t0:.6f} s")
-
-
-# Example 2: Using the jit decorator with an out parameter for reduction
-out = np.zeros(result.shape, dtype=np.int64)
-@blosc2.jit
-def expr_jit_out(a, b, c):
-    return np.cumulative_prod(((a**3 + np.sin(a * 2)) < c) & (b > 0),
-                              axis=0, out=out, include_initial=False)
-
-# Call the function with the jit decorator and out parameter
-t0 = time()
-result_out = expr_jit_out(a, b, c)
-print(f"Time for example 2: {time() - t0:.6f} s")
-
-
-# Example 3: Using the jit decorator with a combination of NumPy functions
-@blosc2.jit
-def expr_jit_diff(a, b, c):
-    return np.diff((a**3 + np.cumsum(b * 2, axis=1) + c), axis=1)
-
-# Call the function with the jit decorator and custom parameters
-t0 = time()
-result = expr_jit_diff(a, b, c)
-print(f"Time for example 3: {time() - t0:.6f} s")
+print(f"Time for blosc2.jit (NDArray): {time() - t0:.3f} s, speedup: {tref / (time() - t0):.2f}x")

--- a/bench/ndarray/jit-reduc.py
+++ b/bench/ndarray/jit-reduc.py
@@ -22,7 +22,7 @@ chunks, blocks= None, None   # enforce automatic chunk and block sizes
 cparams = blosc2.CParams(clevel=1, codec=blosc2.Codec.LZ4)
 cparams_out = blosc2.CParams(clevel=1, codec=blosc2.Codec.LZ4)
 print("Using cparams: ", cparams)
-check_result = True
+check_result = False
 # Lossy compression
 # filters = [blosc2.Filter.TRUNC_PREC, blosc2.Filter.SHUFFLE]
 # filters_meta = [8, 0]  # keep 8 bits of precision in mantissa
@@ -140,5 +140,4 @@ cratio = out.schunk.cratio if isinstance(out, blosc2.NDArray) else 1.0
 print(f"Speedup: {tref / t1:.2f}x, out cratio: {cratio:.2f}x")
 if check_result:
     np.testing.assert_allclose(out, nout)
-
-print("All results are equal!")
+    print("All results are equal!")

--- a/examples/ndarray/jit-numpy-funcs.py
+++ b/examples/ndarray/jit-numpy-funcs.py
@@ -1,0 +1,59 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+# Examples of using the jit decorator with arbitrary NumPy functions.
+# These functions are not optimized for performance, but they show how
+# to use the jit decorator with NumPy functions.
+# You can find benchmarks for this example in the bench/ndarray directory
+
+import numpy as np
+
+import blosc2
+
+# Create some sample data
+a = blosc2.linspace(0, 1, 10 * 100, dtype="float32", shape=(10, 100))
+b = blosc2.linspace(1, 2, 10 * 100, dtype="float32", shape=(10, 100))
+c = blosc2.linspace(-10, 10, 10, dtype="float32", shape=(100,))
+
+
+# Example 1: Basic usage of the jit decorator with reduction
+@blosc2.jit
+def expr_jit(a, b, c):
+    # This function computes a cumulative sum reduction along axis 0
+    return np.cumsum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=0)
+
+
+# Call the function with the jit decorator
+result = expr_jit(a, b, c)
+print(f"Example 1 result[0, 0:10]: {result[0, 0:10]}")
+
+
+# Example 2: Using the jit decorator with an out parameter for reduction
+out = np.zeros(result.shape, dtype=np.int64)
+
+
+@blosc2.jit
+def expr_jit_out(a, b, c):
+    return np.cumulative_prod(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=0, out=out, include_initial=False)
+
+
+# Call the function with the jit decorator and out parameter
+result = expr_jit_out(a, b, c)
+print(f"Example 2 result[0, 0:10]: {result[0, 0:10]}")
+print("Example 2 out[0, 0:10] array:", out[0, 0:10])  # the 'out' array should now contain the same result
+
+
+# Example 3: Using the jit decorator with a combination of NumPy functions
+@blosc2.jit
+def expr_jit_diff(a, b, c):
+    return np.diff((a**3 + np.cumsum(b * 2, axis=1) + c), axis=1)
+
+
+# Call the function with the jit decorator and custom parameters
+result = expr_jit_diff(a, b, c)
+print(f"Example 3 result[0, 0:5]: {result[0, 0:5]}")

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -420,6 +420,16 @@ class LazyArray(ABC):
         """
         pass
 
+    # Provide minimal __array_interface__ to allow NumPy to work with this object
+    @property
+    def __array_interface__(self):
+        return dict(
+            shape=self.shape,
+            typestr=self.dtype.str,
+            data=self[()].__array_interface__["data"],
+            version=3,
+        )
+
 
 def convert_inputs(inputs):
     if not inputs or len(inputs) == 0:

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -423,12 +423,12 @@ class LazyArray(ABC):
     # Provide minimal __array_interface__ to allow NumPy to work with this object
     @property
     def __array_interface__(self):
-        return dict(
-            shape=self.shape,
-            typestr=self.dtype.str,
-            data=self[()].__array_interface__["data"],
-            version=3,
-        )
+        return {
+            "shape": self.shape,
+            "typestr": self.dtype.str,
+            "data": self[()],
+            "version": 3,
+        }
 
 
 def convert_inputs(inputs):

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -12,6 +12,7 @@ import ast
 import asyncio
 import concurrent.futures
 import copy
+import inspect
 import math
 import os
 import pathlib
@@ -154,10 +155,43 @@ functions = [
     "pow" if np.__version__.startswith("2.") else "power",
     "where",
 ]
+
+# Gather all callable functions in numpy
+numpy_funcs = {
+    name for name, member in inspect.getmembers(np, callable)
+    if not name.startswith('_') and not isinstance(member, np.ufunc)
+}
+numpy_ufuncs = {name for name, member in inspect.getmembers(np, lambda x: isinstance(x, np.ufunc))}
+# Add these functions to the list of available functions
+# (will be evaluated via the array interface)
+additional_funcs = sorted((numpy_funcs | numpy_ufuncs) - set(functions))
+functions += additional_funcs
+
 functions += constructors
 
 relational_ops = ["==", "!=", "<", "<=", ">", ">="]
 logical_ops = ["&", "|", "^", "~"]
+
+
+def get_expr_globals(expression):
+    """Build a dictionary of functions needed for evaluating the expression."""
+    _globals = {}
+
+    # Only check for functions that actually appear in the expression
+    # This avoids many unnecessary string searches
+    for func in functions:
+        if func in expression:
+            # Try blosc2 first
+            if hasattr(blosc2, func):
+                _globals[func] = getattr(blosc2, func)
+            # Fall back to numpy
+            elif hasattr(np, func):
+                _globals[func] = getattr(np, func)
+            # Function not found in either module
+            else:
+                raise AttributeError(f"Function {func} not found in blosc2 or numpy")
+
+    return _globals
 
 
 class ReduceOp(Enum):
@@ -2385,7 +2419,7 @@ class LazyExpr(LazyArray):
     def _compute_expr(self, item, kwargs):  # noqa: C901
         if any(method in self.expression for method in reducers):
             # We have reductions in the expression (probably coming from a string lazyexpr)
-            _globals = {func: getattr(blosc2, func) for func in functions if func in self.expression}
+            _globals = get_expr_globals(self.expression)
             lazy_expr = eval(self.expression, _globals, self.operands)
             if not isinstance(lazy_expr, blosc2.LazyExpr):
                 # An immediate evaluation happened (e.g. all operands are numpy arrays)
@@ -2624,7 +2658,7 @@ class LazyExpr(LazyArray):
             # Most in particular, castings like np.int8 et al. can be very useful to allow
             # for desired data types in the output.
             _operands = operands | local_vars
-            _globals = {func: getattr(blosc2, func) for func in functions if func in expression}
+            _globals = get_expr_globals(expression)
             _globals |= dtype_symbols
             new_expr = eval(_expression, _globals, _operands)
             _dtype = new_expr.dtype

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -813,6 +813,7 @@ class Operand:
             np.bitwise_and: "&",
             np.bitwise_or: "|",
             np.bitwise_xor: "^",
+            np.arctan2: "arctan2",
         }
 
         ufunc_map_1param = {

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -782,6 +782,16 @@ class Operand:
         _check_allowed_dtypes(value)
         return blosc2.LazyExpr(new_op=(self, "+", value))
 
+    # Provide minimal __array_interface__ to allow NumPy to work with this object
+    @property
+    def __array_interface__(self):
+        return dict(
+            shape=self.shape,
+            typestr=self.dtype.str,
+            data=self[()].__array_interface__["data"],
+            version=3,
+        )
+
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         # Handle operations at the array level
         if method != "__call__":

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -785,12 +785,12 @@ class Operand:
     # Provide minimal __array_interface__ to allow NumPy to work with this object
     @property
     def __array_interface__(self):
-        return dict(
-            shape=self.shape,
-            typestr=self.dtype.str,
-            data=self[()].__array_interface__["data"],
-            version=3,
-        )
+        return {
+            "shape": self.shape,
+            "typestr": self.dtype.str,
+            "data": self[()],
+            "version": 3,
+        }
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         # Handle operations at the array level

--- a/tests/ndarray/test_evaluate.py
+++ b/tests/ndarray/test_evaluate.py
@@ -88,3 +88,18 @@ def test_reduc_out(sample_data):
     np.testing.assert_equal(d_blosc2_, d_numpy)
     np.testing.assert_equal(out, out2)
     np.testing.assert_equal(out, out3)
+
+
+###### NumPy functions
+
+
+@pytest.mark.parametrize("func", ["cumsum", "cumulative_sum", "cumprod"])
+def test_numpy_funcs(sample_data, func):
+    a, b, c, shape = sample_data
+    d_blosc2 = blosc2.evaluate(f"{func}(((a**3 + sin(a * 2)) < c) & (b > 0), axis=0)")
+    a = a[:]
+    b = b[:]
+    c = c[:]  # ensure that all operands are numpy arrays
+    npfunc = getattr(np, func)
+    d_numpy = npfunc(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=0)
+    np.testing.assert_equal(d_blosc2, d_numpy)

--- a/tests/ndarray/test_full.py
+++ b/tests/ndarray/test_full.py
@@ -169,5 +169,7 @@ def test_complex_datatype():
     b = blosc2.asarray(a, cparams=cparams, urlpath="b.b2nd", mode="w")
     # Iterate over the fields of the structured array and check that the data is the same
     for field in dtype.fields:
-        assert np.array_equal(b[field], a[field])
+        # TODO: the next is not working
+        # np.testing.assert_allclose(b[field][:], a[field], rtol=1e-5, atol=1e-5)
+        assert np.array_equal(b[field][:], a[field])
     blosc2.remove_urlpath("b.b2nd")

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1297,3 +1297,13 @@ def test_only_ndarrays_or_constructors(obj, getitem, item):
     assert b.dtype == larr.dtype
     if not isinstance(obj, str):
         assert np.allclose(b[:], obj[item])
+
+
+@pytest.mark.parametrize("func", ["cumsum", "cumulative_sum", "cumprod"])
+def test_numpy_funcs(array_fixture, func):
+    a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    npfunc = getattr(np, func)
+    d_blosc2 = npfunc(((a1**3 + blosc2.sin(na2 * 2)) < a3) & (na2 > 0), axis=0)
+    npfunc = getattr(np, func)
+    d_numpy = npfunc(((na1**3 + np.sin(na2 * 2)) < na3) & (na2 > 0), axis=0)
+    np.testing.assert_equal(d_blosc2, d_numpy)

--- a/tests/ndarray/test_nans.py
+++ b/tests/ndarray/test_nans.py
@@ -41,4 +41,4 @@ def test_large_typesize(shape, typesize, asarray):
         # b = blosc2.nans(shape, dtype=dtype)  # TODO: this is not working; perhaps deprecate blosc2.nans()?
         b = blosc2.full(shape, np.nan, dtype=dtype)
     for field in dtype.fields:
-        np.testing.assert_allclose(b[field], a[field], equal_nan=True)
+        np.testing.assert_allclose(b[field][:], a[field], equal_nan=True)


### PR DESCRIPTION
This implements the array interface to array containers.  This allows evaluating blosc2 containers with numpy functions, like:

```
@blosc2.jit
def expr_jit(a, b, c):
    # This function computes a cumulative sum reduction along axis 0
    return np.cumsum(((a**3 + np.sin(a * 2)) < c) & (b > 0), axis=0)
```

In this case, `np.cumsum` is not implemented in blosc2 as a function, but the array interface automatically converts the LazyArray into a numpy ndarray, and proceeds with the computation.  This requires a conversion, but in exchange, we have access to all the functions in numpy seamlessly.