### PR TITLE
Add support for new pandas UDF engine

### DIFF
--- a/src/blosc2/proxy.py
+++ b/src/blosc2/proxy.py
@@ -720,7 +720,7 @@ class PandasUdfEngine:
             for row_idx in range(data.shape[1]):
                 result.append(func(data[:, row_idx], *args, **kwargs))
             return np.vstack(result).transpose()
-        elif axis == (1, "columns"):
+        elif axis in (1, "columns"):
             # pandas apply(axis=1) row-wise
             result = []
             for col_idx in range(data.shape[0]):

--- a/src/blosc2/proxy.py
+++ b/src/blosc2/proxy.py
@@ -713,13 +713,7 @@ class PandasUdfEngine:
         """
         data = cls._ensure_numpy_data(data)
         func = decorator(func)
-        if data.ndim in (1, 2):
-            return func(data, *args, **kwargs)
-        else:
-            raise NotImplementedError(
-                "The blosc2 engine only supports data with with 1 or 2 dimensions. "
-                f"A NumPy array with {data.ndim} dimensions has been received."
-            )
+        return func(data, *args, **kwargs)
 
 
 jit.__pandas_udf__ = PandasUdfEngine

--- a/tests/test_pandas_udf_engine.py
+++ b/tests/test_pandas_udf_engine.py
@@ -1,0 +1,125 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+import numpy as np
+
+import blosc2
+
+
+class TestPandasUDF:
+    def test_map_1d(self):
+        def add_one(x):
+            return x + 1
+
+        data = np.array([1, 2])
+
+        result = blosc2.jit.__pandas_udf__.map(
+            data,
+            add_one,
+            args=(),
+            kwargs={},
+            decorator=blosc2.jit,
+            skip_na=False,
+        )
+        assert result.shape == (2,)
+        assert result[0] == 2
+        assert result[1] == 3
+
+    def test_map_1d_with_args(self):
+        def add_numbers(x, num1, num2):
+            return x + num1 + num2
+
+        data = np.array([1, 2])
+
+        result = blosc2.jit.__pandas_udf__.map(
+            data,
+            add_numbers,
+            args=(10,),
+            kwargs={"num2": 100},
+            decorator=blosc2.jit,
+            skip_na=False,
+        )
+        assert result.shape == (2,)
+        assert result[0] == 111
+        assert result[1] == 112
+
+    def test_map_2d(self):
+        def add_one(x):
+            return x + 1
+
+        data = np.array([[1, 2], [3, 4]])
+
+        result = blosc2.jit.__pandas_udf__.map(
+            data,
+            add_one,
+            args=(),
+            kwargs={},
+            decorator=blosc2.jit,
+            skip_na=False,
+        )
+        assert result.shape == (2, 2)
+        assert result[0, 0] == 2
+        assert result[0, 1] == 3
+        assert result[1, 0] == 4
+        assert result[1, 1] == 5
+
+    def test_apply_1d(self):
+        def add_one(x):
+            return x + 1
+
+        data = np.array([1, 2])
+
+        result = blosc2.jit.__pandas_udf__.apply(
+            data,
+            add_one,
+            args=(),
+            kwargs={},
+            decorator=blosc2.jit,
+            axis=0,
+        )
+        assert result.shape == (2,)
+        assert result[0] == 2
+        assert result[1] == 3
+
+    def test_apply_1d_with_args(self):
+        def add_numbers(x, num1, num2):
+            return x + num1 + num2
+
+        data = np.array([1, 2])
+
+        result = blosc2.jit.__pandas_udf__.apply(
+            data,
+            add_numbers,
+            args=(10,),
+            kwargs={"num2": 100},
+            decorator=blosc2.jit,
+            axis=0,
+        )
+        assert result.shape == (2,)
+        assert result[0] == 111
+        assert result[1] == 112
+
+    def test_apply_2d(self):
+        def add_one(x):
+            return x + 1
+
+        data = np.array([[1, 2], [3, 4]])
+
+        result = blosc2.jit.__pandas_udf__.apply(
+            data,
+            add_one,
+            args=(),
+            kwargs={},
+            decorator=blosc2.jit,
+            axis=0,
+        )
+        assert result.shape == (2, 2)
+        assert result[0, 0] == 2
+        assert result[0, 1] == 3
+        assert result[1, 0] == 4
+        assert result[1, 1] == 5

--- a/tests/test_pandas_udf_engine.py
+++ b/tests/test_pandas_udf_engine.py
@@ -7,66 +7,27 @@
 #######################################################################
 
 import numpy as np
+import pytest
 
 import blosc2
 
 
 class TestPandasUDF:
-    def test_map_1d(self):
+    def test_map(self):
         def add_one(x):
             return x + 1
 
         data = np.array([1, 2])
 
-        result = blosc2.jit.__pandas_udf__.map(
-            data,
-            add_one,
-            args=(),
-            kwargs={},
-            decorator=blosc2.jit,
-            skip_na=False,
-        )
-        assert result.shape == (2,)
-        assert result[0] == 2
-        assert result[1] == 3
-
-    def test_map_1d_with_args(self):
-        def add_numbers(x, num1, num2):
-            return x + num1 + num2
-
-        data = np.array([1, 2])
-
-        result = blosc2.jit.__pandas_udf__.map(
-            data,
-            add_numbers,
-            args=(10,),
-            kwargs={"num2": 100},
-            decorator=blosc2.jit,
-            skip_na=False,
-        )
-        assert result.shape == (2,)
-        assert result[0] == 111
-        assert result[1] == 112
-
-    def test_map_2d(self):
-        def add_one(x):
-            return x + 1
-
-        data = np.array([[1, 2], [3, 4]])
-
-        result = blosc2.jit.__pandas_udf__.map(
-            data,
-            add_one,
-            args=(),
-            kwargs={},
-            decorator=blosc2.jit,
-            skip_na=False,
-        )
-        assert result.shape == (2, 2)
-        assert result[0, 0] == 2
-        assert result[0, 1] == 3
-        assert result[1, 0] == 4
-        assert result[1, 1] == 5
+        with pytest.raises(NotImplementedError):
+            blosc2.jit.__pandas_udf__.map(
+                data,
+                add_one,
+                args=(),
+                kwargs={},
+                decorator=blosc2.jit,
+                skip_na=False,
+            )
 
     def test_apply_1d(self):
         def add_one(x):
@@ -106,9 +67,28 @@ class TestPandasUDF:
 
     def test_apply_2d(self):
         def add_one(x):
+            assert x.shape == (2, 3)
             return x + 1
 
-        data = np.array([[1, 2], [3, 4]])
+        data = np.array([[1, 2, 3], [4, 5, 6]])
+
+        result = blosc2.jit.__pandas_udf__.apply(
+            data,
+            add_one,
+            args=(),
+            kwargs={},
+            decorator=blosc2.jit,
+            axis=None,
+        )
+        expected = np.array([[2, 3, 4], [5, 6, 7]])
+        assert np.array_equal(result, expected)
+
+    def test_apply_2d_by_column(self):
+        def add_one(x):
+            assert x.shape == (2,)
+            return x + 1
+
+        data = np.array([[1, 2, 3], [4, 5, 6]])
 
         result = blosc2.jit.__pandas_udf__.apply(
             data,
@@ -118,8 +98,23 @@ class TestPandasUDF:
             decorator=blosc2.jit,
             axis=0,
         )
-        assert result.shape == (2, 2)
-        assert result[0, 0] == 2
-        assert result[0, 1] == 3
-        assert result[1, 0] == 4
-        assert result[1, 1] == 5
+        expected = np.array([[2, 3, 4], [5, 6, 7]])
+        assert np.array_equal(result, expected)
+
+    def test_apply_2d_by_row(self):
+        def add_one(x):
+            assert x.shape == (3,)
+            return x + 1
+
+        data = np.array([[1, 2, 3], [4, 5, 6]])
+
+        result = blosc2.jit.__pandas_udf__.apply(
+            data,
+            add_one,
+            args=(),
+            kwargs={},
+            decorator=blosc2.jit,
+            axis=1,
+        )
+        expected = np.array([[2, 3, 4], [5, 6, 7]])
+        assert np.array_equal(result, expected)


### PR DESCRIPTION
Closes #383 

With these changes, it'll be possible to do things like this with pandas and blosc2:

```python
import pandas
import blosc2

def my_func(x):
    return np.sin(x * 2)

s = pandas.Series([1, 2, 3], index=list('abc'), name='sample')

# blosc2 will jit the function
print(s.map(my_func, engine=blosc2.jit))
```

In this PR I'm assuming that `blosc2.jit` is intended to be used with vectorized numpy operations. If that's not the case, and you want to support scalar functions and jit Python loops (see example below), let me know and we can implement this for map:

```python

@blosc2.jit
def my_func(array):
    for item in array:
        scalar_udf(item)
```

Also, `apply` is designed in pandas to call the udf for each column or row in a dataframe. I'm passing the whole array since it's a numpy array and I think operations should be vectorized, but I can make it work by columns or rows.