### PR TITLE
Make behaviour of compute consistent for slicing

### DIFF
--- a/examples/ndarray/lazyexpr_where_indexing.py
+++ b/examples/ndarray/lazyexpr_where_indexing.py
@@ -1,0 +1,42 @@
+# Imports
+
+import numpy as np
+
+import blosc2
+
+N = 1000
+it = ((-x + 1, x - 2, 0.1 * x) for x in range(N))
+sa = blosc2.fromiter(
+    it, dtype=[("A", "i4"), ("B", "f4"), ("C", "f8")], shape=(N,), urlpath="sa-1M.b2nd", mode="w"
+)
+expr = sa["(A < B)"]
+A = sa["A"][:]
+B = sa["B"][:]
+C = sa["C"][:]
+temp = sa[:]
+indices = A < B
+idx = np.argmax(indices)
+
+# One might think that expr[:10] gives the first 10 elements of the evaluated expression, but this is not the case.
+# It actually computes the expression on the first 10 elements of the operands; since for some elements the condition
+# is False, the result will be shorter than 10 elements.
+# Returns less than 10 elements in general
+sliced = expr.compute(slice(0, 10))
+gotitem = expr[:10]
+np.testing.assert_array_equal(sliced[:], gotitem)
+np.testing.assert_array_equal(gotitem, temp[:10][indices[:10]])  # Equivalent syntax
+# Actually this makes sense since one can understand this as a request to compute on a portion of operands.
+# If one desires a portion of the result, one should compute the whole expression and then slice it.
+
+# Get first element for which condition is true
+sliced = expr.compute(idx)
+gotitem = expr[idx]
+# Arrays of one element
+np.testing.assert_array_equal(sliced[()], gotitem)
+np.testing.assert_array_equal(gotitem, temp[idx])
+
+# Should return void arrays here.
+sliced = expr.compute(0)
+gotitem = expr[0]
+np.testing.assert_array_equal(sliced[()], gotitem)
+np.testing.assert_array_equal(gotitem, temp[0])

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1378,7 +1378,7 @@ def slices_eval(  # noqa: C901
             for i, (c, s) in enumerate(zip(coords, chunks, strict=True))
         )
         # Check whether current slice_ intersects with _slice
-        if _slice is not None and _slice != ():  # can't use != when _slice is np.int
+        if _slice is not None and _slice is not ():  # noqa: F632  # can't use != when _slice is np.int
             # Ensure that _slice is of type slice
             key = ndindex.ndindex(_slice).expand(shape).raw
             _slice = tuple(k if isinstance(k, slice) else slice(k, k + 1, None) for k in key)

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -279,7 +279,8 @@ class LazyArray(ABC):
         ----------
         item: slice, list of slices, optional
             If not None, only the chunks that intersect with the slices
-            in items will be evaluated.
+            in item will be evaluated. If provided, items of the operands to be used in computation.
+            Important to note that item is used to slice the operands PRIOR to computation.
 
         kwargs: Any, optional
             Keyword arguments that are supported by the :func:`empty` constructor.
@@ -328,7 +329,9 @@ class LazyArray(ABC):
         Parameters
         ----------
         item: int, slice or sequence of slices
-            The slice(s) to be retrieved. Note that step parameter is not yet honored.
+            If provided, items of the operands to be used in computation.
+            Important to note that item is used to slice the operands PRIOR to computation, not to retrieve specified
+            slices of the evaluated result.
 
         Returns
         -------
@@ -2689,21 +2692,6 @@ class LazyExpr(LazyArray):
         return lazy_expr
 
     def compute(self, item=None, **kwargs) -> blosc2.NDArray:
-        """
-        Compute the expression with the given item and kwargs.
-        Parameters
-        ----------
-        item: int, slice or sequence of slices, optional
-            The slice(s) of the operands to be used in computation. Note that step parameter is not honored yet.
-            Item is used to slice the operands PRIOR to computation.
-        kwargs
-
-        Returns:
-        blosc2.NDArray or numpy.ndarray
-        -------
-
-        """
-
         # When NumPy ufuncs are called, the user may add an `out` parameter to kwargs
         if "out" in kwargs:
             kwargs["_output"] = kwargs.pop("out")
@@ -2738,17 +2726,6 @@ class LazyExpr(LazyArray):
         return result
 
     def __getitem__(self, item):
-        """
-        Apply LazyExpr on a slice of the oeprands.
-        Parameters
-        ----------
-        item: int, slice or sequence of slices, optional
-            The slice(s) of the operands to be used in computation. Note that step parameter is not honored yet.
-            Item is used to slice the operands PRIOR to computation.
-        Returns:
-        numpy.ndarray
-        """
-
         kwargs = {"_getitem": True}
         return self.compute(item, **kwargs)
 

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1378,7 +1378,7 @@ def slices_eval(  # noqa: C901
             for i, (c, s) in enumerate(zip(coords, chunks, strict=True))
         )
         # Check whether current slice_ intersects with _slice
