### PR TITLE
New slices_eval_getitem() for accelerating evals with __getitem__

### DIFF
--- a/bench/ndarray/slice-expr.py
+++ b/bench/ndarray/slice-expr.py
@@ -2,7 +2,8 @@
 import numpy as np
 import blosc2
 import time
-
+from memory_profiler import memory_usage
+import matplotlib.pyplot as plt
 
 file = "dset-ones.b2nd"
 # a = blosc2.open(file)
@@ -25,27 +26,46 @@ expr = a * 2
 print(f"Time to create expression: {time.time() - t:.6f} seconds")
 
 # dim0
-t = time.time()
-res = expr[1]
-t0 = time.time() - t
-print(f"Time to access dim0: {t0:.6f} seconds")
+def slice_dim0():
+    t = time.time()
+    res = expr[1]
+    t0 = time.time() - t
+    print(f"Time to access dim0: {t0:.6f} seconds")
 
 # dim1
-t = time.time()
-res = expr[:,1]
-t1 = time.time() - t
-print(f"Time to access dim1: {t1:.6f} seconds")
+def slice_dim1():
+    t = time.time()
+    res = expr[:,1]
+    t1 = time.time() - t
+    print(f"Time to access dim1: {t1:.6f} seconds")
 
 # dim2
-t = time.time()
-res = expr[:,:,1]
-t2 = time.time() - t
-print(f"Time to access dim2: {t2:.6f} seconds")
+def slice_dim2():
+    t = time.time()
+    res = expr[:,:,1]
+    t2 = time.time() - t
+    print(f"Time to access dim2: {t2:.6f} seconds")
 
 # dim3
-t = time.time()
-res = expr[:,:,:,1]
-#res = expr[1]
-t3 = time.time() - t
+def slice_dim3():
+    t = time.time()
+    res = expr[:,:,:,1]
+    #res = expr[1]
+    t3 = time.time() - t
 
-print(f"Time to access dim3: {t3:.6f} seconds")
+    print(f"Time to access dim3: {t3:.6f} seconds")
+
+fig = plt.figure()
+interval = 0.001
+offset = 0
+for f in [slice_dim0, slice_dim1, slice_dim2, slice_dim3]:
+    mem = memory_usage((f,), interval=interval)
+    times = offset + interval * np.arange(len(mem))
+    offset = times[-1]
+    plt.plot(times, mem)
+
+plt.xlabel('Time (s)')
+plt.ylabel('Memory usage (MiB)')
+plt.title('Memory usage over time for slicing operations, slice-expr.py')
+plt.legend(['dim0', 'dim1', 'dim2', 'dim3'])
+plt.savefig('plots/slice-expr.png', format="png")

