### PR TITLE
open lazyexpr don't fail if missing operands (wip)

### DIFF
--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -3083,7 +3083,10 @@ def _open_lazyarray(array):
     for key, value in operands.items():
         if isinstance(value, str):
             value = parent_path / value
-            op = blosc2.open(value)
+            try:
+                op = blosc2.open(value)
+            except FileNotFoundError:
+                op = None
             operands_dict[key] = op
         elif isinstance(value, dict):
             # C2Array


### PR DESCRIPTION
To reproduce:

    blosc2.open('path-to-lazy-expression-with-missing operands')

With this change it still tries to guess the dtype and the shape, but this either fails with an error or makes the wrong guess. Because with missing operands it's imposible to correctly find out the dtype and shape, in this case dtype and shape should be None (this remains to be done).

There should be an error when trying to evaluate the expression, but not when opening it, because we may want to inspect it.