### PR TITLE
Update to cat2cloud

### DIFF
--- a/doc/getting_started/tutorials/06.remote_proxy.ipynb
+++ b/doc/getting_started/tutorials/06.remote_proxy.ipynb
@@ -17,8 +17,8 @@
    "id": "92755a11cc34e834",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-07-17T12:17:15.343456Z",
-     "start_time": "2025-07-17T12:17:15.224486Z"
+     "end_time": "2025-07-17T12:21:54.225036Z",
+     "start_time": "2025-07-17T12:21:54.222799Z"
     }
    },
    "source": [
@@ -30,7 +30,7 @@
     "from blosc2 import ProxyNDSource"
    ],
    "outputs": [],
-   "execution_count": 1
+   "execution_count": 16
   },
   {
    "cell_type": "markdown",
@@ -48,8 +48,8 @@
    "id": "bab50ca19740a1aa",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-07-17T12:17:15.353489Z",
-     "start_time": "2025-07-17T12:17:15.350506Z"
+     "end_time": "2025-07-17T12:21:54.239037Z",
+     "start_time": "2025-07-17T12:21:54.235968Z"
     }
    },
    "source": [
@@ -89,7 +89,7 @@
     "        return self.data.get_chunk(nchunk)"
    ],
    "outputs": [],
-   "execution_count": 2
+   "execution_count": 17
   },
   {
    "cell_type": "markdown",
@@ -102,25 +102,25 @@
    "id": "aa92e842ec2a2fd7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-07-17T12:17:15.373773Z",
-     "start_time": "2025-07-17T12:17:15.358343Z"
+     "end_time": "2025-07-17T12:21:54.422531Z",
+     "start_time": "2025-07-17T12:21:54.246151Z"
     }
    },
    "source": [
-    "urlbase = \"http://localhost:8002\"\n",
+    "urlbase = \"https://cat2.cloud/demo\"\n",
     "path = \"@public/examples/lung-jpeg2000_10x.b2nd\"\n",
     "remote_array = blosc2.C2Array(path, urlbase=urlbase)"
    ],
    "outputs": [],
-   "execution_count": 3
+   "execution_count": 18
   },
   {
    "cell_type": "code",
    "id": "9360ba9e4f946fe0",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-07-17T12:17:15.441338Z",
-     "start_time": "2025-07-17T12:17:15.438365Z"
+     "end_time": "2025-07-17T12:21:54.434914Z",
+     "start_time": "2025-07-17T12:21:54.430258Z"
     }
    },
    "source": [
@@ -143,7 +143,7 @@
      ]
     }
    ],
-   "execution_count": 4
+   "execution_count": 19
   },
   {
    "cell_type": "markdown",
@@ -167,8 +167,8 @@
    "id": "ae1babeebf0a75ee",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-07-17T12:17:15.557293Z",
-     "start_time": "2025-07-17T12:17:15.451539Z"
+     "end_time": "2025-07-17T12:21:55.322939Z",
+     "start_time": "2025-07-17T12:21:54.445747Z"
     }
    },
    "source": [
@@ -185,7 +185,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to fetch: 0.01 s\n",
+      "Time to fetch: 0.85 s\n",
       "File size after fetch (2 chunks): 1.28 MB\n",
       "[[[15712 13933 18298 ... 21183 22486 20541]\n",
       "  [18597 21261 23925 ... 22861 21008 19155]]\n",
@@ -195,7 +195,7 @@
      ]
     }
    ],
-   "execution_count": 5
+   "execution_count": 20
   },
   {
    "cell_type": "markdown",
@@ -214,8 +214,8 @@
    "id": "937180b9469272ae",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-07-17T12:17:15.606288Z",
-     "start_time": "2025-07-17T12:17:15.566141Z"
+     "end_time": "2025-07-17T12:21:55.818242Z",
+     "start_time": "2025-07-17T12:21:55.333597Z"
     }
    },
    "source": [
@@ -232,7 +232,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to fetch: 0.01 s\n",
+      "Time to fetch: 0.44 s\n",
       "File size after fetch (1 chunk): 1.92 MB\n",
       "[[[15712 13933 18298 ... 21183 22486 20541]\n",
       "  [18597 21261 23925 ... 22861 21008 19155]]\n",
@@ -242,7 +242,7 @@
      ]
     }
    ],