--- a/bench/ndarray/slice-expr.py
+++ b/bench/ndarray/slice-expr.py
@@ -1,0 +1,51 @@
+# Imports
+import numpy as np
+import blosc2
+import time
+
+
+file = "dset-ones.b2nd"
+# a = blosc2.open(file)
+# expr = blosc2.where(a < 5, a * 2**14, a)
+d = 200
+shape = (d,) * 4
+chunks = (d // 4,) * 4
+blocks = (d // 10,) * 4
+print(f"Creating a 4D array of shape {shape} with chunks {chunks} and blocks {blocks}...")
+t = time.time()
+#a = blosc2.linspace(0, d, num=d**4, shape=(d,) * 4, blocks=(d//10,) * 4, chunks=(d//2,) * 4, urlpath=file, mode="w")
+#a = blosc2.linspace(0, d, num = d**4, shape=(d,)*4, blocks=(d//10,)*4, chunks=(d//2,)*4)
+# a = blosc2.arange(0, d**4, shape=(d,) * 4, blocks=(d//10,) * 4, chunks=(d//2,) * 4, urlpath=file, mode="w")
+a = blosc2.ones(shape=shape, chunks=chunks, blocks=blocks) #, urlpath=file, mode="w")
+t = time.time() - t
+print(f"Time to create array: {t:.6f} seconds")
+t = time.time()
+#expr = a * 30
+expr = a * 2
+print(f"Time to create expression: {time.time() - t:.6f} seconds")
+
+# dim0
+t = time.time()
+res = expr[1]
+t0 = time.time() - t
+print(f"Time to access dim0: {t0:.6f} seconds")
+
+# dim1
+t = time.time()
+res = expr[:,1]
+t1 = time.time() - t
+print(f"Time to access dim1: {t1:.6f} seconds")
+
+# dim2
+t = time.time()
+res = expr[:,:,1]
+t2 = time.time() - t
+print(f"Time to access dim2: {t2:.6f} seconds")
+
+# dim3
+t = time.time()
+res = expr[:,:,:,1]
+#res = expr[1]
+t3 = time.time() - t
+
+print(f"Time to access dim3: {t3:.6f} seconds")

--- a/bench/ndarray/slice-expr.py
+++ b/bench/ndarray/slice-expr.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 file = "dset-ones.b2nd"
 # a = blosc2.open(file)
 # expr = blosc2.where(a < 5, a * 2**14, a)
-d = 200
+d = 160
 shape = (d,) * 4
 chunks = (d // 4,) * 4
 blocks = (d // 10,) * 4

--- a/src/blosc2/__init__.py
+++ b/src/blosc2/__init__.py
@@ -138,6 +138,11 @@ MAX_BUFFERSIZE = MAX_BUFFERSIZE
 """
 Maximum buffer size in bytes for a Blosc2 chunk."""
 
+MAX_FAST_PATH_SIZE = 2**30
+"""
+Maximum size in bytes for a fast path evaluation.
+"""
+
 MAX_OVERHEAD = MAX_OVERHEAD
 """
 Maximum overhead during compression (in bytes). This is

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1663,6 +1663,7 @@ def slices_eval_getitem(
         ne_args = {}
     where: dict | None = kwargs.pop("_where_args", None)
 
+    dtype = kwargs.pop("dtype", None)
     if out is None:
         # Compute the shape and chunks of the output array, including broadcasting
         shape = compute_broadcast_shape(operands.values())
@@ -1700,7 +1701,7 @@ def slices_eval_getitem(
         result = ne_evaluate(new_expr, slice_operands, **ne_args)
 
     if out is None:  # avoid copying unnecessarily
-        return result
+        return result.astype(dtype, copy=False) if dtype else result
     else:
         out[()] = result
         return out

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1663,7 +1663,6 @@ def slices_eval_getitem(
         ne_args = {}
     where: dict | None = kwargs.pop("_where_args", None)
 
-    dtype = kwargs.pop("dtype", None)
     if out is None:
         # Compute the shape and chunks of the output array, including broadcasting
         shape = compute_broadcast_shape(operands.values())
@@ -1700,11 +1699,11 @@ def slices_eval_getitem(
         new_expr = f"where({expression}, _where_x, _where_y)"
         result = ne_evaluate(new_expr, slice_operands, **ne_args)
 
-    if out is None:
-        out = np.empty(shape=result.shape, dtype=dtype)
-    out[()] = result
-
-    return out
+    if out is None:  # avoid copying unnecessarily
+        return result
+    else:
+        out[()] = result
+        return out
 
 
 def infer_reduction_dtype(dtype, operation):

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1383,263 +1383,6 @@ def slices_eval(  # noqa: C901
     operands: dict
         A dictionary containing the operands for the expression.
     getitem: bool, optional
-        Indicates whether the expression is being evaluated for a getitem operation.
-    _slice: slice, list of slices, optional
-        If provided, only the chunks that intersect with this slice
-        will be evaluated.
-    kwargs: Any, optional
-        Additional keyword arguments that are supported by the :func:`empty` constructor.
-
-    Returns
-    -------
-    :ref:`NDArray` or np.ndarray
-        The output array.
-    """
-    out: blosc2.NDArray | None = kwargs.pop("_output", None)
-    ne_args: dict = kwargs.pop("_ne_args", {})
-    if ne_args is None:
-        ne_args = {}
-    chunks = kwargs.get("chunks")
-    where: dict | None = kwargs.pop("_where_args", None)
-    _indices = kwargs.pop("_indices", False)
-    if _indices and (not where or len(where) != 1):
-        raise NotImplementedError("Indices can only be used with one where condition")
-    _order = kwargs.pop("_order", None)
-    if _order is not None and not isinstance(_order, list):
-        # Always use a list for _order
-        _order = [_order]
-
-    dtype = kwargs.pop("dtype", None)
-    if out is None:
-        # Compute the shape and chunks of the output array, including broadcasting
-        shape = compute_broadcast_shape(operands.values())
-    else:
-        shape = out.shape
-
-    # We need to keep the original _slice arg, for allowing a final getitem (if necessary)
-    orig_slice = _slice
-
-    if chunks is None:
-        # Either out, or operand with `chunks`, can be used to get the chunks
-        operands_ = [o for o in operands.values() if hasattr(o, "chunks") and o.shape == shape]
-        if out is not None and hasattr(out, "chunks"):
-            chunks = out.chunks
-        elif len(operands_) > 0:
-            # Use the first operand with chunks to get the necessary chunking information
-            chunks = operands_[0].chunks
-        else:
-            # Typically, we enter here when using UDFs, and out is a NumPy array.
-            # Use operands to get the shape and chunks
-            # operand will be a 'fake' NDArray just to get the necessary chunking information
-            temp = blosc2.empty(shape, dtype=dtype)
-            chunks = temp.chunks
-            del temp
-
-    # Get the indexes for chunks
-    chunks_idx, nchunks = get_chunks_idx(shape, chunks)
-    # The starting point for the indices of the inputs
-    leninputs = compute_start_index(shape, orig_slice) if orig_slice is not None else 0
-    lenout = 0
-    behaved = False
-    indices_ = None
-    chunk_indices = None
-    dtype_ = np.int64 if _indices else dtype
-    if _order is not None:
-        # Get the dtype of the array to sort
-        dtype_ = operands["_where_x"].dtype
-        # Now, use only the fields that are necessary for the sorting
-        dtype_ = np.dtype([(f, dtype_[f]) for f in _order])
-
-    # Iterate over the operands and get the chunks
-    chunk_operands = {}
-    for nchunk in range(nchunks):
-        coords = tuple(np.unravel_index(nchunk, chunks_idx))
-        # Calculate the shape of the (chunk) slice_ (specially at the end of the array)
-        slice_ = tuple(
-            slice(c * s, min((c + 1) * s, shape[i]))
-            for i, (c, s) in enumerate(zip(coords, chunks, strict=True))
-        )
-        # Check whether current slice_ intersects with _slice
-        checker = _slice.item() if hasattr(_slice, "item") else _slice  # can't use != when _slice is np.int
-        if checker is not None and checker != ():
-            # Ensure that _slice is of type slice
-            key = ndindex.ndindex(_slice).expand(shape).raw
-            _slice = tuple(k if isinstance(k, slice) else slice(k, k + 1, None) for k in key)
-            # Ensure that slices do not have any None as start or stop
-            _slice = tuple(slice(s.start or 0, s.stop or shape[i], s.step) for i, s in enumerate(_slice))
-            slice_ = tuple(slice(s.start or 0, s.stop or shape[i], s.step) for i, s in enumerate(slice_))
-            intersects = do_slices_intersect(_slice, slice_)
-            if not intersects:
-                continue
-            # Compute the part of the slice_ that intersects with _slice
-            slice_ = tuple(
-                slice(max(s1.start, s2.start), min(s1.stop, s2.stop))
-                for s1, s2 in zip(slice_, _slice, strict=True)
-            )
-        slice_shape = tuple(s.stop - s.start for s in slice_)
-        len_chunk = math.prod(slice_shape)
-
-        # Get the starts and stops for the slice
-        starts = [s.start if s.start is not None else 0 for s in slice_]
-        stops = [s.stop if s.stop is not None else sh for s, sh in zip(slice_, slice_shape, strict=True)]
-
-        # Get the slice of each operand
-        for key, value in operands.items():
-            if np.isscalar(value):
-                chunk_operands[key] = value
-                continue
-            if value.shape == ():
-                chunk_operands[key] = value[()]
-                continue
-            if check_smaller_shape(value, shape, slice_shape):
-                # We need to fetch the part of the value that broadcasts with the operand
-                smaller_slice = compute_smaller_slice(shape, value.shape, slice_)
-                chunk_operands[key] = value[smaller_slice]
-                continue
-            # If key is in operands, we can reuse the buffer
-            if (
-                key in chunk_operands
-                and slice_shape == chunk_operands[key].shape
-                and isinstance(value, blosc2.NDArray)
-            ):
-                value.get_slice_numpy(chunk_operands[key], (starts, stops))
-                continue
-
-            chunk_operands[key] = value[slice_]
-
-        # Evaluate the expression using chunks of operands
-
-        if callable(expression):
-            result = np.empty(slice_shape, dtype=out.dtype)
-            # Call the udf directly and use result as the output array
-            offset = tuple(s.start for s in slice_)
-            expression(tuple(chunk_operands.values()), result, offset=offset)
-            out[slice_] = result
-            continue
-
-        if where is None:
-            result = ne_evaluate(expression, chunk_operands, **ne_args)
-        else:
-            # Apply the where condition (in result)
-            if len(where) == 2:
-                # x = chunk_operands["_where_x"]
-                # y = chunk_operands["_where_y"]
-                # result = np.where(result, x, y)
-                # numexpr is a bit faster than np.where, and we can fuse operations in this case
-                new_expr = f"where({expression}, _where_x, _where_y)"
-                result = ne_evaluate(new_expr, chunk_operands, **ne_args)
-            elif len(where) == 1:
-                result = ne_evaluate(expression, chunk_operands, **ne_args)
-                if _indices or _order:
-                    # Return indices only makes sense when the where condition is a tuple with one element
-                    # and result is a boolean array
-                    x = chunk_operands["_where_x"]
-                    if len(x.shape) > 1:
-                        raise ValueError("indices() and sort() only support 1D arrays")
-                    if result.dtype != np.bool_:
-                        raise ValueError("indices() and sort() only support bool conditions")
-                    indices = np.arange(leninputs, leninputs + len_chunk, dtype=np.int64).reshape(
-                        slice_shape
-                    )
-                    if _order:
-                        # We need to cumulate all the fields in _order, as well as indices
-                        chunk_indices = indices[result]
-                        result = x[_order][result]
-                    else:
-                        result = indices[result]
-                    leninputs += len_chunk
-                else:
-                    x = chunk_operands["_where_x"]
-                    result = x[result]
-            else:
-                raise ValueError("The where condition must be a tuple with one or two elements")
-
-        if out is None:
-            shape_ = shape
-            if where is not None and len(where) < 2:
-                # The result is a linear array
-                shape_ = math.prod(shape)
-            if getitem or _order:
-                out = np.empty(shape_, dtype=dtype_)
-                if _order:
-                    indices_ = np.empty(shape_, dtype=np.int64)
-            else:
-                if "chunks" not in kwargs and (where is None or len(where) == 2):
-                    # Let's use the same chunks as the first operand (it could have been automatic too)
-                    out = blosc2.empty(shape_, chunks=chunks, dtype=dtype_, **kwargs)
-                elif "chunks" in kwargs and (where is not None and len(where) < 2 and len(shape_) > 1):
-                    # Remove the chunks argument if the where condition is not a tuple with two elements
-                    kwargs.pop("chunks")
-                    out = blosc2.empty(shape_, dtype=dtype_, **kwargs)
-                else:
-                    out = blosc2.empty(shape_, dtype=dtype_, **kwargs)
-                # Check if the in out partitions are well-behaved (i.e. no padding)
-                behaved = blosc2.are_partitions_behaved(out.shape, out.chunks, out.blocks)
-
-        if where is None or len(where) == 2:
-            if behaved and result.shape == out.chunks and result.dtype == out.dtype:
-                # Fast path
-                out.schunk.update_data(nchunk, result, copy=False)
-            else:
-                out[slice_] = result
-        elif len(where) == 1:
-            lenres = len(result)
-            out[lenout : lenout + lenres] = result
-            if _order is not None:
-                indices_[lenout : lenout + lenres] = chunk_indices
-            lenout += lenres
-        else:
-            raise ValueError("The where condition must be a tuple with one or two elements")
-
-    if where is not None and len(where) < 2:  # Don't need to take orig_slice since filled up from 0 index
-        if _order is not None:
-            # argsort the result following _order
-            new_order = np.argsort(out[:lenout])
-            # And get the corresponding indices in array
-            out = indices_[new_order]
-        # Cap the output array to the actual length
-        if isinstance(out, np.ndarray):
-            out = out[:lenout]
-        else:
-            out.resize((lenout,))
-
-    else:  # Need to take orig_slice since filled up array according to slice_ for each chunk
-        if orig_slice is not None:
-            if isinstance(out, np.ndarray):
-                out = out[orig_slice]
-                if _order is not None:
-                    indices_ = indices_[orig_slice]
-            elif isinstance(out, blosc2.NDArray):
-                # It *seems* better to choose an automatic chunks and blocks for the output array
-                # out = out.slice(orig_slice, chunks=out.chunks, blocks=out.blocks)
-                out = out.slice(orig_slice)
-            else:
-                raise ValueError("The output array is not a NumPy array or a NDArray")
-
-    return out
-
-
-def slices_eval2(  # noqa: C901
-    expression: str | Callable[[tuple, np.ndarray, tuple[int]], None],
-    operands: dict,
-    getitem: bool,
-    _slice=None,
-    **kwargs,
-) -> blosc2.NDArray | np.ndarray:
-    """Evaluate the expression in chunks of operands.
-
-    This function can handle operands with different chunk shapes and
-    can evaluate only a slice of the output array if needed.
-
-    This is also flexible enough to work with operands of different shapes.
-
-    Parameters
-    ----------
-    expression: str or callable
-        The expression or user-defined (udf) to evaluate.
-    operands: dict
-        A dictionary containing the operands for the expression.
-    getitem: bool, optional
         Indicates whether the expression is being evaluated for a getitem operation or compute().
         Default is False.
     _slice: slice, list of slices, optional
@@ -1674,7 +1417,6 @@ def slices_eval2(  # noqa: C901
         # Compute the shape and chunks of the output array, including broadcasting
         shape = compute_broadcast_shape(operands.values())
         if _slice is not None:
-            # print("shape abans:", shape)
             # Remove the step parts from the slice, as code below does not support it
             # First ensure _slice is a tuple, even if it's a single slice
             _slice_ = _slice if isinstance(_slice, tuple) else (_slice,)
@@ -1686,7 +1428,6 @@ def slices_eval2(  # noqa: C901
                 for i, s in enumerate(_slice_)
             )
             shape_slice = compute_slice_shape(shape, _slice_, dont_squeeze=True)
-            # print("shape despres:", shape_slice)
     else:
         shape = out.shape
 
@@ -2314,9 +2055,7 @@ def chunked_eval(  # noqa: C901
             if getitem and (where is None or len(where) == 2) and not callable(expression):
                 # If we are using getitem, we can still use some optimizations
                 return slices_eval_getitem(expression, operands, _slice=item, **kwargs)
-            # return slices_eval(expression, operands, getitem=getitem, _slice=item, **kwargs)
-            # The next is an improved version of slices_eval that consumes less memory
-            return slices_eval2(expression, operands, getitem=getitem, _slice=item, **kwargs)
+            return slices_eval(expression, operands, getitem=getitem, _slice=item, **kwargs)
 
         if fast_path:
             if getitem:
@@ -2330,9 +2069,7 @@ def chunked_eval(  # noqa: C901
                 # a blosc2.NDArray
                 return fast_eval(expression, operands, getitem=False, **kwargs)
 
-        # res = slices_eval(expression, operands, getitem=getitem, _slice=item, **kwargs)
-        # The next is an improved version of slices_eval that consumes less memory
-        res = slices_eval2(expression, operands, getitem=getitem, _slice=item, **kwargs)
+        res = slices_eval(expression, operands, getitem=getitem, _slice=item, **kwargs)
 
     finally:
         # Deactivate cache for NDField instances

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1076,11 +1076,20 @@ def test_eval_getitem(array_fixture):
     np.testing.assert_allclose(expr[:10], nres[:10])
     np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
 
-    # Small test
+    # Small test for non-isomorphic shape
     shape = (2, 10, 5)
     test_arr = blosc2.linspace(0, 10, np.prod(shape), shape=shape)
     expr = test_arr * 30
     nres = test_arr[:] * 30
+    np.testing.assert_allclose(expr[0], nres[0])
+    np.testing.assert_allclose(expr[:10], nres[:10])
+    np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
+
+    # Small test for broadcasting
+    shape = (2, 10, 5)
+    test_arr = blosc2.linspace(0, 10, np.prod(shape), shape=shape)
+    expr = test_arr + test_arr.slice(slice(1, 2))
+    nres = test_arr[:] + test_arr[1]
     np.testing.assert_allclose(expr[0], nres[0])
     np.testing.assert_allclose(expr[:10], nres[:10])
     np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1054,7 +1054,7 @@ def test_lazyexpr_out(array_fixture, out_param, operand_mix):
     np.testing.assert_allclose(out[:], nres)
 
 
-# Test eval with an item parameter
+# Test compute with an item parameter
 def test_eval_item(array_fixture):
     a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
     expr = blosc2.lazyexpr("a1 + a2 - a3 * a4", operands={"a1": a1, "a2": a2, "a3": a3, "a4": a4})
@@ -1065,6 +1065,16 @@ def test_eval_item(array_fixture):
     np.testing.assert_allclose(res[()], nres[:10])
     res = expr.compute(item=slice(0, 10, 2))
     np.testing.assert_allclose(res[()], nres[0:10:2])
+
+
+# Test getitem with an item parameter
+def test_eval_getitem(array_fixture):
+    a1, a2, a3, a4, na1, na2, na3, na4 = array_fixture
+    expr = blosc2.lazyexpr("a1 + a2 - a3 * a4", operands={"a1": a1, "a2": a2, "a3": a3, "a4": a4})
+    nres = ne_evaluate("na1 + na2 - na3 * na4")
+    np.testing.assert_allclose(expr[0], nres[0])
+    np.testing.assert_allclose(expr[:10], nres[:10])
+    np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
 
 
 # Test lazyexpr's slice method

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1076,6 +1076,15 @@ def test_eval_getitem(array_fixture):
     np.testing.assert_allclose(expr[:10], nres[:10])
     np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
 
+    # Small test
+    shape = (2, 10, 5)
+    test_arr = blosc2.linspace(0, 10, np.prod(shape), shape=shape)
+    expr = test_arr * 30
+    nres = test_arr[:] * 30
+    np.testing.assert_allclose(expr[0], nres[0])
+    np.testing.assert_allclose(expr[:10], nres[:10])
+    np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
+
 
 # Test lazyexpr's slice method
 def test_eval_slice(array_fixture):


### PR DESCRIPTION
The new `slices_eval_getitem()` internal function allows to evaluate things like:

```python
d = 200
shape = (d,) * 4
chunks = (d // 4,) * 4
blocks = (d // 10,) * 4
a = blosc2.ones(shape=shape, chunks=chunks, blocks=blocks)
expr = a * 2

t = time.time()
res = expr[:,:,:,1]
t3 = time.time() - t
```

more efficiently, so that t3 can be up to 10x faster than with existing code.

The solution is partial because this only works for `expr[:,:,:,1]` idiom, and not `expr.compute(item=...)`.  Also, memory handling for operand temporaries has changed: now all the operands will use the final slice prior to do the computation.  While for the case above this is (very) beneficial, this should not be the case in general.

I tried to assemble a more general solution in the new `slices_eval2()`, but it is not ready yet.  My hunch is that we could do much better code if we use the [chunking machinery](https://quansight-labs.github.io/ndindex/api/chunking.html) in the ndindex package.  Even with this, I think `slices_eval_getitem()` will always be more efficient than `slices_eval2()` for small slices, so we will probably need some heuristics to decide which one to use.