### PR TITLE
Add slicing to string lazyexprs

### DIFF
--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -116,7 +116,7 @@ dtype_symbols = {
 constructors = ("arange", "linspace", "fromiter", "zeros", "ones", "empty", "full", "frombuffer")
 # Note that, as reshape is accepted as a method too, it should always come last in the list
 constructors += ("reshape",)
-reducers = ("sum", "prod", "min", "max", "std", "mean", "var", "any", "all")
+reducers = ("sum", "prod", "min", "max", "std", "mean", "var", "any", "all", "slice")
 
 functions = [
     "sin",
@@ -551,7 +551,20 @@ validation_patterns = [
 _blacklist_re = re.compile("|".join(validation_patterns))
 
 # Define valid method names
-valid_methods = {"sum", "prod", "min", "max", "std", "mean", "var", "any", "all", "where", "reshape"}
+valid_methods = {
+    "sum",
+    "prod",
+    "min",
+    "max",
+    "std",
+    "mean",
+    "var",
+    "any",
+    "all",
+    "where",
+    "reshape",
+    "slice",
+}
 valid_methods |= {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}
 valid_methods |= {"float32", "float64", "complex64", "complex128"}
 valid_methods |= {"bool", "str", "bytes"}
@@ -2534,6 +2547,7 @@ class LazyExpr(LazyArray):
     def _compute_expr(self, item, kwargs):  # noqa: C901
         if any(method in self.expression for method in reducers):
             # We have reductions in the expression (probably coming from a string lazyexpr)
+            # Also includes slice
             _globals = get_expr_globals(self.expression)
             lazy_expr = eval(self.expression, _globals, self.operands)
             if not isinstance(lazy_expr, blosc2.LazyExpr):

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -541,7 +541,6 @@ def compute_smaller_slice(larger_shape, smaller_shape, larger_slice):
 
 # Define the patterns for validation
 validation_patterns = [
-    # r"[\;\[\:]",  # Flow control characters
     r"[\;]",  # Flow control characters
     r"(^|[^\w])__[\w]+__($|[^\w])",  # Dunder methods
     r"\.\b(?!real|imag|(\d*[eE]?[+-]?\d+)|(\d*[eE]?[+-]?\d+j)|\d*j\b|(sum|prod|min|max|std|mean|var|any|all|where)"
@@ -747,7 +746,8 @@ def conserve_functions(  # noqa: C901
 
 def convert_to_slice(expression):
     """
-    Assumes all operands are of the form o...
+    Takes expression and converts all instances of [] to .slice(....)
+
     Parameters
     ----------
     expression: str
@@ -770,6 +770,8 @@ def convert_to_slice(expression):
             if any(isinstance(el, str) for el in slicer):  # handle fields
                 raise ValueError("Cannot handle fields for slicing lazy expressions.")
             slicer = str(slicer)
+            # use slice so that lazyexpr uses blosc arrays internally
+            # (and doesn't decompress according to getitem syntax)
             new_expr += ".slice(" + slicer + ")"
             skip_to_char = i + k + 1
         else:

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -430,9 +430,25 @@ def test_reduction_index():
     assert arr.shape == newarr.shape
 
 
-def test_slice_in_lazy():
+def test_slice_lazy():
     shape = (20, 20)
     a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
     arr = blosc2.lazyexpr("anarr.slice(slice(10,15)) + 1", {"anarr": a})
     newarr = arr.compute()
     np.testing.assert_allclose(newarr[:], a.slice(slice(10, 15))[:] + 1)
+
+
+def test_slicebrackets_lazy():
+    shape = (20, 20)
+    a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
+    arr = blosc2.lazyexpr("anarr[10:15] + 1", {"anarr": a})
+    newarr = arr.compute()
+    np.testing.assert_allclose(newarr[:], a[10:15] + 1)
+
+    arr = blosc2.lazyexpr("anarr[10:15, 2:9] + 1", {"anarr": a})
+    newarr = arr.compute()
+    np.testing.assert_allclose(newarr[:], a[10:15, 2:9] + 1)
+
+    arr = blosc2.lazyexpr("anarr[10:15][2:9] + 1", {"anarr": a})
+    newarr = arr.compute()
+    np.testing.assert_allclose(newarr[:], a[10:15][2:9] + 1)

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -445,6 +445,13 @@ def test_slicebrackets_lazy():
     newarr = arr.compute()
     np.testing.assert_allclose(newarr[:], a[10:15] + 1)
 
+    # Try with getitem
+    a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
+    arr = blosc2.lazyexpr("anarr[10:15] + 1", {"anarr": a})
+    newarr = arr[:3]
+    res = a[10:15] + 1
+    np.testing.assert_allclose(newarr, res[:3])
+
     arr = blosc2.lazyexpr("anarr[10:15, 2:9] + 1", {"anarr": a})
     newarr = arr.compute()
     np.testing.assert_allclose(newarr[:], a[10:15, 2:9] + 1)

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -428,3 +428,11 @@ def test_reduction_index():
     assert arr[:10].shape == (10,)
     assert arr[0].shape == (1,)
     assert arr.shape == newarr.shape
+
+
+def test_slice_in_lazy():
+    shape = (20, 20)
+    a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
+    arr = blosc2.lazyexpr("anarr.slice(slice(10,15)) + 1", {"anarr": a})
+    newarr = arr.compute()
+    np.testing.assert_allclose(newarr[:], a.slice(slice(10, 15))[:] + 1)


### PR DESCRIPTION
Solves #412. For []-indxeing, converts internally to .slice to avoid decompressing and then recompressing for .compute function.