### PR TITLE
Fix lazyexpr o0 bug to pass test

### DIFF
--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -719,11 +719,13 @@ def conserve_functions(  # noqa: C901
                         opname,
                         v,
                     ) in localop.operands.items():  # expression operands already in terms of basic operands
-                        newopname = ";" + self.update_func(v)  # add illegal character ;
+                        # add illegal character ; to track changed operands and not overwrite later
+                        newopname = ";" + self.update_func(v)
                         newexpr = re.sub(
                             rf"(?<=\s){opname}|(?<=\(){opname}", newopname, newexpr
                         )  # replace with newopname
-                    node.id = newexpr.replace(";", "")  # remove all illegal characters
+                    # remove all instances of ; as all changes completed
+                    node.id = newexpr.replace(";", "")
                 else:
                     node.id = self.update_func(localop)
             else:

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -719,11 +719,11 @@ def conserve_functions(  # noqa: C901
                         opname,
                         v,
                     ) in localop.operands.items():  # expression operands already in terms of basic operands
-                        newopname = self.update_func(v)
+                        newopname = ";" + self.update_func(v)  # add illegal character ;
                         newexpr = re.sub(
                             rf"(?<=\s){opname}|(?<=\(){opname}", newopname, newexpr
                         )  # replace with newopname
-                    node.id = newexpr
+                    node.id = newexpr.replace(";", "")  # remove all illegal characters
                 else:
                     node.id = self.update_func(localop)
             else:


### PR DESCRIPTION
Resolves #415. The problem was in the conserve_functions function when looping over the operands of a lazyexpr which contains operands already labelled using the o- convention. Adding an illegal character to keep track of already changed operands, and then removing, solves the problem.