### PR TITLE
Mark fancy indexing tests as heavy

### DIFF
--- a/tests/ndarray/test_ndarray.py
+++ b/tests/ndarray/test_ndarray.py
@@ -294,21 +294,13 @@ def test_oindex():
     np.testing.assert_allclose(arr[:], nparr)
 
 
-@pytest.mark.parametrize(
-    "c",
-    [
-        pytest.param(None, marks=pytest.mark.heavy),
-        pytest.param(10, marks=pytest.mark.heavy),
-    ],
-)
+@pytest.mark.parametrize("c", [None, 10])
 def test_fancy_index(c):
     # Test 1d
     ndim = 1
     chunks = (c,) * ndim if c is not None else None
     dtype = np.dtype("float")
-    d = (
-        1 + int(blosc2.MAX_FAST_PATH_SIZE / dtype.itemsize) if c is None else 100
-    )  # just over numpy fast path size
+    d = 1 + int(1000 / dtype.itemsize) if c is None else 50
     shape = (d,) * ndim
     arr = blosc2.linspace(0, 100, num=np.prod(shape), shape=shape, dtype=dtype, chunks=chunks)
     rng = np.random.default_rng()
@@ -322,9 +314,7 @@ def test_fancy_index(c):
     np.testing.assert_allclose(b, n)
 
     ndim = 3
-    d = (
-        1 + int((blosc2.MAX_FAST_PATH_SIZE / 8) ** (1 / ndim)) if c is None else d
-    )  # just over numpy fast path size
+    d = 1 + int((1000 / 8) ** (1 / ndim)) if c is None else d  # just over numpy fast path size
     shape = (d,) * ndim
     chunks = (c,) * ndim if c is not None else None
     arr = blosc2.linspace(0, 100, num=np.prod(shape), shape=shape, dtype=dtype, chunks=chunks)


### PR DESCRIPTION
Fancy indexing tests take long to time to execute, making the current whole suite more than 30% slower; this is a bit too much for a test.  This marks the test as heavy, so that:

```
pytest tests/ndarray/test_ndarray.py -v -m "heavy"
```

can still execute them.