### PR TITLE
Avoid using loop variable outside the loop

### DIFF
--- a/tests/ndarray/test_getitem.py
+++ b/tests/ndarray/test_getitem.py
@@ -140,9 +140,10 @@ def test_iter(shape, chunks, blocks):
     npa = np.arange(int(np.prod(shape)), dtype=np.int32).reshape(shape)
     b2a = blosc2.asarray(npa, chunks=chunks, blocks=blocks)
 
-    for _i, (a, b) in enumerate(zip(b2a, npa, strict=False)):
+    zip_b2a_npa = zip(b2a, npa, strict=False)
+    assert len(zip_b2a_npa) == shape[0] - 1
+    for a, b in zip_b2a_npa:
         np.testing.assert_equal(a, b)
-    assert _i == shape[0] - 1
 
 
 @pytest.mark.parametrize("dtype", [np.int32, np.float32, np.float64])

--- a/tests/ndarray/test_lazyexpr_fields.py
+++ b/tests/ndarray/test_lazyexpr_fields.py
@@ -564,10 +564,11 @@ def test_iter(shape, chunks, blocks):
     nsa["b"] = nb
     sa = blosc2.asarray(nsa, chunks=chunks, blocks=blocks)
 
-    for _i, (a, b) in enumerate(zip(sa, nsa, strict=False)):
+    zip_sa_nsa = zip(sa, nsa, strict=False)
+    assert len(zip_sa_nsa) == shape[0] - 1
+    for a, b in zip_sa_nsa:
         np.testing.assert_equal(a, b)
         assert a.dtype == b.dtype
-    assert _i == shape[0] - 1
 
 
 @pytest.mark.parametrize("reduce_op", ["sum", "mean", "min", "max", "std", "var"])


### PR DESCRIPTION
Although that's not the case here, the variable will be undefined if the list is empty.