### PR TITLE
Edited NDarray slice to default to original codec/clevel for recompression 

### DIFF
--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1837,7 +1837,11 @@ class NDArray(blosc2_ext.NDArray, Operand):
         >>> print(type(c))
         <class 'blosc2.ndarray.NDArray'>
         """
-        kwargs = _check_ndarray_kwargs(**kwargs)
+        original_codec = self.cparams.codec
+        original_clevel = self.cparams.clevel
+        if "cparams" not in kwargs:
+            kwargs["cparams"] = {"codec": original_codec, "clevel": original_clevel}
+        kwargs = _check_ndarray_kwargs(**kwargs)  # sets cparams to defaults
         key, mask = process_key(key, self.shape)
         start, stop, step = get_ndarray_start_stop(self.ndim, key, self.shape)
         key = (start, stop)

--- a/tests/ndarray/test_slice.py
+++ b/tests/ndarray/test_slice.py
@@ -30,6 +30,19 @@ def test_slice(shape, chunks, blocks, slices, dtype):
     np.testing.assert_almost_equal(b[...], np_slice)
 
 
+@pytest.mark.parametrize(argnames, argvalues)
+def test_slice_codec_and_clevel(shape, chunks, blocks, slices, dtype):
+    size = int(np.prod(shape))
+    nparray = np.arange(size, dtype=dtype).reshape(shape)
+    a = blosc2.asarray(
+        nparray, chunks=chunks, blocks=blocks, cparams={"codec": blosc2.Codec.LZ4, "clevel": 6}
+    )
+
+    b = a.slice(slices)
+    assert b.cparams.codec == a.cparams.codec
+    assert b.cparams.clevel == a.cparams.clevel
+
+
 argnames = "shape, chunks, blocks, slices, dtype, chunks2, blocks2"
 argvalues = [
     ([456], [258], [73], slice(0, 1), np.int32, [1], [1]),


### PR DESCRIPTION
Slice would decompress data, get slice, and recompress by default using dflt_cparams. Changed to use codec and clevel of original compressed data to recompress slice.