-   "execution_count": 6
+   "execution_count": 21
   },
   {
    "cell_type": "markdown",
@@ -266,8 +266,8 @@
    "id": "4f4fb754d2c34a48",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2025-07-17T12:17:15.657507Z",
-     "start_time": "2025-07-17T12:17:15.615663Z"
+     "end_time": "2025-07-17T12:21:56.761267Z",
+     "start_time": "2025-07-17T12:21:55.827658Z"
     }
    },
    "source": [
@@ -285,7 +285,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Proxy __getitem__ time: 0.040 s\n",
+      "Proxy __getitem__ time: 0.931 s\n",
       "[[[16540 15270 20144 ... 20689 21494 19655]\n",
       "  [17816 21097 24378 ... 21449 20582 19715]]\n",
       "\n",
@@ -296,7 +296,7 @@
      ]
     }
    ],
-   "execution_count": 7
+   "execution_count": 22
   },
   {
    "cell_type": "markdown",

--- a/doc/getting_started/tutorials/06.remote_proxy.ipynb
+++ b/doc/getting_started/tutorials/06.remote_proxy.ipynb
@@ -14,15 +14,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
    "id": "92755a11cc34e834",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T08:42:54.896377Z",
-     "start_time": "2024-10-08T08:42:52.998694Z"
+     "end_time": "2025-07-17T12:17:15.343456Z",
+     "start_time": "2025-07-17T12:17:15.224486Z"
     }
    },
-   "outputs": [],
    "source": [
     "import asyncio\n",
     "import os\n",
@@ -30,7 +28,9 @@
     "\n",
     "import blosc2\n",
     "from blosc2 import ProxyNDSource"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 1
   },
   {
    "cell_type": "markdown",
@@ -45,15 +45,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
    "id": "bab50ca19740a1aa",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T08:43:00.603510Z",
-     "start_time": "2024-10-08T08:43:00.589048Z"
+     "end_time": "2025-07-17T12:17:15.353489Z",
+     "start_time": "2025-07-17T12:17:15.350506Z"
     }
    },
-   "outputs": [],
    "source": [
     "def get_file_size(filepath):\n",
     "    \"\"\"Returns the file size in megabytes.\"\"\"\n",
@@ -89,41 +87,51 @@
     "    async def aget_chunk(self, nchunk):\n",
     "        await asyncio.sleep(0.1)  # simulate an asynchronous operation\n",
     "        return self.data.get_chunk(nchunk)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 2
   },
   {
    "cell_type": "markdown",
    "id": "32fffd14035b20c4",
    "metadata": {},
-   "source": "Next, we will establish a connection to a [multidimensional array stored remotely](https://demo.caterva2.net/roots/example/lung-jpeg2000_10x.b2nd?roots=example) on a [Caterva2](https://ironarray.io/caterva2) demo server (https://demo.caterva2.net/). The remote_array object will represent this dataset on the server, enabling us to access the information without the need to load all the data into local memory at once."
+   "source": "Next, we will establish a connection to a [multidimensional array stored remotely](https://cat2.cloud/demo/roots/@public/examples/lung-jpeg2000_10x.b2nd?roots=%40public) on a [Cat2Cloud](https://ironarray.io/cat2cloud) demo server (https://cat2.cloud/demo). The remote_array object will represent this dataset on the server, enabling us to access the information without the need to load all the data into local memory at once."
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
    "id": "aa92e842ec2a2fd7",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T08:43:10.073998Z",
-     "start_time": "2024-10-08T08:43:09.567381Z"
+     "end_time": "2025-07-17T12:17:15.373773Z",
+     "start_time": "2025-07-17T12:17:15.358343Z"
     }
    },
-   "outputs": [],
    "source": [
-    "urlbase = \"https://demo.caterva2.net/\"\n",
-    "path = \"example/lung-jpeg2000_10x.b2nd\"\n",
+    "urlbase = \"http://localhost:8002\"\n",
+    "path = \"@public/examples/lung-jpeg2000_10x.b2nd\"\n",
     "remote_array = blosc2.C2Array(path, urlbase=urlbase)"
-   ]
+   ],
+   "outputs": [],
+   "execution_count": 3
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
    "id": "9360ba9e4f946fe0",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T08:43:11.259755Z",
-     "start_time": "2024-10-08T08:43:11.238191Z"
+     "end_time": "2025-07-17T12:17:15.441338Z",
+     "start_time": "2025-07-17T12:17:15.438365Z"
     }
    },
+   "source": [
+    "# Define a local file path to save the proxy container\n",
+    "local_path = \"local_proxy_container.b2nd\"\n",
+    "source = MyProxySource(remote_array)\n",
+    "proxy = blosc2.Proxy(source, urlpath=local_path, mode=\"w\")\n",
+    "print(type(proxy))\n",
+    "initial_size = get_file_size(local_path)\n",
+    "print(f\"Initial local file size: {os.path.getsize(local_path)} bytes\")"
+   ],
    "outputs": [
     {
      "name": "stdout",
@@ -135,15 +143,7 @@
      ]
     }
    ],
