### PR TITLE
Fixing reductions and slicing for lazy expressions

### DIFF
--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1418,7 +1418,7 @@ def slices_eval(  # noqa: C901
                 need_final_slice = True
             _slice = tuple(slice(i, i + 1) if isinstance(i, int) else i for i in _slice)
             full_slice = tuple(
-                slice(s.start or 0, s.stop or shape[i], None) for i, s in enumerate(_slice)
+                slice(s.start or 0, s.stop or shape[i], 1) for i, s in enumerate(_slice)
             )  # get rid of non-unit steps
             # shape_slice in general not equal to final shape:
             # dummy dims (due to ints) or non-unit steps will be dealt with by taking final_slice

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -1424,9 +1424,9 @@ def slices_eval(  # noqa: C901
             shape_slice = ndindex.ndindex(full_slice).newshape(shape)
             orig_slice = ndindex.ndindex(orig_slice).as_subindex(full_slice).raw
     else:
-        # out should always have shape of full array
-        if shape is not None and shape != out.shape:
-            raise ValueError("Provided output shape does not match the operands' shape.")
+        # # out should always have shape of full array
+        # if shape is not None and shape != out.shape:
+        #     raise ValueError("Provided output shape does not match the operands' shape.")
         shape = out.shape
 
     if chunks is None:  # Guess chunk shape
@@ -1799,13 +1799,9 @@ def reduce_slices(  # noqa: C901
     _slice = _slice.raw
     shape_slice = shape
     full_slice = ()  # by default the full_slice is the whole array
-    if out is None:
-        if _slice != ():
-            shape_slice = ndindex.ndindex(_slice).newshape(shape)
-            full_slice = _slice
-    else:
-        if shape != out.shape:
-            raise ValueError("Provided output shape does not match the operands' shape.")
+    if out is None and _slice != ():
+        shape_slice = ndindex.ndindex(_slice).newshape(shape)
+        full_slice = _slice
 
     # after slicing, we reduce to calculate shape of output
     if axis is None:
@@ -1817,6 +1813,9 @@ def reduce_slices(  # noqa: C901
         reduced_shape = tuple(1 if i in axis else s for i, s in enumerate(shape_slice))
     else:
         reduced_shape = tuple(s for i, s in enumerate(shape_slice) if i not in axis)
+
+    if out is not None and reduced_shape != out.shape:
+        raise ValueError("Provided output shape does not match the reduced shape.")
 
     if is_inside_new_expr():
         # We already have the dtype and reduced_shape, so return immediately

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1475,16 +1475,14 @@ class NDArray(blosc2_ext.NDArray, Operand):
             key_ = (slice(key, key + 1), *(slice(None),) * (self.ndim - 1))
             start, stop, step = get_ndarray_start_stop(self.ndim, key_, self.shape)
             shape = tuple(
-                sp - st for st, sp in zip(start, stop, strict=True) if st < sp
+                sp - st for st, sp in zip(start, stop, strict=True)
             )  # add condition to avoid 0 in shape
         elif isinstance(key, tuple) and (
             builtins.sum(isinstance(k, builtins.slice) for k in key) == self.ndim
         ):
             # This can be processed in a fast way already
             start, stop, step = get_ndarray_start_stop(self.ndim, key, self.shape)
-            shape = tuple(
-                sp - st for st, sp in zip(start, stop, strict=True) if st < sp
-            )  # add condition to avoid 0 in shape
+            shape = tuple(sp - st for st, sp in zip(start, stop, strict=True))
         elif isinstance(key, (list, np.ndarray, NDArray)):
             if isinstance(key, list):
                 key = np.array(key, dtype=np.int64)

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1474,9 +1474,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
             # Massage the key to a tuple and go the fast path
             key_ = (slice(key, key + 1), *(slice(None),) * (self.ndim - 1))
             start, stop, step = get_ndarray_start_stop(self.ndim, key_, self.shape)
-            shape = tuple(
-                sp - st for st, sp in zip(start, stop, strict=True)
-            )  # add condition to avoid 0 in shape
+            shape = tuple(sp - st for st, sp in zip(start, stop, strict=True))
         elif isinstance(key, tuple) and (
             builtins.sum(isinstance(k, builtins.slice) for k in key) == self.ndim
         ):

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1474,13 +1474,17 @@ class NDArray(blosc2_ext.NDArray, Operand):
             # Massage the key to a tuple and go the fast path
             key_ = (slice(key, key + 1), *(slice(None),) * (self.ndim - 1))
             start, stop, step = get_ndarray_start_stop(self.ndim, key_, self.shape)
-            shape = tuple(sp - st for st, sp in zip(start, stop, strict=True))
+            shape = tuple(
+                sp - st for st, sp in zip(start, stop, strict=True) if st < sp
+            )  # add condition to avoid 0 in shape
         elif isinstance(key, tuple) and (
             builtins.sum(isinstance(k, builtins.slice) for k in key) == self.ndim
         ):
             # This can be processed in a fast way already
             start, stop, step = get_ndarray_start_stop(self.ndim, key, self.shape)
-            shape = tuple(sp - st for st, sp in zip(start, stop, strict=True))
+            shape = tuple(
+                sp - st for st, sp in zip(start, stop, strict=True) if st < sp
+            )  # add condition to avoid 0 in shape
         elif isinstance(key, (list, np.ndarray, NDArray)):
             if isinstance(key, list):
                 key = np.array(key, dtype=np.int64)

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1078,6 +1078,8 @@ def test_eval_getitem(array_fixture):
     np.testing.assert_allclose(expr[:10], nres[:10])
     np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
 
+
+def test_eval_getitem2():
     # Small test for non-isomorphic shape
     shape = (2, 10, 5)
     test_arr = blosc2.linspace(0, 10, np.prod(shape), shape=shape, chunks=(1, 5, 1))
@@ -1086,15 +1088,17 @@ def test_eval_getitem(array_fixture):
     np.testing.assert_allclose(expr[0], nres[0])
     np.testing.assert_allclose(expr[1:, :7], nres[1:, :7])
     np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
+    # This works, but it is not very efficient since it relies on blosc2.ndarray.slice for non-unit steps
+    np.testing.assert_allclose(expr.slice((slice(None, None, None), slice(0, 10, 2)))[:], nres[:, 0:10:2])
 
     # Small test for broadcasting
-    shape = (2, 10, 5)
-    test_arr = blosc2.linspace(0, 10, np.prod(shape), shape=shape)
-    expr = test_arr + test_arr.slice(slice(1, 2))
+    expr = test_arr + test_arr.slice(1)
     nres = test_arr[:] + test_arr[1]
     np.testing.assert_allclose(expr[0], nres[0])
-    np.testing.assert_allclose(expr[:10], nres[:10])
-    np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
+    np.testing.assert_allclose(expr[1:, :7], nres[1:, :7])
+    np.testing.assert_allclose(expr[:, 0:10:2], nres[:, 0:10:2])
+    # This works, but it is not very efficient since it relies on blosc2.ndarray.slice for non-unit steps
+    np.testing.assert_allclose(expr.slice((slice(None, None, None), slice(0, 10, 2)))[:], nres[:, 0:10:2])
 
 
 # Test lazyexpr's slice method

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1080,11 +1080,11 @@ def test_eval_getitem(array_fixture):
 
     # Small test for non-isomorphic shape
     shape = (2, 10, 5)
-    test_arr = blosc2.linspace(0, 10, np.prod(shape), shape=shape)
+    test_arr = blosc2.linspace(0, 10, np.prod(shape), shape=shape, chunks=(1, 5, 1))
     expr = test_arr * 30
     nres = test_arr[:] * 30
     np.testing.assert_allclose(expr[0], nres[0])
-    np.testing.assert_allclose(expr[:10], nres[:10])
+    np.testing.assert_allclose(expr[1:, :7], nres[1:, :7])
     np.testing.assert_allclose(expr[0:10:2], nres[0:10:2])
 
     # Small test for broadcasting

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -191,9 +191,9 @@ def test_reduce_item(reduce_op, dtype, stripes, stripe_len, shape, chunks):
 
 @pytest.mark.parametrize("reduce_op", ["sum", "prod", "min", "max", "any", "all", "mean", "std", "var"])
 def test_reduce_slice(reduce_op):
-    shape = (2, 10, 5)
+    shape = (8, 12, 5)
     na = np.linspace(0, 1, num=np.prod(shape)).reshape(shape)
-    a = blosc2.asarray(na, chunks=(1, 5, 1))
+    a = blosc2.asarray(na, chunks=(2, 5, 1))
     tol = 1e-6 if na.dtype == np.float32 else 1e-15
     _slice = (slice(1, 2, 1), slice(3, 7, 1))
     res = getattr(a, reduce_op)(item=_slice, axis=-1)

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -189,6 +189,18 @@ def test_reduce_item(reduce_op, dtype, stripes, stripe_len, shape, chunks):
             np.testing.assert_allclose(res, nres, atol=tol, rtol=tol)
 
 
+@pytest.mark.parametrize("reduce_op", ["sum", "prod", "min", "max", "any", "all", "mean", "std", "var"])
+def test_reduce_slice(reduce_op):
+    shape = (2, 10, 5)
+    na = np.linspace(0, 1, num=np.prod(shape)).reshape(shape)
+    a = blosc2.asarray(na, chunks=(1, 5, 1))
+    tol = 1e-6 if na.dtype == np.float32 else 1e-15
+    _slice = (slice(1, 2, 1), slice(3, 7, 1))
+    res = getattr(a, reduce_op)(item=_slice, axis=-1)
+    nres = getattr(na[_slice], reduce_op)(axis=-1)
+    np.testing.assert_allclose(res, nres, atol=tol, rtol=tol)
+
+
 # Test fast path for reductions
 @pytest.mark.parametrize(
     ("chunks", "blocks"),

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -200,6 +200,12 @@ def test_reduce_slice(reduce_op):
     nres = getattr(na[_slice], reduce_op)(axis=-1)
     np.testing.assert_allclose(res, nres, atol=tol, rtol=tol)
 
+    # Test reductions with slices and strides
+    _slice = (slice(1, 2, 1), slice(1, 9, 2))
+    res = getattr(a, reduce_op)(item=_slice, axis=1)
+    nres = getattr(na[_slice], reduce_op)(axis=1)
+    np.testing.assert_allclose(res, nres, atol=tol, rtol=tol)
+
 
 # Test fast path for reductions
 @pytest.mark.parametrize(


### PR DESCRIPTION
Now support steps for reductions. More complex slicing operations also now give correct answers. The new step_handler function could be incorporated into slice_eval to avoid numpy arrays completely and only use final_slice to get rid of dummy dimensions.