### PR TITLE
Fixed bug for integer indexes

### DIFF
--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -766,7 +766,7 @@ def convert_to_slice(expression):
             k = expression[i:].find("]")  # start checking from after [
             slice_convert = expression[i : i + k + 1]  # include [ and ]
             slicer = eval(f"np.s_{slice_convert}")
-            slicer = (slicer,) if isinstance(slicer, slice) else slicer  # standardise to tuple
+            slicer = (slicer,) if not isinstance(slicer, tuple) else slicer  # standardise to tuple
             if any(isinstance(el, str) for el in slicer):  # handle fields
                 raise ValueError("Cannot handle fields for slicing lazy expressions.")
             slicer = str(slicer)

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -452,6 +452,7 @@ def test_slicebrackets_lazy():
     res = a[10:15] + 1
     np.testing.assert_allclose(newarr, res[:3])
 
+    # Test other cases
     arr = blosc2.lazyexpr("anarr[10:15, 2:9] + 1", {"anarr": a})
     newarr = arr.compute()
     np.testing.assert_allclose(newarr[:], a[10:15, 2:9] + 1)
@@ -459,3 +460,11 @@ def test_slicebrackets_lazy():
     arr = blosc2.lazyexpr("anarr[10:15][2:9] + 1", {"anarr": a})
     newarr = arr.compute()
     np.testing.assert_allclose(newarr[:], a[10:15][2:9] + 1)
+
+    arr = blosc2.lazyexpr("anarr[10] + 1", {"anarr": a})
+    newarr = arr.compute()
+    np.testing.assert_allclose(newarr[:], a[10] + 1)
+
+    arr = blosc2.lazyexpr("anarr[10, 1] + 1", {"anarr": a})
+    newarr = arr[:]
+    np.testing.assert_allclose(newarr, a[10, 1] + 1)


### PR DESCRIPTION
Since np.s_[1] does not return a slice object, but rather an integer, the code failed for cases such as this. Now fixed.