### PR TITLE
Fix view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
     include(FetchContent)
     FetchContent_Declare(blosc2
         GIT_REPOSITORY https://github.com/Blosc/c-blosc2
-        GIT_TAG 82a85f9d285d7ae6d141c73e84c7574bfc24a134  # v2.21.2
+        GIT_TAG ab7a0cc3b5ca3cf09c5ddaeb66ba1100c1986f23  # fix view
     )
     FetchContent_MakeAvailable(blosc2)
     include_directories("${blosc2_SOURCE_DIR}/include")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
     include(FetchContent)
     FetchContent_Declare(blosc2
         GIT_REPOSITORY https://github.com/Blosc/c-blosc2
-        GIT_TAG ab7a0cc3b5ca3cf09c5ddaeb66ba1100c1986f23  # fix view
+        GIT_TAG ae52f60b0c7caeac68d461f1ae5b0b2d57060e6a  # v2.21.2
     )
     FetchContent_MakeAvailable(blosc2)
     include_directories("${blosc2_SOURCE_DIR}/include")

--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -24,6 +24,7 @@ from cpython cimport (
     PyObject_GetBuffer,
 )
 from cpython.pycapsule cimport PyCapsule_GetPointer, PyCapsule_New
+from cpython.ref cimport Py_INCREF, Py_DECREF
 from cython.operator cimport dereference
 from libc.stdint cimport uintptr_t
 from libc.stdlib cimport free, malloc, realloc
@@ -2996,5 +2997,8 @@ def expand_dims(arr1: NDArray, axis_mask: list[bool], final_dims: int) -> blosc2
         mask_[i] = axis_mask[i]
     _check_rc(b2nd_expand_dims(arr1.array, &view, mask_, final_dims),"Error while expanding the arrays")
 
+    # Increase the reference count of the original array
+    Py_INCREF(arr1)
+
     return blosc2.NDArray(_schunk=PyCapsule_New(view.sc, <char *> "blosc2_schunk*", NULL),
-                              _array=PyCapsule_New(view, <char *> "b2nd_array_t*", NULL))
+                          _array=PyCapsule_New(view, <char *> "b2nd_array_t*", NULL))

--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -2357,9 +2357,10 @@ cdef class slice_flatter:
 cdef class NDArray:
     cdef b2nd_array_t* array
 
-    def __init__(self, array):
+    def __init__(self, array, base=None):
         self._dtype = None
         self.array = <b2nd_array_t *> PyCapsule_GetPointer(array, <char *> "b2nd_array_t*")
+        self.base = base # add reference to base if NDArray is a view
 
     @property
     def shape(self) -> tuple[int]:
@@ -2997,8 +2998,7 @@ def expand_dims(arr1: NDArray, axis_mask: list[bool], final_dims: int) -> blosc2
         mask_[i] = axis_mask[i]
     _check_rc(b2nd_expand_dims(arr1.array, &view, mask_, final_dims),"Error while expanding the arrays")
 
-    # Increase the reference count of the original array
-    Py_INCREF(arr1)
-
+    # create view with reference to arr1 to hold onto
+    new_base = arr1 if arr1.base is None else arr1.base
     return blosc2.NDArray(_schunk=PyCapsule_New(view.sc, <char *> "blosc2_schunk*", NULL),
-                          _array=PyCapsule_New(view, <char *> "b2nd_array_t*", NULL))
+                          _array=PyCapsule_New(view, <char *> "b2nd_array_t*", NULL), _base=new_base)

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -1170,10 +1170,12 @@ class NDOuterIterator:
 class NDArray(blosc2_ext.NDArray, Operand):
     def __init__(self, **kwargs):
         self._schunk = SChunk(_schunk=kwargs["_schunk"], _is_view=True)  # SChunk Python instance
+        self.base = SChunk(_schunk=kwargs["_schunk"], _is_view=True)  # SChunk Python instance
         self._keep_last_read = False
         # Where to store the last read data
         self._last_read = {}
-        super().__init__(kwargs["_array"])
+        base = kwargs.pop("_base", None)
+        super().__init__(kwargs["_array"], base=base)
         # Accessor to fields
         self._fields = {}
         if self.dtype.fields:


### PR DESCRIPTION
Prior to this fix c = blosc2.expand_dims(c, axis=1) would cause the reference to the original array c to disappear, meaning that the original data is garbage collected and the data to which the expanded view points no longer existed. Consequently, c[0] for example would fail.

By including a base attribute in NDArray objects we ensure views always hold a reference to the array object. When views are garbage collected (created) the reference count for the original array then automatically reduces (increases) by one.