### PR TITLE
Improve mode handling for concatenating to disk

### DIFF
--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -3580,8 +3580,13 @@ def concatenate(arrays: list[NDArray], /, axis=0, **kwargs: Any) -> NDArray:  # 
     kwargs = _check_ndarray_kwargs(**kwargs)
     # Proceed with the actual concatenation
     copy = True
+    # When provided urlpath coincides with an array
+    mode = kwargs.pop("mode", "a")  # default mode for blosc2 is "a"
     for arr2 in arrays[1:]:
-        arr1 = blosc2_ext.concatenate(arr1, arr2, axis, copy=copy, **kwargs)
+        arr1 = blosc2_ext.concatenate(arr1, arr2, axis, copy=copy, mode=mode, **kwargs)
+        # Have now overwritten existing file (if mode ='w'), need to change mode
+        # for concatenating to the same file
+        mode = "r" if mode == "r" else "a"
         # arr1 is now the result of the concatenation, so we can now just enlarge it
         copy = False
 

--- a/tests/ndarray/test_concatenate.py
+++ b/tests/ndarray/test_concatenate.py
@@ -85,6 +85,11 @@ def test_stack(shape, dtype, axis):
     ndarr2 = blosc2.arange(0, int(np.prod(shape)), 1, dtype=dtype, shape=shape)
     ndarr3 = blosc2.arange(0, int(np.prod(shape)), 1, dtype=dtype, shape=shape)
     cparams = blosc2.CParams(codec=blosc2.Codec.BLOSCLZ)
-    result = blosc2.stack([ndarr1, ndarr2, ndarr3], axis=axis, cparams=cparams)
+    result = blosc2.stack(
+        [ndarr1, ndarr2, ndarr3], axis=axis, cparams=cparams, urlpath="localfile.b2nd", mode="w"
+    )
     nparray = np.stack([ndarr1[:], ndarr2[:], ndarr3[:]], axis=axis)
     np.testing.assert_almost_equal(result[:], nparray)
+
+    newres = blosc2.open("localfile.b2nd", mode="r")
+    np.testing.assert_almost_equal(newres[:], nparray)

--- a/tests/ndarray/test_concatenate.py
+++ b/tests/ndarray/test_concatenate.py
@@ -93,3 +93,9 @@ def test_stack(shape, dtype, axis):
 
     newres = blosc2.open("localfile.b2nd", mode="r")
     np.testing.assert_almost_equal(newres[:], nparray)
+
+    # Test overwriting existing file
+    result = blosc2.stack(
+        [ndarr1, ndarr2, ndarr3], axis=axis, cparams=cparams, urlpath="localfile.b2nd", mode="w"
+    )
+    np.testing.assert_almost_equal(result[:], nparray)


### PR DESCRIPTION
When writing to disk, first concatenate must be in write mode, but afterwards in read/write mode.