### PR TITLE
Rename ruff ruleset: `TCH` → `TC`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ extend-select = [
     "RET",
     "RUF",
     "SIM",
-    "TCH",
+    "TC",
     "UP",
 ]
 ignore = [


### PR DESCRIPTION
Ruff 0.8.0 changes the error codes for the rules in the [`flake8-type-checking`](https://docs.astral.sh/ruff/rules/#flake8-type-checking-tc) category from `TCH` to `TC`. This matches changes that were made in the original `flake8-type-checking` plugin from which these rules were originally adapted.

https://astral.sh/blog/ruff-v0.8.0#new-error-codes-for-flake8-type-checking-rules