-   "source": [
-    "# Define a local file path to save the proxy container\n",
-    "local_path = \"local_proxy_container.b2nd\"\n",
-    "source = MyProxySource(remote_array)\n",
-    "proxy = blosc2.Proxy(source, urlpath=local_path, mode=\"w\")\n",
-    "print(type(proxy))\n",
-    "initial_size = get_file_size(local_path)\n",
-    "print(f\"Initial local file size: {os.path.getsize(local_path)} bytes\")"
-   ]
+   "execution_count": 4
   },
   {
    "cell_type": "markdown",
@@ -164,20 +164,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
    "id": "ae1babeebf0a75ee",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T08:43:51.053692Z",
-     "start_time": "2024-10-08T08:43:49.190803Z"
+     "end_time": "2025-07-17T12:17:15.557293Z",
+     "start_time": "2025-07-17T12:17:15.451539Z"
     }
    },
+   "source": [
+    "# Fetch a slice of the data from the proxy\n",
+    "t0 = time.time()\n",
+    "slice_data = proxy.fetch(slice(0, 2))\n",
+    "t1 = time.time() - t0\n",
+    "print(f\"Time to fetch: {t1:.2f} s\")\n",
+    "print(f\"File size after fetch (2 chunks): {get_file_size(local_path):.2f} MB\")\n",
+    "print(slice_data[1:3, 1:3])"
+   ],
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to fetch: 1.49 s\n",
+      "Time to fetch: 0.01 s\n",
       "File size after fetch (2 chunks): 1.28 MB\n",
       "[[[15712 13933 18298 ... 21183 22486 20541]\n",
       "  [18597 21261 23925 ... 22861 21008 19155]]\n",
@@ -187,15 +195,7 @@
      ]
     }
    ],
-   "source": [
-    "# Fetch a slice of the data from the proxy\n",
-    "t0 = time.time()\n",
-    "slice_data = proxy.fetch(slice(0, 2))\n",
-    "t1 = time.time() - t0\n",
-    "print(f\"Time to fetch: {t1:.2f} s\")\n",
-    "print(f\"File size after fetch (2 chunks): {get_file_size(local_path):.2f} MB\")\n",
-    "print(slice_data[1:3, 1:3])"
-   ]
+   "execution_count": 5
   },
   {
    "cell_type": "markdown",
@@ -211,20 +211,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
    "id": "937180b9469272ae",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T08:44:13.262876Z",
-     "start_time": "2024-10-08T08:44:12.132677Z"
+     "end_time": "2025-07-17T12:17:15.606288Z",
+     "start_time": "2025-07-17T12:17:15.566141Z"
     }
    },
+   "source": [
+    "# Fetch a slice of the data from the proxy\n",
+    "t0 = time.time()\n",
+    "slice_data2 = proxy.fetch((slice(2, 3), slice(6, 7)))\n",
+    "t1 = time.time() - t0\n",
+    "print(f\"Time to fetch: {t1:.2f} s\")\n",
+    "print(f\"File size after fetch (1 chunk): {get_file_size(local_path):.2f} MB\")\n",
+    "print(slice_data[1:3, 1:3])"
+   ],
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Time to fetch: 0.93 s\n",
+      "Time to fetch: 0.01 s\n",
       "File size after fetch (1 chunk): 1.92 MB\n",
       "[[[15712 13933 18298 ... 21183 22486 20541]\n",
       "  [18597 21261 23925 ... 22861 21008 19155]]\n",
@@ -234,15 +242,7 @@
      ]
     }
    ],
-   "source": [
-    "# Fetch a slice of the data from the proxy\n",
-    "t0 = time.time()\n",
-    "slice_data2 = proxy.fetch((slice(2, 3), slice(6, 7)))\n",
-    "t1 = time.time() - t0\n",
-    "print(f\"Time to fetch: {t1:.2f} s\")\n",
-    "print(f\"File size after fetch (1 chunk): {get_file_size(local_path):.2f} MB\")\n",
-    "print(slice_data[1:3, 1:3])"
-   ]
+   "execution_count": 6
   },
   {
    "cell_type": "markdown",
@@ -263,20 +263,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
    "id": "4f4fb754d2c34a48",
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2024-10-08T08:44:27.127563Z",
-     "start_time": "2024-10-08T08:44:25.512306Z"
+     "end_time": "2025-07-17T12:17:15.657507Z",
+     "start_time": "2025-07-17T12:17:15.615663Z"
     }
    },
