### PR TITLE
Subprocess run with ignored non-zero exit

### DIFF
--- a/src/blosc2/core.py
+++ b/src/blosc2/core.py
@@ -1163,10 +1163,11 @@ def apple_silicon_cache_size(cache_level: int) -> int:
 
 
 def get_cache_info(cache_level: int) -> tuple:
-    result = subprocess.run(["lscpu", "--json"], capture_output=True, text=True)
-    lscpu_info = json.loads(result.stdout)
     if cache_level == 0:
         cache_level = "1d"
+
+    result = subprocess.run(["lscpu", "--json"], capture_output=True, check=True, text=True)
+    lscpu_info = json.loads(result.stdout)
     for entry in lscpu_info["lscpu"]:
         if entry["field"] == f"L{cache_level} cache:":
             size_str, instances_str = entry["data"].split(" (")


### PR DESCRIPTION
[`subprocess.run`](https://docs.python.org/3/library/subprocess.html#subprocess.run) uses a default of [`check=False`](https://docs.python.org/3/library/subprocess.html#using-the-subprocess-module), which means that a non-zero exit code will be ignored by default, instead of raising an exception.

I think we do want an exception in this case. Alternatively, catch the [`subprocess.CalledProcessError`](https://docs.python.org/3/library/subprocess.html#subprocess.CalledProcessError) exception and raise `ValueError` instead.