-        if _slice is not None and _slice is not ():  # noqa: F632  # can't use != when _slice is np.int
+        if _slice is not None and np.any(_slice != ()):  # can't use != when _slice is np.int
             # Ensure that _slice is of type slice
             key = ndindex.ndindex(_slice).expand(shape).raw
             _slice = tuple(k if isinstance(k, slice) else slice(k, k + 1, None) for k in key)

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1378,7 +1378,8 @@ def slices_eval(  # noqa: C901
             for i, (c, s) in enumerate(zip(coords, chunks, strict=True))
         )
         # Check whether current slice_ intersects with _slice
-        if _slice is not None and np.any(_slice != ()):  # can't use != when _slice is np.int
+        checker = _slice.item() if hasattr(_slice, "item") else _slice  # can't use != when _slice is np.int
+        if checker is not None and checker != ():
             # Ensure that _slice is of type slice
             key = ndindex.ndindex(_slice).expand(shape).raw
             _slice = tuple(k if isinstance(k, slice) else slice(k, k + 1, None) for k in key)

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -278,9 +278,9 @@ class LazyArray(ABC):
         Parameters
         ----------
         item: slice, list of slices, optional
-            If not None, only the chunks that intersect with the slices
-            in item will be evaluated. If provided, items of the operands to be used in computation.
-            Important to note that item is used to slice the operands PRIOR to computation.
+            If provided, item is used to slice the operands *prior* to computation; not to retrieve specified slices of
+            the evaluated result. This difference between slicing operands and slicing the final expression
+            is important when reductions or a where clause are used in the expression.
 
         kwargs: Any, optional
             Keyword arguments that are supported by the :func:`empty` constructor.
@@ -329,9 +329,9 @@ class LazyArray(ABC):
         Parameters
         ----------
         item: int, slice or sequence of slices
-            If provided, items of the operands to be used in computation.
-            Important to note that item is used to slice the operands PRIOR to computation, not to retrieve specified
-            slices of the evaluated result.
+            If provided, item is used to slice the operands *prior* to computation; not to retrieve specified slices of
+            the evaluated result. This difference between slicing operands and slicing the final expression
+            is important when reductions or a where clause are used in the expression.
 
         Returns
         -------

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1829,7 +1829,8 @@ def chunked_eval(  # noqa: C901
     operands: dict
         A dictionary containing the operands for the expression.
     item: int, slice or sequence of slices, optional
-        The slice(s) to be retrieved. Note that step parameter is not honored yet.
+        The slice(s) of the operands to be used in computation. Note that step parameter is not honored yet.
+        Item is used to slice the operands PRIOR to computation.
     kwargs: Any, optional
         Additional keyword arguments supported by the :func:`empty` constructor.  In addition,
         the following keyword arguments are supported:
@@ -2688,6 +2689,21 @@ class LazyExpr(LazyArray):
         return lazy_expr
 
     def compute(self, item=None, **kwargs) -> blosc2.NDArray:
+        """
+        Compute the expression with the given item and kwargs.
+        Parameters
+        ----------
+        item: int, slice or sequence of slices, optional
+            The slice(s) of the operands to be used in computation. Note that step parameter is not honored yet.
+            Item is used to slice the operands PRIOR to computation.
+        kwargs
+
+        Returns:
+        blosc2.NDArray or numpy.ndarray
+        -------
+
+        """
+
         # When NumPy ufuncs are called, the user may add an `out` parameter to kwargs
         if "out" in kwargs:
             kwargs["_output"] = kwargs.pop("out")
@@ -2722,6 +2738,17 @@ class LazyExpr(LazyArray):
         return result
 
     def __getitem__(self, item):
+        """
+        Apply LazyExpr on a slice of the oeprands.
+        Parameters
+        ----------
+        item: int, slice or sequence of slices, optional
+            The slice(s) of the operands to be used in computation. Note that step parameter is not honored yet.
+            Item is used to slice the operands PRIOR to computation.
+        Returns:
+        numpy.ndarray
+        """
+
         kwargs = {"_getitem": True}
         return self.compute(item, **kwargs)
 


### PR DESCRIPTION
As discussed in #399, there were problems for slicing lazy expressions with one where condition, since the output is in general of a different length to the input.
The .compute function when provided with a slice argument internally takes slices of the operands prior to evaluating the expression. One could change this, but I think it is better to interpret the argument as slicing operands prior to calculation. If one is interested in a general slice of the full result one can always force via expr.compute().slice(sl). 
An unfortunate consequence is that the syntax of the get_item method is a little misleading (hence why I have changed the tests).

expr.compute(sl)[:] is equal to the numpy syntax nsa1[sl][ne_evaluate(expr)[sl]].
