### PR TITLE
Refactoring slicing of lazyexprs using ndindex

### DIFF
--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -2528,8 +2528,15 @@ cdef class NDArray:
         _check_rc(b2nd_resize(self.array, new_shape_, NULL),
                   "Error while resizing the array")
 
-    def squeeze(self):
-        _check_rc(b2nd_squeeze(self.array), "Error while performing the squeeze")
+    def squeeze(self, mask=None):
+        cdef c_bool mask_[B2ND_MAX_DIM]
+        if mask is None:
+            _check_rc(b2nd_squeeze(self.array), "Error while performing the squeeze")
+        else:
+            for i in range(self.ndim):
+                mask_[i] = mask[i]
+            _check_rc(b2nd_squeeze_index(self.array, mask_), "Error while squeezing array")
+
         if self.array.shape[0] == 1 and self.ndim == 1:
             self.array.ndim = 0
 

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1967,6 +1967,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
                 for order, nchunk in enumerate(aligned_chunks):
                     chunk = self.schunk.get_chunk(nchunk)
                     newarr.schunk.update_chunk(order, chunk)
+                newarr.squeeze(mask=mask)  # remove any dummy dims introduced
                 return newarr
 
         key = (start, stop)
@@ -1985,10 +1986,12 @@ class NDArray(blosc2_ext.NDArray, Operand):
 
         return ndslice
 
-    def squeeze(self) -> NDArray:
+    def squeeze(self, mask=None) -> NDArray:
         """Remove single-dimensional entries from the shape of the array.
 
-        This method modifies the array in-place, removing any dimensions with size 1.
+        This method modifies the array in-place. If mask is None removes any dimensions with size 1.
+        If mask is provided, it should be a boolean array of the same shape as the array, and the corresponding
+        dimensions (of size 1) will be removed.
 
         Returns
         -------
@@ -2007,7 +2010,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         >>> a.shape
         (23, 11)
         """
-        super().squeeze()
+        super().squeeze(mask=mask)
         return self
 
     def indices(self, order: str | list[str] | None = None, **kwargs: Any) -> NDArray:


### PR DESCRIPTION
Trying to simplify slicing code using NDindex. Also added functionality to squeeze function and improved case handling of indexing for blosc2 so that dummy dimensions are not introduced (thus respecting numpy responses for the same inputs). 