### PR TITLE
Fix incorrect appending of dim to computed reductions

### DIFF
--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -423,7 +423,7 @@ def test_save_constructor_reduce2(shape, disk, compute):
 def test_reduction_index():
     shape = (20, 20)
     a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
-    arr = blosc2.lazyexpr('sum(a,axis=0)', {'a': a})
+    arr = blosc2.lazyexpr("sum(a,axis=0)", {"a": a})
     newarr = arr.compute()
     assert arr[:10].shape == (10,)
     assert arr[0].shape == (1,)

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -423,6 +423,8 @@ def test_save_constructor_reduce2(shape, disk, compute):
 def test_reduction_index():
     shape = (20, 20)
     a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
-    expr = blosc2.sum(a, axis=0)
-    assert expr[:10].shape == (10,)
-    assert expr[0].shape == ()
+    arr = blosc2.lazyexpr('sum(a,axis=0)', {'a': a})
+    newarr = arr.compute()
+    assert arr[:10].shape == (10,)
+    assert arr[0].shape == (1,)
+    assert arr.shape == newarr.shape


### PR DESCRIPTION
Fix bug introduced in #402 that added extra dimension due to None indexing for reductions. Extended test to check that dimensions are correct. Solves https://github.com/ironArray/Caterva2/issues/179