+   "source": [
+    "# Using __getitem__ to get a slice of the data\n",
+    "t0 = time.time()\n",
+    "result = proxy[5:7, 1:3]\n",
+    "t1 = time.time() - t0\n",
+    "print(f\"Proxy __getitem__ time: {t1:.3f} s\")\n",
+    "print(result)\n",
+    "print(type(result))\n",
+    "print(f\"File size after __getitem__ (2 chunks): {get_file_size(local_path):.2f} MB\")"
+   ],
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Proxy __getitem__ time: 1.611 s\n",
+      "Proxy __getitem__ time: 0.040 s\n",
       "[[[16540 15270 20144 ... 20689 21494 19655]\n",
       "  [17816 21097 24378 ... 21449 20582 19715]]\n",
       "\n",
@@ -287,16 +296,7 @@
      ]
     }
    ],
-   "source": [
-    "# Using __getitem__ to get a slice of the data\n",
-    "t0 = time.time()\n",
-    "result = proxy[5:7, 1:3]\n",
-    "t1 = time.time() - t0\n",
-    "print(f\"Proxy __getitem__ time: {t1:.3f} s\")\n",
-    "print(result)\n",
-    "print(type(result))\n",
-    "print(f\"File size after __getitem__ (2 chunks): {get_file_size(local_path):.2f} MB\")"
-   ]
+   "execution_count": 7
   },
   {
    "cell_type": "markdown",
@@ -329,7 +329,7 @@
    "source": [
     "## About the remote dataset\n",
     "\n",
-    "The remote dataset is available at: https://demo.caterva2.net/roots/example/lung-jpeg2000_10x.b2nd?roots=example. You may want to explore the data values by clicking on the *Data* tab; this dataset is actually a tomography of a lung, which you can visualize by clicking on the *Tomography* tab. Finally, by clicking on the **Download** button, it can be downloaded locally in case you want to experiment more with the data.\n",
+    "The remote dataset is available at: https://cat2.cloud/demo/roots/@public/examples/lung-jpeg2000_10x.b2nd?roots=%40public. You may want to explore the data values by clicking on the *Data* tab; this dataset is actually a tomography of a lung, which you can visualize by clicking on the *Tomography* tab. Finally, by clicking on the **Download** button, it can be downloaded locally in case you want to experiment more with the data.\n",
     "\n",
     "As we have seen, every time that we downloaded a chunk, the size of the local file increased by a fix amount (around 0.64 MB). This is because the chunks (whose size is around 6.4 MB) are compressed with the `Codec.GROK` codec, which has been configured to reduce the size of the data by a *constant* factor of 10. This means that the compressed data occupies only one-tenth of the space that it would occupy without compression.  This reduction in data size optimizes both storage and transfer, as data is always handled in a compressed state when downloading or storing images, which accelerates the transfer process.\n",
     "\n"

--- a/examples/ndarray/c2array_expr.py
+++ b/examples/ndarray/c2array_expr.py
@@ -4,20 +4,15 @@ import numpy as np
 
 import blosc2
 
-host = "https://demo.caterva2.net/"
-root = "b2tests"
-dir = "expr/"
+host = "https://cat2.cloud/demo"
+root = "@public"
+dir = "examples/"
 
 # For a Caterva2 server running locally, use:
-# host = 'localhost:8002'
+# host = 'http://localhost:8002'
 
-# The root of the datasets
-root = "b2tests"
-# The directory inside root where the datasets are stored
-dir = "expr/"
-
-name1 = "ds-0-10-linspace-float64-(True, True)-a1-(60, 60)d.b2nd"
-name2 = "ds-0-10-linspace-float64-(True, True)-a2-(60, 60)d.b2nd"
+name1 = "ds-1d.b2nd"
+name2 = "dir1/ds-2d.b2nd"
 path1 = pathlib.Path(f"{root}/{dir + name1}").as_posix()
 path2 = pathlib.Path(f"{root}/{dir + name2}").as_posix()
 
@@ -25,12 +20,12 @@ a = blosc2.C2Array(path1, host)
 b = blosc2.C2Array(path2, host)
 
 # Evaluate only a slice of the expression
-c = a + b
+c = a[:20] + b
 print(type(c))
-print(c[10:20, 10:20])
+print(c[10:20])
 
-np.testing.assert_allclose(c[:], a[:] + b[:])
+np.testing.assert_allclose(c[:], a[:20] + b[:])
 
 # Get an NDArray instance instead of a NumPy array
 ndarr = c.compute()
-np.testing.assert_allclose(ndarr[:], a[:] + b[:])
+np.testing.assert_allclose(ndarr[:], a[:20] + b[:])

--- a/examples/ndarray/proxy-carray.py
+++ b/examples/ndarray/proxy-carray.py
@@ -14,8 +14,8 @@ from time import time
 
 import blosc2
 
-urlbase = "https://demo.caterva2.net/"
-path = "example/lung-jpeg2000_10x.b2nd"
+urlbase = "https://cat2.cloud/demo"
+path = "@public/examples/lung-jpeg2000_10x.b2nd"
 a = blosc2.C2Array(path, urlbase=urlbase)
 b = blosc2.Proxy(a, urlpath="proxy.b2nd", mode="w")
 

--- a/src/blosc2/c2array.py
+++ b/src/blosc2/c2array.py
@@ -202,8 +202,8 @@ class C2Array(blosc2.Operand):
         Examples
         --------
         >>> import blosc2
-        >>> urlbase = "https://demo.caterva2.net/"
-        >>> path = "example/dir1/ds-3d.b2nd"
+        >>> urlbase = "https://cat2.cloud/demo"
+        >>> path = "@public/examples/dir1/ds-3d.b2nd"
         >>> remote_array = blosc2.C2Array(path, urlbase=urlbase)
         >>> remote_array.shape
         (3, 4, 5)
@@ -212,7 +212,7 @@ class C2Array(blosc2.Operand):
         >>> remote_array.blocks
         (2, 2, 2)
         >>> remote_array.dtype
-        float32
+        dtype('float32')
         """
         if path.startswith("/"):
             raise ValueError("The path should start with a root name, not a slash")
@@ -258,15 +258,15 @@ class C2Array(blosc2.Operand):
         Examples
         --------
         >>> import blosc2
-        >>> urlbase = "https://demo.caterva2.net/"
-        >>> path = "example/dir1/ds-2d.b2nd"
+        >>> urlbase = "https://cat2.cloud/demo"
+        >>> path = "@public/examples/dir1/ds-2d.b2nd"
         >>> remote_array = blosc2.C2Array(path, urlbase=urlbase)
         >>> data_slice = remote_array[3:5, 1:4]
         >>> data_slice.shape
         (2, 3)
         >>> data_slice[:]
-        [[61 62 63]
-        [81 82 83]]
+        array([[61, 62, 63],
+               [81, 82, 83]], dtype=uint16)
         """
         slice_ = slice_to_string(slice_)
         return fetch_data(self.path, self.urlbase, {"slice_": slice_}, auth_token=self.auth_token)
@@ -289,8 +289,8 @@ class C2Array(blosc2.Operand):
         --------
         >>> import numpy as np
         >>> import blosc2
-        >>> urlbase = "https://demo.caterva2.net/"
-        >>> path = "example/dir1/ds-3d.b2nd"
+        >>> urlbase = "https://cat2.cloud/demo"
+        >>> path = "@public/examples/dir1/ds-3d.b2nd"
         >>> a = blosc2.C2Array(path, urlbase)
         >>>  # Get the compressed chunk from array 'a' for index 0
         >>> compressed_chunk = a.get_chunk(0)
@@ -299,8 +299,9 @@ class C2Array(blosc2.Operand):
         >>> # Decompress the chunk and convert it to a NumPy array
         >>> decompressed_chunk = blosc2.decompress(compressed_chunk)
         >>> np.frombuffer(decompressed_chunk, dtype=a.dtype)
-        [ 0.  1.  5.  6. 20. 21. 25. 26.  2.  3.  7.  8. 22. 23. 27. 28. 10. 11.
-          0.  0. 30. 31.  0.  0. 12. 13.  0.  0. 32. 33.  0.  0.]
+        array([ 0.,  1.,  5.,  6., 20., 21., 25., 26.,  2.,  3.,  7.,  8., 22.,
+               23., 27., 28., 10., 11.,  0.,  0., 30., 31.,  0.,  0., 12., 13.,
+                0.,  0., 32., 33.,  0.,  0.], dtype=float32)
         """
         url = _sub_url(self.urlbase, f"api/chunk/{self.path}")
         params = {"nchunk": nchunk}


### PR DESCRIPTION
This migrates from old `demo.caterva2.net` demo site to new `cat2.cloud/demo` one.  The tests still need to be migrated, but this should be done in another PR.