### PR TITLE
Fix chaining

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,6 @@ ignore = [
     "RUF015",
     "SIM108",
     "UP038",  # https://github.com/astral-sh/ruff/issues/7871
-    "C402", #allow dict comprehension as {}
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,7 @@ ignore = [
     "RUF015",
     "SIM108",
     "UP038",  # https://github.com/astral-sh/ruff/issues/7871
+    "C402", #allow dict comprehension as {}
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -2725,7 +2725,9 @@ class LazyExpr(LazyArray):
             if isinstance(new_expr, blosc2.LazyExpr):
                 # DO NOT restore the original expression and operands
                 # Instead rebase operands and restore only constructors
-                expression_, operands_ = conserve_functions(expression, operands, new_expr.operands)
+                expression_, operands_ = conserve_functions(
+                    _expression, _operands, new_expr.operands | local_vars
+                )
                 new_expr.expression = f"({expression_})"  # force parenthesis
                 new_expr.expression_tosave = expression
                 new_expr.operands = operands_

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -2678,10 +2678,10 @@ class LazyExpr(LazyArray):
             _dtype = new_expr.dtype
             _shape = new_expr.shape
             if isinstance(new_expr, blosc2.LazyExpr):
-                # Restore the original expression and operands
-                new_expr.expression = f"({_expression})"  # forcibly add parenthesis
+                # DO NOT restore the original expression and operands
+                # new_expr.expression = new_expr.expression}  #don't have to do anything
                 new_expr.expression_tosave = _expression
-                new_expr.operands = _operands
+                # new_expr.operands = new_expr.operands #don't have to do anything
                 new_expr.operands_tosave = operands
             else:
                 # An immediate evaluation happened (e.g. all operands are numpy arrays)

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -630,49 +630,69 @@ def get_expr_operands(expression: str) -> set:
     return set(visitor.operands)
 
 
-def conserve_functions(
-    expression: str,
-    operands_old: dict[str : blosc2.ndarray | blosc2.LazyExpr],
-    operands_new: dict[str : blosc2.ndarray | blosc2.LazyExpr],
-) -> tuple(str, dict[str : blosc2.ndarray.NDArray | blosc2.LazyExpr]):
-    operand_to_key = {id(v): k for k, v in operands_new.items()}
-
-    class OperandVisitor(ast.NodeVisitor):
-        def __init__(self):
-            self.operandset = set()
-            self.operands = {}
-            self.opcounter = 0
-            self.function_names = set()
-
-        def visit_Name(self, node):
-            if node.id == "np":
-                # Skip NumPy namespace (e.g. np.int8, which will be treated separately)
-                return
-            if node.id in self.function_names:
-                # Skip function names
-                return
-            elif (node.id not in dtype_symbols) and (node.id not in self.operandset):
-                k = operand_to_key[id(operands_old[node.id])]
-                newkey = f"o{self.opcounter}"
-                self.operands[newkey] = operands_new[k]
-                node.id = newkey
-                self.operandset.add(node.id)
-                self.opcounter += 1
-            else:
-                pass
-            self.generic_visit(node)
-
-        def visit_Call(self, node):
-            if isinstance(
-                node.func, ast.Name
-            ):  # visits Call first, then Name, so don't increment operandcounter yet
-                self.function_names.add(node.func.id)
-            self.generic_visit(node)
-
-    tree = ast.parse(expression)
-    visitor = OperandVisitor()
-    visitor.visit(tree)
-    return ast.unparse(tree), visitor.operands
+#
+# def cons_functions(
+#     expression: str,
+#     operands_old: dict[str : blosc2.ndarray | blosc2.LazyExpr],
+#     operands_new: dict[str : blosc2.ndarray | blosc2.LazyExpr],
+# ) -> tuple(str, dict[str : blosc2.ndarray.NDArray | blosc2.LazyExpr]):
+#     operand_to_key = {id(v): k for k, v in operands_new.items()}
+#     for k, v in operands_old.items():  # extend operands_to_key with old operands
+#         try:
+#             operand_to_key[id(v)]
+#         except KeyError:
+#             operand_to_key[id(v)] = k
+#             operands_new[k] = v
+#
+#     class OperandVisitor(ast.NodeVisitor):
+#         def __init__(self):
+#             self.operandmap = {}
+#             self.operands = {}
+#             self.opcounter = 0
+#             self.function_names = set()
+#
+#         def update_func(self, localop):
+#             k = operand_to_key[id(localop)]
+#             if k not in self.operandmap:
+#                 newkey = f"o{self.opcounter}"
+#                 self.operands[newkey] = operands_new[k]
+#                 self.operandmap[k] = newkey
+#                 self.opcounter += 1
+#                 return newkey
+#             else:
+#                 return self.operandmap[k]
+#
+#         def visit_Name(self, node):
+#             if node.id == "np":  # Skip NumPy namespace (e.g. np.int8, which will be treated separately)
+#                 return
+#             if node.id in self.function_names:  # Skip function names
+#                 return
+#             elif node.id not in dtype_symbols:
+#                 localop = operands_old[node.id]
+#                 if isinstance(localop, blosc2.LazyExpr):
+#                     for (
+#                         _,
+#                         v,
+#                     ) in localop.operands.items():  # expression operands already in terms of basic operands
+#                         _ = self.update_func(v)
+#                     node.id = localop.expression
+#                 else:
+#                     node.id = self.update_func(localop)
+#             else:
+#                 pass
+#             self.generic_visit(node)
+#
+#         def visit_Call(self, node):
+#             if isinstance(
+#                 node.func, ast.Name
+#             ):  # visits Call first, then Name, so don't increment operandcounter yet
+#                 self.function_names.add(node.func.id)
+#             self.generic_visit(node)
+#
+#     tree = ast.parse(expression)
+#     visitor = OperandVisitor()
+#     visitor.visit(tree)
+#     return ast.unparse(tree), visitor.operands
 
 
 class TransformNumpyCalls(ast.NodeTransformer):
@@ -2725,12 +2745,12 @@ class LazyExpr(LazyArray):
             if isinstance(new_expr, blosc2.LazyExpr):
                 # DO NOT restore the original expression and operands
                 # Instead rebase operands and restore only constructors
-                expression_, operands_ = conserve_functions(
-                    _expression, _operands, new_expr.operands | local_vars
-                )
-                new_expr.expression = f"({expression_})"  # force parenthesis
+                # expression_, operands_ = cons_functions(
+                #     _expression, _operands, new_expr.operands | local_vars
+                # )
+                # new_expr.expression = f"({expression_})"  # force parenthesis
                 new_expr.expression_tosave = expression
-                new_expr.operands = operands_
+                # new_expr.operands = operands_
                 new_expr.operands_tosave = operands
             else:
                 # An immediate evaluation happened (e.g. all operands are numpy arrays)

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1364,6 +1364,14 @@ def test_chain_expressions():
     le4_ = blosc2.lazyexpr("(le2 & le3)", {"le2": le2_, "le3": le3_})
     assert (le4_[:] == le4[:]).all()
 
+    expr1 = blosc2.lazyexpr("arange(N) + b")
+    expr2 = blosc2.lazyexpr("a * b + 1")
+    expr = blosc2.lazyexpr("expr1 - expr2")
+    expr_final = blosc2.lazyexpr("expr * expr")
+    nres = (expr * expr)[:]
+    res = expr_final.compute()
+    np.testing.assert_allclose(res[:], nres)
+
 
 # Test the chaining of multiple persistent lazy expressions
 def test_chain_persistentexpressions():

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1364,13 +1364,14 @@ def test_chain_expressions():
     le4_ = blosc2.lazyexpr("(le2 & le3)", {"le2": le2_, "le3": le3_})
     assert (le4_[:] == le4[:]).all()
 
-    expr1 = blosc2.lazyexpr("arange(N) + b")
-    expr2 = blosc2.lazyexpr("a * b + 1")
-    expr = blosc2.lazyexpr("expr1 - expr2")
-    expr_final = blosc2.lazyexpr("expr * expr")
-    nres = (expr * expr)[:]
-    res = expr_final.compute()
-    np.testing.assert_allclose(res[:], nres)
+    # TODO: Eventually this test should pass
+    # expr1 = blosc2.lazyexpr("arange(N) + b")
+    # expr2 = blosc2.lazyexpr("a * b + 1")
+    # expr = blosc2.lazyexpr("expr1 - expr2")
+    # expr_final = blosc2.lazyexpr("expr * expr")
+    # nres = (expr * expr)[:]
+    # res = expr_final.compute()
+    # np.testing.assert_allclose(res[:], nres)
 
 
 # Test the chaining of multiple persistent lazy expressions

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1354,45 +1354,43 @@ def test_chain_expressions():
     le3_ = blosc2.lazyexpr("(le2 & (b < 0))", {"le2": le2_, "b": b})
     assert (le3_[:] == le3[:]).all()
 
-    # TODO: This test should pass eventually
-    # le1 = a ** 3 + blosc2.sin(a ** 2)
-    # le2 = le1 < c
-    # le3 = (b < 0)
-    # le4 = le2 & le3
-    # le1_ = blosc2.lazyexpr("a ** 3 + sin(a ** 2)", {"a": a})
-    # le2_ = blosc2.lazyexpr("(le1 < c)", {"le1": le1_, "c": c})
-    # le3_ = blosc2.lazyexpr("(b < 0)", {"b": b})
-    # le4_ = blosc2.lazyexpr("(le2 & le3)", {"le2": le2_, "le3": le3_})
-    # assert (le4_[:] == le4[:]).all()
+    le1 = a**3 + blosc2.sin(a**2)
+    le2 = le1 < c
+    le3 = b < 0
+    le4 = le2 & le3
+    le1_ = blosc2.lazyexpr("a ** 3 + sin(a ** 2)", {"a": a})
+    le2_ = blosc2.lazyexpr("(le1 < c)", {"le1": le1_, "c": c})
+    le3_ = blosc2.lazyexpr("(b < 0)", {"b": b})
+    le4_ = blosc2.lazyexpr("(le2 & le3)", {"le2": le2_, "le3": le3_})
+    assert (le4_[:] == le4[:]).all()
 
 
-# TODO: Test the chaining of multiple persistent lazy expressions
-# def test_chain_persistentexpressions():
-#     N = 1_000
-#     dtype = "float64"
-#     a = blosc2.linspace(0, 1, N * N, dtype=dtype, shape=(N, N), urlpath="a.b2nd", mode="w")
-#     b = blosc2.linspace(1, 2, N * N, dtype=dtype, shape=(N, N), urlpath="b.b2nd", mode="w")
-#     c = blosc2.linspace(0, 1, N, dtype=dtype, shape=(N,), urlpath="c.b2nd", mode="w")
-#
-#     le1 = a ** 3 + blosc2.sin(a ** 2)
-#     le2 = le1 < c
-#     le3 = (b < 0)
-#     le4 = le2 & le3
-#
-#     le1_ = blosc2.lazyexpr("a ** 3 + sin(a ** 2)", {"a": a})
-#     le1_.save("expr1.b2nd", mode="w")
-#     myle1 = blosc2.open("expr1.b2nd")
-#
-#     le2_ = blosc2.lazyexpr("(le1 < c)", {"le1": myle1, "c": c})
-#     le2_.save("expr2.b2nd", mode="w")
-#     myle2 = blosc2.open("expr2.b2nd")
-#
-#     le3_ = blosc2.lazyexpr("(b < 0)", {"b": b})
-#     le3_.save("expr3.b2nd", mode="w")
-#     myle3 = blosc2.open("expr3.b2nd")
-#
-#     le4_ = blosc2.lazyexpr("(le2 & le3)", {"le2": myle2, "le3": myle3})
-#     le4_.save("expr4.b2nd", mode="w")
-#     myle4 = blosc2.open("expr4.b2nd")
-#     print((myle4[:] == le4[:]).all())
-#
+# Test the chaining of multiple persistent lazy expressions
+def test_chain_persistentexpressions():
+    N = 1_000
+    dtype = "float64"
+    a = blosc2.linspace(0, 1, N * N, dtype=dtype, shape=(N, N), urlpath="a.b2nd", mode="w")
+    b = blosc2.linspace(1, 2, N * N, dtype=dtype, shape=(N, N), urlpath="b.b2nd", mode="w")
+    c = blosc2.linspace(0, 1, N, dtype=dtype, shape=(N,), urlpath="c.b2nd", mode="w")
+
+    le1 = a**3 + blosc2.sin(a**2)
+    le2 = le1 < c
+    le3 = b < 0
+    le4 = le2 & le3
+
+    le1_ = blosc2.lazyexpr("a ** 3 + sin(a ** 2)", {"a": a})
+    le1_.save("expr1.b2nd", mode="w")
+    myle1 = blosc2.open("expr1.b2nd")
+
+    le2_ = blosc2.lazyexpr("(le1 < c)", {"le1": myle1, "c": c})
+    le2_.save("expr2.b2nd", mode="w")
+    myle2 = blosc2.open("expr2.b2nd")
+
+    le3_ = blosc2.lazyexpr("(b < 0)", {"b": b})
+    le3_.save("expr3.b2nd", mode="w")
+    myle3 = blosc2.open("expr3.b2nd")
+
+    le4_ = blosc2.lazyexpr("(le2 & le3)", {"le2": myle2, "le3": myle3})
+    le4_.save("expr4.b2nd", mode="w")
+    myle4 = blosc2.open("expr4.b2nd")
+    assert (myle4[:] == le4[:]).all()


### PR DESCRIPTION
Expand possibilities for chaining string-based lazy expressions to include main operand types (LazyExpr and NDArray). Have to incorporate other data types (which do not have shape attribute, e.g. int, float etc.) in future PR - see #406 .