### PR TITLE
Update ruff pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.11
+    rev: v0.13.0
     hooks:
       - id: ruff-check
         args: ["--fix", "--show-fixes"]

--- a/README.rst
+++ b/README.rst
@@ -115,8 +115,8 @@ In addition, other people have participated to the project in different
 aspects:
 
 - Jan Sellner, contributed the mmap support for NDArray/SChunk objects.
-- Dimitri Papadopoulos, contributed a large bunch of improvements to the
-  in many aspects of the project.  His attention to detail is remarkable.
+- Dimitri Papadopoulos, contributed a large bunch of improvements to
+  many aspects of the project.  His attention to detail is remarkable.
 - And many others that have contributed with bug reports, suggestions and
   improvements.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ ignore = [
     "RET508",
     "RUF005",
     "RUF015",
+    "RUF059",
     "SIM108",
     "UP038",  # https://github.com/astral-sh/ruff/issues/7871
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,6 @@ ignore = [
     "RUF015",
     "RUF059",
     "SIM108",
-    "UP038",  # https://github.com/astral-sh/ruff/issues/7871
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]


### PR DESCRIPTION
```console
$ ruff check
warning: The following rules have been removed and ignoring them has no effect:
    - UP038

All checks passed!
$ 
```

Supersedes #470.