### PR TITLE
Fancy index

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,8 +49,7 @@ else()
     set(BLOSC_INSTALL ON)
     include(FetchContent)
     FetchContent_Declare(blosc2
-        GIT_REPOSITORY https://github.com/Blosc/c-blosc2
-        GIT_TAG abb9cd973c2d2d2d068e13934641dcbdedb06752  # v2.19.0 (expand_dims added)
+        SOURCE_DIR /home/lshaw/c-blosc2 # beta trials, should be changed for commits
     )
     FetchContent_MakeAvailable(blosc2)
     include_directories("${blosc2_SOURCE_DIR}/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,8 @@ else()
     set(BLOSC_INSTALL ON)
     include(FetchContent)
     FetchContent_Declare(blosc2
-        SOURCE_DIR /home/lshaw/c-blosc2 # beta trials, should be changed for commits
+        GIT_REPOSITORY https://github.com/Blosc/c-blosc2
+        GIT_TAG abb9cd973c2d2d2d068e13934641dcbdedb06752  # v2.19.0 (expand_dims added)
     )
     FetchContent_MakeAvailable(blosc2)
     include_directories("${blosc2_SOURCE_DIR}/include")

--- a/bench/ndarray/fancy_index.py
+++ b/bench/ndarray/fancy_index.py
@@ -14,30 +14,24 @@ import blosc2
 import time
 from memory_profiler import memory_usage, profile
 import matplotlib.pyplot as plt
+import zarr
+import h5py
+plt.rcParams.update({'text.usetex':True,'font.serif': ['cm'],'font.size':16})
+plt.rcParams['figure.dpi'] = 1000
+plt.rcParams['savefig.dpi'] = 1000
+plt.rc('text', usetex=True)
+plt.rc('font',**{'serif':['cm']})
+plt.style.use('seaborn-v0_8-paper')
 
-MEM_PROFILE = False
+NUMPY_BLOSC = False
 
-# @profile
-def fancyBlosc2(arr, fancyIdx):
+def genarray(r, ndims=1, verbose=True):
+    d = int((r*2**30/8)**(1/ndims))
+    shape = (d,) * ndims
+    chunks = (d // 4,) * ndims
+    blocks = (max(d // 10, 1),) * ndims
     t = time.time()
-    res = arr[fancyIdx]
-    dt = time.time() - t
-    return res, dt
-
-# @profile
-def fancyNumpy(arr, fancyIdx):
-    t = time.time()
-    res = arr[:]
-    res = res[fancyIdx]
-    dt = time.time() - t
-    return res, dt
-
-def genarray(d, verbose=False):
-    shape = (d,) * 4
-    chunks = (d // 4,) * 4
-    blocks = (max(d // 10, 1),) * 4
-    t = time.time()
-    arr = blosc2.ones(shape=shape, chunks=chunks, blocks=blocks)  # , urlpath=file, mode="w")
+    arr = blosc2.ones(shape=shape, chunks=chunks, blocks=blocks, dtype=np.int64)  # , urlpath=file, mode="w")
     t = time.time() - t
     if verbose:
         print(f"Array shape: {arr.shape}")
@@ -45,92 +39,103 @@ def genarray(d, verbose=False):
         print(f"Time to create array: {t:.6f} seconds")
     return arr
 
-if __name__ == '__main__':
-    blosc_times = []
-    np_times = []
-    sizes = []
-    # dims = np.int64(np.array([2**6.76, 2**6.8, 2**6.85, 2**6.9, 2**6.95]))
-    dims = np.int64(np.array([2**4.3, 2**5.25, 2**6.25, 2**6.75, 2**7, 2**7.25, 2**7.4, 2**7.5]))
-    rng = np.random.default_rng()
+blosc_times = []
+np_times = []
+zarr_times = []
+sizes = []
+dims = np.int64(np.array([1, 2, 4, 6, 8]))
+rng = np.random.default_rng()
+blosctimes = []
+nptimes = []
+zarrtimes = []
+h5pytimes = []
 
-    for d in dims:
-        arr = genarray(d)
-        arr_size = np.prod(arr.shape) * arr.dtype.itemsize / 2 ** 30
-        print(arr_size)
-        sizes.append(arr_size)
-        idx = rng.integers(low=0, high=d, size=(d,))
-        if MEM_PROFILE:
-            fancyIdx = np.s_[idx, :, :d // 2, d // 2:]
+for d in dims:
+    arr = genarray(d, ndims=2)
+    sizes.append(d)
+    idx = rng.integers(low=0, high=arr.shape[0], size=(arr.shape[0],))
+    row = np.arange(arr.shape[0])
+    col = row
+    mask = rng.integers(low=0, high=2, size=(d,)) == 1
 
-            interval = 0.001
-            offset = 0
-            for f in [fancyBlosc2, fancyNumpy]:
-                mem = memory_usage((f, (arr, fancyIdx)), interval=interval)
-                times = offset + interval * np.arange(len(mem))
-                offset = times[-1]
-                plt.plot(times, mem)
 
-            plt.xlabel('Time (s)')
-            plt.ylabel('Memory usage (MiB)')
-            plt.title('Memory usage fancy indexing')
-            plt.legend(['blosc2', 'numpy'])
-            plt.savefig(f'plots/MemoryUsagefancyIdx_d{d}.png', format="png")
+    ## Test fancy indexing for different use cases
+    m, M = np.min(idx), np.max(idx)
+    def timer(arr, skip_flag=True, row=row, col=col):
+        time_list = []
+        if not skip_flag:
+            t = time.time()
+            b = arr[row, col]
+            time_list += [time.time() - t]
+            t = time.time()
+            b = arr[slice(1, M // 2, 5), col]
+            time_list += [time.time() - t]
+            t = time.time()
+            b = arr[[[m // 2, M // 2], [m // 4, M // 4]]]
+            time_list += [time.time() - t]
+        t = time.time()
+        b = arr[[m, M//2, M]]
+        time_list += [time.time() - t]
+        t = time.time()
+        b = arr[m, col]
+        time_list += [time.time() - t]
+        return np.array(time_list)
 
-        row = idx
-        col = rng.permutation(idx)
-        mask = rng.integers(low=0, high=2, size=(d,)) == 1
+    if NUMPY_BLOSC:
+        blosctimes += [timer(arr, skip_flag=False, row=idx, col=idx)]
+        arr=arr[:]
+        nptimes += [timer(arr, skip_flag=False, row=idx, col=idx)]
+    else:
+        blosctimes += [timer(arr)]
+        arr = arr[:]
+        nptimes += [timer(arr)]
+        z_test = zarr.zeros(shape=arr.shape, dtype=arr.dtype)
+        z_test[:] = arr
+        # zarr is more limited, as must provide same number of coord arrays as dims of array
+        # also cannot mix with slices
+        zarrtimes += [timer(z_test)]
+        with h5py.File('my_hdf5_file.h5', 'w') as f:
+            dset = f.create_dataset("init", data=arr)
+            h5pytimes += [timer(dset)]
 
-        ## Test fancy indexing for different use cases
-        loc_blosc_times = []
-        loc_np_times = []
-        m, M = np.min(idx), np.max(idx)
-        for i, fancyIdx in enumerate([
-            [m, M//2, M],  # i)
-            [[[m//2, M//2], [m//4, M//4]]],  # ii)
-            [row, col],  # iii)
-            # [row[:, None], col],  # iv)
-            [m, col],  # v)
-            [slice(1, M//2, 5), col],  # vi)
-            # [row[:, None], mask],  # vii)
-        ]):
-            # print(f'\n(case {i + 1})')
-            try:
-                r, c = fancyIdx
-                idx = (r, c)
-            except:
-                r, c = fancyIdx, None
-                idx = r
-            b, blosctime = fancyBlosc2(arr,idx)
-            n, nptime = fancyNumpy(arr,idx)
-            slice_size = np.prod(b.shape) * b.dtype.itemsize / 2 ** 30
-            np.testing.assert_allclose(b, n)
-            loc_blosc_times.append(blosctime)
-            loc_np_times.append(nptime)
-        blosc_times.append(loc_blosc_times)
-        np_times.append(loc_np_times)
-
-    blosc_times = np.array(blosc_times)
-    np_times = np.array(np_times)
-    x = np.arange(len(sizes))
-    width = 0.25
-
+x = np.arange(len(sizes))
+width = 0.2
+blosctimes = np.array(blosctimes)
+nptimes = np.array(nptimes)
+if NUMPY_BLOSC:
     # Create bars for axis 0 plot
-    plt.bar(x - width, np_times.mean(axis=1), width, color='b', alpha=0.5)
-    plt.bar(x - width, np_times.max(axis=1), width, color='b', alpha=0.25)
-    plt.bar(x - width, np_times.min(axis=1), width, label='NumPy', color='b', alpha=1)
-    plt.bar(x, blosc_times.mean(axis=1), width, color='r', alpha=0.5)
-    plt.bar(x, blosc_times.max(axis=1), width, color='r', alpha=0.25)
-    plt.bar(x, blosc_times.min(axis=1), width, label='Blosc2', color='r', alpha=1)
-    plt.bar([],[], label='max', color='k', alpha=0.25)
-    plt.bar([],[], label='min', color='k', alpha=1)
-    plt.bar([],[], label='mean', color='k', alpha=0.5)
+    for i, r in enumerate((["Numpy", nptimes, -width], ["Blosc2", blosctimes, 0])):
+        label, times, w = r
+        c = ['b', 'r'][i]
+        plt.bar(x + w, times.mean(axis=1), width, color=c, alpha=0.5)
+        plt.bar(x + w, times.max(axis=1), width, color=c, alpha=0.25)
+        plt.bar(x + w, times.min(axis=1), width, label=label, color=c, alpha=1)
 
     plt.xlabel('Array size (GB)')
     plt.legend()
     plt.xticks(x, np.round(sizes, 2))
     plt.ylabel("Time (s)")
-    plt.title('Fancy indexing, Blosc2 vs NumPy')
+    plt.title('Fancy indexing NumPy vs Blosc2')
+    plt.savefig('plots/fancyIdxNumpyVsBlosc.png', format="png")
+    plt.show()
+else:
+    zarrtimes = np.array(zarrtimes)
+    h5pytimes = np.array(h5pytimes)
+
+    # Create bars for axis 0 plot
+    for i, r in enumerate((["Numpy",nptimes,-2*width],["Blosc2",blosctimes, -width],["Zarr",zarrtimes, 0],["HDF5",h5pytimes, width])):
+        label,times,w = r
+        c = ['b', 'r', 'g', 'm'][i]
+        plt.bar(x + w, times.mean(axis=1), width, color=c, alpha=0.5)
+        plt.bar(x + w, times.max(axis=1), width, color=c, alpha=0.25)
+        plt.bar(x + w, times.min(axis=1), width, label=label, color=c, alpha=1)
+
+    plt.xlabel('Array size (GB)')
+    plt.legend()
+    plt.xticks(x, np.round(sizes, 2))
+    plt.ylabel("Time (s)")
+    plt.title('Fancy indexing performance comparison')
     plt.savefig('plots/fancyIdx.png', format="png")
     plt.show()
-    ## slowest cases are the ones with broadcasting
-    ## in fact it's a memory problem for blosc2 seemingly
+
+print("Finished everything!")

--- a/bench/ndarray/fancy_index.py
+++ b/bench/ndarray/fancy_index.py
@@ -12,18 +12,19 @@ import numpy as np
 import ndindex
 import blosc2
 import time
-from memory_profiler import memory_usage, profile
 import matplotlib.pyplot as plt
 import zarr
 import h5py
-plt.rcParams.update({'text.usetex':True,'font.serif': ['cm'],'font.size':16})
+import pickle
+plt.rcParams.update({'text.usetex':False,'font.serif': ['cm'],'font.size':16})
 plt.rcParams['figure.dpi'] = 1000
 plt.rcParams['savefig.dpi'] = 1000
-plt.rc('text', usetex=True)
+plt.rc('text', usetex=False)
 plt.rc('font',**{'serif':['cm']})
 plt.style.use('seaborn-v0_8-paper')
 
-NUMPY_BLOSC = False
+NUMPY_BLOSC = True
+NUMPY_BLOSC_ZARR = False
 
 def genarray(r, ndims=1, verbose=True):
     d = int((r*2**30/8)**(1/ndims))
@@ -31,7 +32,7 @@ def genarray(r, ndims=1, verbose=True):
     chunks = (d // 4,) * ndims
     blocks = (max(d // 10, 1),) * ndims
     t = time.time()
-    arr = blosc2.ones(shape=shape, chunks=chunks, blocks=blocks, dtype=np.int64)  # , urlpath=file, mode="w")
+    arr = blosc2.ones(shape=shape, dtype=np.int64)
     t = time.time() - t
     if verbose:
         print(f"Array shape: {arr.shape}")
@@ -39,103 +40,115 @@ def genarray(r, ndims=1, verbose=True):
         print(f"Time to create array: {t:.6f} seconds")
     return arr
 
-blosc_times = []
-np_times = []
-zarr_times = []
-sizes = []
-dims = np.int64(np.array([1, 2, 4, 6, 8]))
+
+sizes = np.int64(np.array([1, 2, 4, 8, 16]))
 rng = np.random.default_rng()
 blosctimes = []
 nptimes = []
 zarrtimes = []
 h5pytimes = []
-
-for d in dims:
-    arr = genarray(d, ndims=2)
-    sizes.append(d)
-    idx = rng.integers(low=0, high=arr.shape[0], size=(arr.shape[0],))
-    row = np.arange(arr.shape[0])
-    col = row
-    mask = rng.integers(low=0, high=2, size=(d,)) == 1
-
-
-    ## Test fancy indexing for different use cases
-    m, M = np.min(idx), np.max(idx)
-    def timer(arr, skip_flag=True, row=row, col=col):
-        time_list = []
-        if not skip_flag:
-            t = time.time()
-            b = arr[row, col]
-            time_list += [time.time() - t]
-            t = time.time()
-            b = arr[slice(1, M // 2, 5), col]
-            time_list += [time.time() - t]
-            t = time.time()
-            b = arr[[[m // 2, M // 2], [m // 4, M // 4]]]
-            time_list += [time.time() - t]
-        t = time.time()
-        b = arr[[m, M//2, M]]
-        time_list += [time.time() - t]
-        t = time.time()
-        b = arr[m, col]
-        time_list += [time.time() - t]
-        return np.array(time_list)
-
-    if NUMPY_BLOSC:
-        blosctimes += [timer(arr, skip_flag=False, row=idx, col=idx)]
-        arr=arr[:]
-        nptimes += [timer(arr, skip_flag=False, row=idx, col=idx)]
-    else:
-        blosctimes += [timer(arr)]
-        arr = arr[:]
-        nptimes += [timer(arr)]
-        z_test = zarr.zeros(shape=arr.shape, dtype=arr.dtype)
-        z_test[:] = arr
-        # zarr is more limited, as must provide same number of coord arrays as dims of array
-        # also cannot mix with slices
-        zarrtimes += [timer(z_test)]
-        with h5py.File('my_hdf5_file.h5', 'w') as f:
-            dset = f.create_dataset("init", data=arr)
-            h5pytimes += [timer(dset)]
-
 x = np.arange(len(sizes))
 width = 0.2
-blosctimes = np.array(blosctimes)
-nptimes = np.array(nptimes)
-if NUMPY_BLOSC:
-    # Create bars for axis 0 plot
-    for i, r in enumerate((["Numpy", nptimes, -width], ["Blosc2", blosctimes, 0])):
-        label, times, w = r
-        c = ['b', 'r'][i]
-        plt.bar(x + w, times.mean(axis=1), width, color=c, alpha=0.5)
-        plt.bar(x + w, times.max(axis=1), width, color=c, alpha=0.25)
-        plt.bar(x + w, times.min(axis=1), width, label=label, color=c, alpha=1)
+labs = 'NumpyBlosc2' if NUMPY_BLOSC else 'NumpyBlosc2ZarrHDF5' 
+labs = 'NumpyBlosc2Zarr' if NUMPY_BLOSC_ZARR else labs
+try:
+    with open(f"results{labs}.pkl", 'rb') as f:
+        result_tuple = pickle.load(f)
+    labs = ''
+    for i, r in enumerate(result_tuple):
+        if r[1].shape != (0,):
+            label,times,w = r
+            c = ['b', 'r', 'g', 'm'][i]
+            mean = times.mean(axis=1)
+            err = [mean - times.min(axis=1), times.max(axis=1)-mean]
+            plt.bar(x + w, mean , width, color=c, label=label, yerr=err, capsize=5, ecolor='k',
+            error_kw=dict(lw=2, capthick=2, ecolor='k'))
+            labs+=label
+except:
+    for d in sizes:
+        arr = genarray(d, ndims=2)
+        idx = rng.integers(low=0, high=arr.shape[0], size=(arr.shape[0],))
+        row = np.sort(np.unique(idx))
+        col = np.sort(np.unique(rng.integers(low=0, high=arr.shape[0], size=(arr.shape[0],))))
+        mask = rng.integers(low=0, high=2, size=(arr.shape[0],)) == 1
 
-    plt.xlabel('Array size (GB)')
-    plt.legend()
-    plt.xticks(x, np.round(sizes, 2))
-    plt.ylabel("Time (s)")
-    plt.title('Fancy indexing NumPy vs Blosc2')
-    plt.savefig('plots/fancyIdxNumpyVsBlosc.png', format="png")
-    plt.show()
-else:
+
+        ## Test fancy indexing for different use cases
+        m, M = np.min(idx), np.max(idx)
+        def timer(arr, row=row, col=col):
+            time_list = []
+            if NUMPY_BLOSC or NUMPY_BLOSC_ZARR:
+                t = time.time()
+                b = arr[row, col]
+                time_list += [time.time() - t]
+            if NUMPY_BLOSC:
+                t = time.time()
+                b = arr[slice(1, M // 2, 5), col]
+                time_list += [time.time() - t]
+                t = time.time()
+                b = arr[[[row], [col]]]
+                time_list += [time.time() - t]
+                t = time.time()
+                b = arr[row[:10, None], col[:10]]
+                time_list += [time.time() - t]
+                t = time.time()
+                b = arr[row[:10, None], mask]
+                time_list += [time.time() - t]
+            t = time.time()
+            b = arr[row]
+            time_list += [time.time() - t]
+            t = time.time()
+            b = arr[m, col]
+            time_list += [time.time() - t]
+            return np.array(time_list)
+
+        if NUMPY_BLOSC or NUMPY_BLOSC_ZARR:
+            blosctimes += [timer(arr, row=idx, col=idx)]
+            arr=arr[:]
+            nptimes += [timer(arr, row=idx, col=idx)]
+            if NUMPY_BLOSC_ZARR:
+                z_test = zarr.zeros(shape=arr.shape, dtype=arr.dtype)
+                z_test[:] = arr
+                zarrtimes += [timer(z_test, row=idx, col=idx)]
+        else:
+            blosctimes += [timer(arr)]
+            arr=arr[:]
+            nptimes += [timer(arr)]
+            z_test = zarr.zeros(shape=arr.shape, dtype=arr.dtype)
+            z_test[:] = arr
+            zarrtimes += [timer(z_test)]
+            with h5py.File('my_hdf5_file.h5', 'w') as f:
+                dset = f.create_dataset("init", data=arr)
+                h5pytimes += [timer(dset)]
+
+    blosctimes = np.array(blosctimes)
+    nptimes = np.array(nptimes)
     zarrtimes = np.array(zarrtimes)
     h5pytimes = np.array(h5pytimes)
+    labs=''
+    result_tuple = (["Numpy",nptimes,-2*width],["Blosc2",blosctimes, -width],["Zarr",zarrtimes, 0],["HDF5",h5pytimes, width])
 
-    # Create bars for axis 0 plot
-    for i, r in enumerate((["Numpy",nptimes,-2*width],["Blosc2",blosctimes, -width],["Zarr",zarrtimes, 0],["HDF5",h5pytimes, width])):
-        label,times,w = r
-        c = ['b', 'r', 'g', 'm'][i]
-        plt.bar(x + w, times.mean(axis=1), width, color=c, alpha=0.5)
-        plt.bar(x + w, times.max(axis=1), width, color=c, alpha=0.25)
-        plt.bar(x + w, times.min(axis=1), width, label=label, color=c, alpha=1)
+    # Create barplot for Numpy vs Blosc vs Zarr vs H5py
+    for i, r in enumerate(result_tuple):
+        if r[1].shape != (0,):
+            label, times, w = r
+            c = ['b', 'r', 'g', 'm'][i]
+            mean = times.mean(axis=1)
+            err = (mean - times.min(axis=1), times.max(axis=1)-mean)
+            plt.bar(x + w, mean , width, color=c, label=label, yerr=err, capsize=5, ecolor='k', 
+            error_kw=dict(lw=2, capthick=2, ecolor='k'))            
+            labs+=label
 
-    plt.xlabel('Array size (GB)')
-    plt.legend()
-    plt.xticks(x, np.round(sizes, 2))
-    plt.ylabel("Time (s)")
-    plt.title('Fancy indexing performance comparison')
-    plt.savefig('plots/fancyIdx.png', format="png")
-    plt.show()
+    with open(f"results{labs}.pkl", 'wb') as f:
+        pickle.dump(result_tuple, f)
+
+plt.xlabel('Array size (GB)')
+plt.legend()
+plt.xticks(x-width, np.round(sizes, 2))
+plt.ylabel("Time (s)")
+plt.title('Fancy indexing performance comparison')
+plt.ylim([0,10])
+plt.savefig(f'plots/fancyIdx{labs}.png', format="png")
+plt.show()
 
 print("Finished everything!")

--- a/bench/ndarray/fancy_index.py
+++ b/bench/ndarray/fancy_index.py
@@ -15,90 +15,121 @@ import time
 from memory_profiler import memory_usage, profile
 import matplotlib.pyplot as plt
 
-d = 160
-shape = (d,) * 4
-chunks = (d // 4,) * 4
-blocks = (d // 10,) * 4
-print(f"Creating a 4D array of shape {shape} with chunks {chunks} and blocks {blocks}...")
-t = time.time()
-arr = blosc2.ones(shape=shape, chunks=chunks, blocks=blocks) #, urlpath=file, mode="w")
-t = time.time() - t
-print(f"Time to create array: {t:.6f} seconds")
-t = time.time()
-idx = np.random.randint(low=0, high=d, size=(d//4,))
-fancyIdx = np.s_[idx, 40, :d//2, d//2:]
-ans = arr[:][fancyIdx]
-
-# dim0
-# @profile
-def slice_dim1():
-    t = time.time()
-    _slice = ndindex.ndindex(fancyIdx).expand(shape)
-    chunk_size = ndindex.ChunkSize(chunks)
-
-    # repeated indices are grouped together
-    intersecting_chunks = chunk_size.as_subchunks(_slice, shape)  # if _slice is (), returns all chunks
-    out_shape = _slice.newshape(shape)
-    print(out_shape)
-
-    # Attempt 1
-    out = np.empty(out_shape, dtype=arr.dtype)
-    for n, c in enumerate(chunk_size.indices(shape)):
-        try:
-            sub_idx = _slice.as_subindex(c).raw
-            sel_idx = c.as_subindex(_slice).raw
-            chunk = blosc2.empty(
-                shape=arr.chunks, chunks=arr.chunks, blocks=arr.blocks, dtype=arr.dtype
-            )  # very cheap memory allocation
-            chunk.schunk.insert_chunk(0, arr.get_chunk(n))
-            out[sel_idx] = chunk[:][sub_idx]
-        except ValueError:
-            # This happens when the _slice and chunk do not intersect
-            continue
-    t0 = time.time() - t
-    np.testing.assert_allclose(out, ans)
-    print(f"Time to access blosc2, method 1: {t0:.6f} seconds")
+MEM_PROFILE = False
 
 # @profile
-def slice_dim2():
+def fancyBlosc2(arr, fancyIdx):
     t = time.time()
-    _slice = ndindex.ndindex(fancyIdx).expand(shape)
-    chunk_size = ndindex.ChunkSize(chunks)
-
-    # repeated indices are grouped together
-    intersecting_chunks = chunk_size.as_subchunks(_slice, shape)  # if _slice is (), returns all chunks
-    out_shape = _slice.newshape(shape)
-    ## Attempt 2
-    out = np.empty(out_shape, dtype=arr.dtype)
-    for c in intersecting_chunks:
-        sub_idx = _slice.as_subindex(c).raw
-        sel_idx = c.as_subindex(_slice).raw
-        chunk = arr[c.raw]
-        out[sel_idx] = chunk[sub_idx]
-    t0 = time.time() - t
-    np.testing.assert_allclose(out, ans)
-    print(f"Time to access blosc2, method 2: {t0:.6f} seconds")
+    res = arr[fancyIdx]
+    dt = time.time() - t
+    return res, dt
 
 # @profile
-def slice_dimNumpy():
+def fancyNumpy(arr, fancyIdx):
     t = time.time()
-    res = arr[:][fancyIdx]
-    t0 = time.time() - t
-    print(f"Time to access numpy: {t0:.6f} seconds")
-    print(f"dim0 slice size: {np.prod(res.shape) * res.dtype.itemsize / 2**30:.6f} GB")
+    res = arr[:]
+    res = res[fancyIdx]
+    dt = time.time() - t
+    return res, dt
+
+def genarray(d, verbose=False):
+    shape = (d,) * 4
+    chunks = (d // 4,) * 4
+    blocks = (max(d // 10, 1),) * 4
+    t = time.time()
+    arr = blosc2.ones(shape=shape, chunks=chunks, blocks=blocks)  # , urlpath=file, mode="w")
+    t = time.time() - t
+    if verbose:
+        print(f"Array shape: {arr.shape}")
+        print(f"Array size: {np.prod(arr.shape) * arr.dtype.itemsize / 2 ** 30:.6f} GB")
+        print(f"Time to create array: {t:.6f} seconds")
+    return arr
 
 if __name__ == '__main__':
-    interval = 0.001
-    offset = 0
-    for f in [slice_dim1, slice_dim2, slice_dimNumpy]:
-        # mem = memory_usage((f,), interval=interval)
-        f()
-    #     times = offset + interval * np.arange(len(mem))
-    #     offset = times[-1]
-    #     plt.plot(times, mem)
-    #
-    # plt.xlabel('Time (s)')
-    # plt.ylabel('Memory usage (MiB)')
-    # plt.title('Memory usage fancy indexing')
-    # plt.legend(['method1', 'method2', 'numpy'])
-    # plt.savefig('plots/fancyIdx.png', format="png")
+    blosc_times = []
+    np_times = []
+    sizes = []
+    # dims = np.int64(np.array([2**6.76, 2**6.8, 2**6.85, 2**6.9, 2**6.95]))
+    dims = np.int64(np.array([2**4.3, 2**5.25, 2**6.25, 2**6.75, 2**7, 2**7.25, 2**7.4, 2**7.5]))
+
+    for d in dims:
+        arr = genarray(d)
+        arr_size = np.prod(arr.shape) * arr.dtype.itemsize / 2 ** 30
+        print(arr_size)
+        sizes.append(arr_size)
+        idx = np.random.randint(low=0, high=d, size=(d,))
+        if MEM_PROFILE:
+            fancyIdx = np.s_[idx, :, :d // 2, d // 2:]
+
+            interval = 0.001
+            offset = 0
+            for f in [fancyBlosc2, fancyNumpy]:
+                mem = memory_usage((f, (arr, fancyIdx)), interval=interval)
+                times = offset + interval * np.arange(len(mem))
+                offset = times[-1]
+                plt.plot(times, mem)
+
+            plt.xlabel('Time (s)')
+            plt.ylabel('Memory usage (MiB)')
+            plt.title('Memory usage fancy indexing')
+            plt.legend(['blosc2', 'numpy'])
+            plt.savefig(f'plots/MemoryUsagefancyIdx_d{d}.png', format="png")
+
+        row = idx
+        col = np.random.permutation(idx)
+        mask = np.random.randint(low=0, high=2, size=(d,)) == 1
+
+        ## Test fancy indexing for different use cases
+        loc_blosc_times = []
+        loc_np_times = []
+        m, M = np.min(idx), np.max(idx)
+        for i, fancyIdx in enumerate([
+            [m, M//2, M],  # i)
+            [[[m//2, M//2], [m//4, M//4]]],  # ii)
+            [row, col],  # iii)
+            # [row[:, None], col],  # iv)
+            [m, col],  # v)
+            [slice(1, M//2, 5), col],  # vi)
+            # [row[:, None], mask],  # vii)
+        ]):
+            # print(f'\n(case {i + 1})')
+            try:
+                r, c = fancyIdx
+                idx = (r, c)
+            except:
+                r, c = fancyIdx, None
+                idx = r
+            b, blosctime = fancyBlosc2(arr,idx)
+            n, nptime = fancyNumpy(arr,idx)
+            slice_size = np.prod(b.shape) * b.dtype.itemsize / 2 ** 30
+            np.testing.assert_allclose(b, n)
+            loc_blosc_times.append(blosctime)
+            loc_np_times.append(nptime)
+        blosc_times.append(loc_blosc_times)
+        np_times.append(loc_np_times)
+
+    blosc_times = np.array(blosc_times)
+    np_times = np.array(np_times)
+    x = np.arange(len(sizes))
+    width = 0.25
+
+    # Create bars for axis 0 plot
+    plt.bar(x - width, np_times.mean(axis=1), width, color='b', alpha=0.5)
+    plt.bar(x - width, np_times.max(axis=1), width, color='b', alpha=0.25)
+    plt.bar(x - width, np_times.min(axis=1), width, label='NumPy', color='b', alpha=1)
+    plt.bar(x, blosc_times.mean(axis=1), width, color='r', alpha=0.5)
+    plt.bar(x, blosc_times.max(axis=1), width, color='r', alpha=0.25)
+    plt.bar(x, blosc_times.min(axis=1), width, label='Blosc2', color='r', alpha=1)
+    plt.bar([],[], label='max', color='k', alpha=0.25)
+    plt.bar([],[], label='min', color='k', alpha=1)
+    plt.bar([],[], label='mean', color='k', alpha=0.5)
+
+    plt.xlabel('Array size (GB)')
+    plt.legend()
+    plt.xticks(x, np.round(sizes, 2))
+    plt.ylabel("Time (s)")
+    plt.title('Fancy indexing, Blosc2 vs NumPy')
+    plt.savefig('plots/fancyIdx.png', format="png")
+    plt.show()
+    ## slowest cases are the ones with broadcasting
+    ## in fact it's a problem for blosc2

--- a/bench/ndarray/fancy_index.py
+++ b/bench/ndarray/fancy_index.py
@@ -51,13 +51,14 @@ if __name__ == '__main__':
     sizes = []
     # dims = np.int64(np.array([2**6.76, 2**6.8, 2**6.85, 2**6.9, 2**6.95]))
     dims = np.int64(np.array([2**4.3, 2**5.25, 2**6.25, 2**6.75, 2**7, 2**7.25, 2**7.4, 2**7.5]))
+    rng = np.random.default_rng()
 
     for d in dims:
         arr = genarray(d)
         arr_size = np.prod(arr.shape) * arr.dtype.itemsize / 2 ** 30
         print(arr_size)
         sizes.append(arr_size)
-        idx = np.random.randint(low=0, high=d, size=(d,))
+        idx = rng.integers(low=0, high=d, size=(d,))
         if MEM_PROFILE:
             fancyIdx = np.s_[idx, :, :d // 2, d // 2:]
 
@@ -76,8 +77,8 @@ if __name__ == '__main__':
             plt.savefig(f'plots/MemoryUsagefancyIdx_d{d}.png', format="png")
 
         row = idx
-        col = np.random.permutation(idx)
-        mask = np.random.randint(low=0, high=2, size=(d,)) == 1
+        col = rng.permutation(idx)
+        mask = rng.integers(low=0, high=2, size=(d,)) == 1
 
         ## Test fancy indexing for different use cases
         loc_blosc_times = []
@@ -132,4 +133,4 @@ if __name__ == '__main__':
     plt.savefig('plots/fancyIdx.png', format="png")
     plt.show()
     ## slowest cases are the ones with broadcasting
-    ## in fact it's a problem for blosc2
+    ## in fact it's a memory problem for blosc2 seemingly

--- a/bench/ndarray/fancy_index.py
+++ b/bench/ndarray/fancy_index.py
@@ -1,0 +1,104 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# This source code is licensed under a BSD-style license (found in the
+# LICENSE file in the root directory of this source tree)
+#######################################################################
+
+# Benchmark for computing a fancy index of a blosc2 array
+
+import numpy as np
+import ndindex
+import blosc2
+import time
+from memory_profiler import memory_usage, profile
+import matplotlib.pyplot as plt
+
+d = 160
+shape = (d,) * 4
+chunks = (d // 4,) * 4
+blocks = (d // 10,) * 4
+print(f"Creating a 4D array of shape {shape} with chunks {chunks} and blocks {blocks}...")
+t = time.time()
+arr = blosc2.ones(shape=shape, chunks=chunks, blocks=blocks) #, urlpath=file, mode="w")
+t = time.time() - t
+print(f"Time to create array: {t:.6f} seconds")
+t = time.time()
+idx = np.random.randint(low=0, high=d, size=(d//4,))
+fancyIdx = np.s_[idx, 40, :d//2, d//2:]
+ans = arr[:][fancyIdx]
+
+# dim0
+# @profile
+def slice_dim1():
+    t = time.time()
+    _slice = ndindex.ndindex(fancyIdx).expand(shape)
+    chunk_size = ndindex.ChunkSize(chunks)
+
+    # repeated indices are grouped together
+    intersecting_chunks = chunk_size.as_subchunks(_slice, shape)  # if _slice is (), returns all chunks
+    out_shape = _slice.newshape(shape)
+    print(out_shape)
+
+    # Attempt 1
+    out = np.empty(out_shape, dtype=arr.dtype)
+    for n, c in enumerate(chunk_size.indices(shape)):
+        try:
+            sub_idx = _slice.as_subindex(c).raw
+            sel_idx = c.as_subindex(_slice).raw
+            chunk = blosc2.empty(
+                shape=arr.chunks, chunks=arr.chunks, blocks=arr.blocks, dtype=arr.dtype
+            )  # very cheap memory allocation
+            chunk.schunk.insert_chunk(0, arr.get_chunk(n))
+            out[sel_idx] = chunk[:][sub_idx]
+        except ValueError:
+            # This happens when the _slice and chunk do not intersect
+            continue
+    t0 = time.time() - t
+    np.testing.assert_allclose(out, ans)
+    print(f"Time to access blosc2, method 1: {t0:.6f} seconds")
+
+# @profile
+def slice_dim2():
+    t = time.time()
+    _slice = ndindex.ndindex(fancyIdx).expand(shape)
+    chunk_size = ndindex.ChunkSize(chunks)
+
+    # repeated indices are grouped together
+    intersecting_chunks = chunk_size.as_subchunks(_slice, shape)  # if _slice is (), returns all chunks
+    out_shape = _slice.newshape(shape)
+    ## Attempt 2
+    out = np.empty(out_shape, dtype=arr.dtype)
+    for c in intersecting_chunks:
+        sub_idx = _slice.as_subindex(c).raw
+        sel_idx = c.as_subindex(_slice).raw
+        chunk = arr[c.raw]
+        out[sel_idx] = chunk[sub_idx]
+    t0 = time.time() - t
+    np.testing.assert_allclose(out, ans)
+    print(f"Time to access blosc2, method 2: {t0:.6f} seconds")
+
+# @profile
+def slice_dimNumpy():
+    t = time.time()
+    res = arr[:][fancyIdx]
+    t0 = time.time() - t
+    print(f"Time to access numpy: {t0:.6f} seconds")
+    print(f"dim0 slice size: {np.prod(res.shape) * res.dtype.itemsize / 2**30:.6f} GB")
+
+if __name__ == '__main__':
+    interval = 0.001
+    offset = 0
+    for f in [slice_dim1, slice_dim2, slice_dimNumpy]:
+        # mem = memory_usage((f,), interval=interval)
+        f()
+    #     times = offset + interval * np.arange(len(mem))
+    #     offset = times[-1]
+    #     plt.plot(times, mem)
+    #
+    # plt.xlabel('Time (s)')
+    # plt.ylabel('Memory usage (MiB)')
+    # plt.title('Memory usage fancy indexing')
+    # plt.legend(['method1', 'method2', 'numpy'])
+    # plt.savefig('plots/fancyIdx.png', format="png")

--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -510,6 +510,9 @@ cdef extern from "b2nd.h":
     int b2nd_concatenate(b2nd_context_t *ctx, b2nd_array_t *src1, b2nd_array_t *src2,
                          int8_t axis, c_bool copy, b2nd_array_t **array)
     int b2nd_expand_dims(const b2nd_array_t *array, b2nd_array_t ** view, const int8_t axis)
+    int b2nd_get_orthogonal_selection(const b2nd_array_t *array, int64_t ** selection,
+                                      int64_t *selection_size, void *buffer,
+                                      int64_t *buffershape, int64_t buffersize)
     int b2nd_from_schunk(blosc2_schunk *schunk, b2nd_array_t **array)
 
     void blosc2_unidim_to_multidim(uint8_t ndim, int64_t *shape, int64_t i, int64_t *index)
@@ -2417,6 +2420,39 @@ cdef class NDArray:
                   "Error while getting the buffer")
         PyBuffer_Release(&view)
 
+        return arr
+
+    def get_oindex_numpy(self, arr, key):
+        """
+        Orthogonal indexing. Key is a tuple of lists of integer indices.
+        """
+        ## have to maybe edit key to be C-compatible
+        if len(key) != self.array.ndim:
+            raise ValueError(f"Key must have {self.array.ndim} dimensions, got {len(key)}.")
+        cdef int64_t[B2ND_MAX_DIM] buffershape_
+        cdef int64_t** key_
+        cdef int64_t buffersize_ = self.array.sc.typesize
+        cdef int64_t[B2ND_MAX_DIM] sel_size
+
+        key_ = <int64_t**> malloc(len(key) * sizeof(int64_t *))
+
+        for i in range(self.array.ndim):
+            buffershape_[i] = len(key[i])
+            buffersize_ *= buffershape_[i]
+            sel_size[i] = len(key[i])
+            key_[i] = <int64_t *> malloc(sel_size[i] * sizeof(int64_t))
+            for j in range(len(key[i])):
+                key_[i][j] = key[i][j]
+
+        cdef Py_buffer buf
+        PyObject_GetBuffer(arr, &buf, PyBUF_SIMPLE)
+
+        _check_rc(b2nd_get_orthogonal_selection(self.array, key_, sel_size, buf.buf,
+                                                buffershape_, buffersize_), "Error while getting orthogonal selection")
+        PyBuffer_Release(&buf)
+        for i in range(len(key)):
+            free(key_[i])  # Free the allocated memory for each key
+        free(key_)
         return arr
 
 

--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -513,6 +513,9 @@ cdef extern from "b2nd.h":
     int b2nd_get_orthogonal_selection(const b2nd_array_t *array, int64_t ** selection,
                                       int64_t *selection_size, void *buffer,
                                       int64_t *buffershape, int64_t buffersize)
+    int b2nd_set_orthogonal_selection(const b2nd_array_t *array, int64_t ** selection,
+                                      int64_t *selection_size, void *buffer,
+                                      int64_t *buffershape, int64_t buffersize)
     int b2nd_from_schunk(blosc2_schunk *schunk, b2nd_array_t **array)
 
     void blosc2_unidim_to_multidim(uint8_t ndim, int64_t *shape, int64_t i, int64_t *index)
@@ -2426,7 +2429,6 @@ cdef class NDArray:
         """
         Orthogonal indexing. Key is a tuple of lists of integer indices.
         """
-        ## have to maybe edit key to be C-compatible
         if len(key) != self.array.ndim:
             raise ValueError(f"Key must have {self.array.ndim} dimensions, got {len(key)}.")
         cdef int64_t[B2ND_MAX_DIM] buffershape_
@@ -2448,6 +2450,38 @@ cdef class NDArray:
         PyObject_GetBuffer(arr, &buf, PyBUF_SIMPLE)
 
         _check_rc(b2nd_get_orthogonal_selection(self.array, key_, sel_size, buf.buf,
+                                                buffershape_, buffersize_), "Error while getting orthogonal selection")
+        PyBuffer_Release(&buf)
+        for i in range(len(key)):
+            free(key_[i])  # Free the allocated memory for each key
+        free(key_)
+        return arr
+
+    def set_oindex_numpy(self, key, arr):
+        """
+        Orthogonal indexing. Set elements of self with arr using key.
+        """
+        if len(key) != self.array.ndim:
+            raise ValueError(f"Key must have {self.array.ndim} dimensions, got {len(key)}.")
+        cdef int64_t[B2ND_MAX_DIM] buffershape_
+        cdef int64_t** key_
+        cdef int64_t buffersize_ = self.array.sc.typesize
+        cdef int64_t[B2ND_MAX_DIM] sel_size
+
+        key_ = <int64_t**> malloc(len(key) * sizeof(int64_t *))
+
+        for i in range(self.array.ndim):
+            buffershape_[i] = len(key[i])
+            buffersize_ *= buffershape_[i]
+            sel_size[i] = len(key[i])
+            key_[i] = <int64_t *> malloc(sel_size[i] * sizeof(int64_t))
+            for j in range(len(key[i])):
+                key_[i][j] = key[i][j]
+
+        cdef Py_buffer buf
+        PyObject_GetBuffer(arr, &buf, PyBUF_SIMPLE)
+
+        _check_rc(b2nd_set_orthogonal_selection(self.array, key_, sel_size, buf.buf,
                                                 buffershape_, buffersize_), "Error while getting orthogonal selection")
         PyBuffer_Release(&buf)
         for i in range(len(key)):

--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -509,9 +509,6 @@ cdef extern from "b2nd.h":
     int b2nd_copy(b2nd_context_t *ctx, b2nd_array_t *src, b2nd_array_t **array)
     int b2nd_concatenate(b2nd_context_t *ctx, b2nd_array_t *src1, b2nd_array_t *src2,
                          int8_t axis, c_bool copy, b2nd_array_t **array)
-    int b2nd_get_orthogonal_selection(const b2nd_array_t *array, int64_t **selection,
-                                  int64_t *selection_size, void *buffer,
-                                  int64_t *buffershape, int64_t buffersize)
     int b2nd_expand_dims(const b2nd_array_t *array, b2nd_array_t ** view, const int8_t axis)
     int b2nd_from_schunk(blosc2_schunk *schunk, b2nd_array_t **array)
 
@@ -2422,23 +2419,6 @@ cdef class NDArray:
 
         return arr
 
-    def get_oindex_numpy(self, arr, key):
-        """
-        Orthogonal indexing. Key is a tuple of lists of integer indices.
-        """
-
-        cdef int64_t[B2ND_MAX_DIM] bufshape
-        for i in range(len(key)):
-            bufshape[i] = len(key[i])
-
-        cdef Py_buffer buf
-        PyObject_GetBuffer(arr, &buf, PyBUF_SIMPLE)
-        cdef int64_t bufsize = np.prod(bufshape) * self.dtype.itemsize
-
-        _check_rc(b2nd_get_orthogonal_selection(self.array, key, bufshape, buf.buf,
-                                                bufshape, bufsize), "Error while getting orthogonal selection")
-        PyBuffer_Release(&buf)
-        return arr
 
     def get_slice(self, key, mask, **kwargs):
         start, stop = key

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1469,8 +1469,10 @@ class NDArray(blosc2_ext.NDArray, Operand):
         shape = tuple(len(k) for k in key) + self.shape[len(key) :]
         # Create the array to store the result
         arr = np.empty(shape, dtype=self.dtype)
-
         return super().get_oindex_numpy(arr, key)
+
+    def set_oselection_numpy(self, key, arr):
+        return super().set_oindex_numpy(key, arr)
 
     def __getitem__(  # noqa: C901
         self,
@@ -4386,9 +4388,11 @@ class OIndex:
     def __init__(self, array: NDArray):
         self.array = array
 
-    # TODO: add __setitem__
     def __getitem__(self, selection) -> np.ndarray:
         return self.array.get_oselection_numpy(selection)
+
+    def __setitem__(self, selection, input) -> np.ndarray:
+        return self.array.set_oselection_numpy(selection, input)
 
 
 class VIndex:

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1442,9 +1442,6 @@ class NDArray(blosc2_ext.NDArray, Operand):
     def get_fselection_numpy(self, key):
         # TODO: Make this faster for broadcasted keys
         shape = self.shape
-        if math.prod(shape) * self.dtype.itemsize < blosc2.MAX_FAST_PATH_SIZE:
-            # just load whole array into memory and do numpy indexing
-            return self[:][key]
         chunks = self.chunks
         _slice = ndindex.ndindex(key).expand(shape)
         chunk_size = ndindex.ChunkSize(chunks)
@@ -1466,20 +1463,20 @@ class NDArray(blosc2_ext.NDArray, Operand):
         return out
 
     def get_oselection_numpy(self, key):
-        '''
+        """
         Select independently from self along axes specified in key. Key must be same length as self shape.
         See Zarr https://zarr.readthedocs.io/en/stable/user-guide/arrays.html#orthogonal-indexing.
-        '''
+        """
         shape = tuple(len(k) for k in key) + self.shape[len(key) :]
         # Create the array to store the result
         arr = np.empty(shape, dtype=self.dtype)
         return super().get_oindex_numpy(arr, key)
 
     def set_oselection_numpy(self, key, arr: np.ndarray):
-        '''
+        """
         Select independently from self along axes specified in key and set to entries in arr. Key must be same length as self shape.
         See Zarr https://zarr.readthedocs.io/en/stable/user-guide/arrays.html#orthogonal-indexing.
-        '''
+        """
         return super().set_oindex_numpy(key, arr)
 
     def __getitem__(  # noqa: C901
@@ -4409,7 +4406,7 @@ class VIndex:
 
     # TODO: all this
     def __getitem__(self, selection) -> np.ndarray:
-        return NotImplementedError 
+        return NotImplementedError
 
     def __setitem__(self, selection, input) -> np.ndarray:
         return NotImplementedError

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1502,7 +1502,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         elif isinstance(key, tuple):
             if builtins.any(isinstance(k, (list, np.ndarray)) for k in key):
                 return self.vindex_numpy(key)  # fancy index
-            if builtins.sum(isinstance(k, (list, builtins.slice)) for k in key) != self.ndim:
+            if builtins.any(not isinstance(k, (list, builtins.slice)) for k in key):
                 key_, mask = process_key(key, self.shape)
         elif isinstance(key, (list, np.ndarray, NDArray)):
             if isinstance(key, list):

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1502,7 +1502,7 @@ class NDArray(blosc2_ext.NDArray, Operand):
         elif isinstance(key, tuple):
             if builtins.any(isinstance(k, (list, np.ndarray)) for k in key):
                 return self.vindex_numpy(key)  # fancy index
-            if builtins.any(not isinstance(k, (list, builtins.slice)) for k in key):
+            if builtins.sum(isinstance(k, (list, builtins.slice)) for k in key) != self.ndim:
                 key_, mask = process_key(key, self.shape)
         elif isinstance(key, (list, np.ndarray, NDArray)):
             if isinstance(key, list):

--- a/tests/ndarray/test_ndarray.py
+++ b/tests/ndarray/test_ndarray.py
@@ -277,14 +277,23 @@ def test_oindex():
     sel1 = [2, 5]
     sel2 = [3, 3, 3, 9, 3, 1, 0]
     sel = [sel0, sel1, sel2]
-    nparr = arr[:][sel0][:, sel1][:, :, sel2]
+    sel0_=np.array(sel0).reshape(-1,1,1)
+    sel1_=np.array(sel1).reshape(1,-1,1)
+    sel2_=np.array(sel2).reshape(1,1,-1)
+
+    nparr = arr[:]
+    n = nparr[sel0_,sel1_,sel2_]
     b = arr.oindex[sel]
 
-    np.testing.assert_allclose(b, nparr)
+    np.testing.assert_allclose(b, n)
+    # Test set
+    arr.oindex[sel] = np.zeros(n.shape)
+    nparr[sel0_,sel1_,sel2_] = 0
+    np.testing.assert_allclose(arr[:], nparr)
 
 
 def test_vindex():
-    ndim = 2
+    ndim = 3
     d = 100
     shape = (d,) * ndim
     arr = blosc2.linspace(0, 100, num=np.prod(shape), shape=shape, dtype="i4")
@@ -297,45 +306,58 @@ def test_vindex():
 
     ## Test fancy indexing for different use cases
     m, M = np.min(idx), np.max(idx)
+    nparr = arr[:]
     # i)
     b = arr[[m, M // 2, M]]
-    n = arr[:][[m, M // 2, M]]
+    n = nparr[[m, M // 2, M]]
     b2 = arr.vindex[[m, M // 2, M]]
     np.testing.assert_allclose(b, n)
     np.testing.assert_allclose(b2, n)
     # ii)
     b = arr[[[m // 2, M // 2], [m // 4, M // 4]]]
-    n = arr[:][[[m // 2, M // 2], [m // 4, M // 4]]]
+    n = nparr[[[m // 2, M // 2], [m // 4, M // 4]]]
     b2 = arr.vindex[[[m // 2, M // 2], [m // 4, M // 4]]]
     np.testing.assert_allclose(b, n)
     np.testing.assert_allclose(b2, n)
     # iii)
     b = arr[row, col]
-    n = arr[:][row, col]
+    n = nparr[row, col]
     b2 = arr.vindex[row, col]
     np.testing.assert_allclose(b, n)
     np.testing.assert_allclose(b2, n)
     # iv)
     b = arr[row[:, None], col]
-    n = arr[:][row[:, None], col]
+    n = nparr[row[:, None], col]
     b2 = arr.vindex[row[:, None], col]
     np.testing.assert_allclose(b, n)
     np.testing.assert_allclose(b2, n)
     # v)
     b = arr[m, col]
-    n = arr[:][m, col]
+    n = nparr[m, col]
     b2 = arr.vindex[m, col]
     np.testing.assert_allclose(b, n)
     np.testing.assert_allclose(b2, n)
     # vi)
     b = arr[1 : M // 2 : 5, col]
-    n = arr[:][1 : M // 2 : 5, col]
+    n = nparr[1 : M // 2 : 5, col]
     b2 = arr.vindex[1 : M // 2 : 5, col]
     np.testing.assert_allclose(b, n)
     np.testing.assert_allclose(b2, n)
     # vii)
     b = arr[row[:, None], mask]
-    n = arr[:][row[:, None], mask]
+    n = nparr[row[:, None], mask]
     b2 = arr.vindex[row[:, None], mask]
     np.testing.assert_allclose(b, n)
     np.testing.assert_allclose(b2, n)
+    # Transposition test (3rd example is transposed)
+    b1 = arr[:, [0, 1], 0]
+    b2 = arr[[0, 1], 0, :]
+    b3 = arr[0, :, [0, 1]]
+    n1 = nparr[:, [0, 1], 0]
+    n2 = nparr[[0, 1], 0, :]
+    n3 = nparr[0, :, [0, 1]]
+    print(b3.shape)
+    np.testing.assert_allclose(b1, n1)
+    np.testing.assert_allclose(b2, n2)
+    np.testing.assert_allclose(b3, n3)
+

--- a/tests/ndarray/test_ndarray.py
+++ b/tests/ndarray/test_ndarray.py
@@ -269,6 +269,7 @@ def test_save():
 
 
 def test_oindex():
+    # Test Get
     ndim = 3
     shape = (10,) * ndim
     arr = blosc2.linspace(0, 100, num=np.prod(shape), shape=shape, dtype="i4")

--- a/tests/ndarray/test_ndarray.py
+++ b/tests/ndarray/test_ndarray.py
@@ -277,22 +277,22 @@ def test_oindex():
     sel1 = [2, 5]
     sel2 = [3, 3, 3, 9, 3, 1, 0]
     sel = [sel0, sel1, sel2]
-    sel0_=np.array(sel0).reshape(-1,1,1)
-    sel1_=np.array(sel1).reshape(1,-1,1)
-    sel2_=np.array(sel2).reshape(1,1,-1)
+    sel0_ = np.array(sel0).reshape(-1, 1, 1)
+    sel1_ = np.array(sel1).reshape(1, -1, 1)
+    sel2_ = np.array(sel2).reshape(1, 1, -1)
 
     nparr = arr[:]
-    n = nparr[sel0_,sel1_,sel2_]
+    n = nparr[sel0_, sel1_, sel2_]
     b = arr.oindex[sel]
 
     np.testing.assert_allclose(b, n)
     # Test set
     arr.oindex[sel] = np.zeros(n.shape)
-    nparr[sel0_,sel1_,sel2_] = 0
+    nparr[sel0_, sel1_, sel2_] = 0
     np.testing.assert_allclose(arr[:], nparr)
 
 
-def test_vindex():
+def test_findex():
     ndim = 3
     d = 100
     shape = (d,) * ndim
@@ -310,45 +310,31 @@ def test_vindex():
     # i)
     b = arr[[m, M // 2, M]]
     n = nparr[[m, M // 2, M]]
-    b2 = arr.vindex[[m, M // 2, M]]
     np.testing.assert_allclose(b, n)
-    np.testing.assert_allclose(b2, n)
     # ii)
     b = arr[[[m // 2, M // 2], [m // 4, M // 4]]]
     n = nparr[[[m // 2, M // 2], [m // 4, M // 4]]]
-    b2 = arr.vindex[[[m // 2, M // 2], [m // 4, M // 4]]]
     np.testing.assert_allclose(b, n)
-    np.testing.assert_allclose(b2, n)
     # iii)
     b = arr[row, col]
     n = nparr[row, col]
-    b2 = arr.vindex[row, col]
     np.testing.assert_allclose(b, n)
-    np.testing.assert_allclose(b2, n)
     # iv)
     b = arr[row[:, None], col]
     n = nparr[row[:, None], col]
-    b2 = arr.vindex[row[:, None], col]
     np.testing.assert_allclose(b, n)
-    np.testing.assert_allclose(b2, n)
     # v)
     b = arr[m, col]
     n = nparr[m, col]
-    b2 = arr.vindex[m, col]
     np.testing.assert_allclose(b, n)
-    np.testing.assert_allclose(b2, n)
     # vi)
     b = arr[1 : M // 2 : 5, col]
     n = nparr[1 : M // 2 : 5, col]
-    b2 = arr.vindex[1 : M // 2 : 5, col]
     np.testing.assert_allclose(b, n)
-    np.testing.assert_allclose(b2, n)
     # vii)
     b = arr[row[:, None], mask]
     n = nparr[row[:, None], mask]
-    b2 = arr.vindex[row[:, None], mask]
     np.testing.assert_allclose(b, n)
-    np.testing.assert_allclose(b2, n)
     # Transposition test (3rd example is transposed)
     b1 = arr[:, [0, 1], 0]
     b2 = arr[[0, 1], 0, :]
@@ -360,4 +346,3 @@ def test_vindex():
     np.testing.assert_allclose(b1, n1)
     np.testing.assert_allclose(b2, n2)
     np.testing.assert_allclose(b3, n3)
-


### PR DESCRIPTION
Support fancy indexing in Blosc2. 

Remaining tasks: 
- implement vindex (for numpy and blosc array return types)
- finish implementation of oindex (return blosc array)
- optimise fancy indexing for broadcasted index arrays
- implement setitem for fancy indexing
- implement fancy indexing in slice (i.e. return blosc array not numpy array)