### PR TITLE
Add general lazy evaluation for all blosc2 functions

### DIFF
--- a/ADD_LAZYFUNCS.md
+++ b/ADD_LAZYFUNCS.md
@@ -1,0 +1,17 @@
+# Adding (lazy) functions
+
+Once you have written a (public API) function in Blosc2, it is important to:
+* Import it from the relevant module in the ``__init__.py`` file
+* Add it to the list of functions in ``__all__`` in the ``__init__.py`` file
+* If it is present in numpy, add it to the relevant dictionary (``local_ufunc_map``, ``ufunc_map`` ``ufunc_map_1param``) in ``ndarray.py``
+
+Finally, you also need to deal with it correctly within ``shape_utils.py``.
+
+If the function does not change the shape of the output, simply add it to ``elementwise_funcs`` and you're done.
+
+If the function _does_ change the shape of the output, it is likely either a reduction, a constructor, or a linear algebra function and so should be added to one of those lists (``reducers``, ``constructor`` or ``linalg_funcs``). If the function is a reduction, unless you need to handle an argument that is neither ``axis`` nor ``keepdims``, you don't need to do anything else.
+If your function is a constructor, you need to ensure it is handled within the ``visit_Call`` function appropriately (if it has a shape argument this is easy, just add it to the list of functions that has ``zeros, zeros_like`` etc.).
+
+For linear algebra functions it is likely you will have to write a bespoke shape handler within the ``linalg_shape`` function. There is also a list ``linalg_attrs`` for attributes which change the shape (currently only ``T`` and ``mT``) should you need to add one. You will probably need to edit the ``validation_patterns`` list at the top of the ``lazyexpr.py`` file to handle these attributes. Just extend the part that has the negative lookahead "(?!real|imag|T|mT|(".
+
+After this, the imports at the top of the ``lazyexpr.py`` should handle things, where an ``eager_funcs`` list is defined to handle eager execution of functions which change the output shape. Finally, in order to handle name changes between NumPy versions 1 and 2, it may be necessary to add aliases for functions within the blocks defined by ``if NUMPY_GE_2_0:`` in ``lazyexpr.py`` and ``ndarray.py``.

--- a/src/blosc2/linalg.py
+++ b/src/blosc2/linalg.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 import numpy as np
 
 import blosc2
-from blosc2.ndarray import get_intersecting_chunks, slice_to_chunktuple
+from blosc2.ndarray import get_intersecting_chunks, npvecdot, slice_to_chunktuple
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -340,7 +340,7 @@ def vecdot(x1: blosc2.NDArray, x2: blosc2.NDArray, axis: int = -1, **kwargs) -> 
     fast_path = kwargs.pop("fast_path", None)  # for testing purposes
     # Added this to pass array-api tests (which use internal getitem to check results)
     if isinstance(x1, np.ndarray) and isinstance(x2, np.ndarray):
-        return np.vecdot(x1, x2, axis=axis)
+        return npvecdot(x1, x2, axis=axis)
 
     x1, x2 = blosc2.asarray(x1), blosc2.asarray(x2)
 
@@ -399,7 +399,7 @@ def vecdot(x1: blosc2.NDArray, x2: blosc2.NDArray, axis: int = -1, **kwargs) -> 
         if fast_path:  # just load everything, also handles case of 0 in shapes
             bx1 = x1[a_selection]
             bx2 = x2[b_selection]
-            result[res_chunk] += np.vecdot(bx1, bx2, axis=axis)  # handles conjugation of bx1
+            result[res_chunk] += npvecdot(bx1, bx2, axis=axis)  # handles conjugation of bx1
         else:  # operands too big, have to go chunk-by-chunk
             for ochunk in range(0, a_shape_red, a_chunks_red):
                 op_chunk = (slice(ochunk, builtins.min(ochunk + a_chunks_red, x1.shape[a_axes]), 1),)
@@ -407,7 +407,7 @@ def vecdot(x1: blosc2.NDArray, x2: blosc2.NDArray, axis: int = -1, **kwargs) -> 
                 b_selection = b_selection[:b_axes] + op_chunk + b_selection[b_axes + 1 :]
                 bx1 = x1[a_selection]
                 bx2 = x2[b_selection]
-                res = np.vecdot(bx1, bx2, axis=axis)  # handles conjugation of bx1
+                res = npvecdot(bx1, bx2, axis=axis)  # handles conjugation of bx1
                 result[res_chunk] += res
     return result
 

--- a/src/blosc2/linalg.py
+++ b/src/blosc2/linalg.py
@@ -353,10 +353,6 @@ def vecdot(x1: blosc2.NDArray, x2: blosc2.NDArray, axis: int = -1, **kwargs) -> 
     a_keep[a_axes] = False
     b_keep = [True] * x2.ndim
     b_keep[b_axes] = False
-    x1shape = np.array(x1.shape)
-    x2shape = np.array(x2.shape)
-    result_shape = np.broadcast_shapes(x1shape[a_keep], x2shape[b_keep])
-    result = blosc2.zeros(result_shape, dtype=np.result_type(x1, x2), **kwargs)
 
     x1shape = np.array(x1.shape)
     x2shape = np.array(x2.shape)

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -41,10 +41,15 @@ if NUMPY_GE_2_0:  # array-api compliant
     nplshift = np.bitwise_left_shift
     nprshift = np.bitwise_right_shift
     npbinvert = np.bitwise_invert
+    npvecdot = np.vecdot
 else:  # not array-api compliant
     nplshift = np.left_shift
     nprshift = np.right_shift
     npbinvert = np.bitwise_not
+
+    def npvecdot(a, b, axis=-1):
+        return np.einsum("...i,...i->...", np.moveaxis(np.conj(a), axis, -1), np.moveaxis(b, axis, -1))
+
 
 # These functions in ufunc_map in ufunc_map_1param are implemented in numexpr and so we call
 # those instead (since numexpr uses multithreading it is faster)
@@ -2932,6 +2937,7 @@ def clip(
     x: blosc2.Array,
     min: int | float | blosc2.Array | None = None,
     max: int | float | blosc2.Array | None = None,
+    **kwargs: Any,
 ) -> NDArray:
     """
     Clamps each element x_i of the input array x to the range [min, max].
@@ -2949,6 +2955,9 @@ def clip(
         Upper-bound of the range to which to clamp. If None, no upper bound must be applied.
         Default: None.
 
+    kwargs: Any
+        kwargs accepted by the :func:`empty` constructor
+
     Returns
     -------
     out: NDArray
@@ -2960,10 +2969,10 @@ def clip(
         x, min, max = inputs
         output[:] = np.clip(x, min, max)
 
-    return blosc2.lazyudf(chunkwise_clip, (x, min, max), dtype=x.dtype, shape=x.shape)
+    return blosc2.lazyudf(chunkwise_clip, (x, min, max), dtype=x.dtype, shape=x.shape, **kwargs)
 
 
-def logaddexp(x1: int | float | blosc2.Array, x2: int | float | blosc2.Array) -> NDArray:
+def logaddexp(x1: int | float | blosc2.Array, x2: int | float | blosc2.Array, **kwargs: Any) -> NDArray:
     """
     Calculates the logarithm of the sum of exponentiations log(exp(x1) + exp(x2)) for
     each element x1_i of the input array x1 with the respective element x2_i of the
@@ -2974,9 +2983,12 @@ def logaddexp(x1: int | float | blosc2.Array, x2: int | float | blosc2.Array) ->
     x1: blosc2.Array
         First input array. May have any real-valued floating-point data type.
 
-    x2:blosc2.Array
+    x2: blosc2.Array
         Second input array. Must be compatible with x1. May have any
         real-valued floating-point data type.
+
+    kwargs: Any
+        kwargs accepted by the :func:`empty` constructor
 
     Returns
     -------
@@ -2995,7 +3007,7 @@ def logaddexp(x1: int | float | blosc2.Array, x2: int | float | blosc2.Array) ->
 
     if np.issubdtype(dtype, np.integer):
         dtype = blosc2.float32
-    return blosc2.lazyudf(chunkwise_logaddexp, (x1, x2), dtype=dtype, shape=x1.shape)
+    return blosc2.lazyudf(chunkwise_logaddexp, (x1, x2), dtype=dtype, shape=x1.shape, **kwargs)
 
 
 # implemented in python-blosc2

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -3076,7 +3076,7 @@ class Operand:
         if ufunc in ufunc_map:
             value = inputs[0] if inputs[1] is self else inputs[1]
             _check_allowed_dtypes(value)
-            return blosc2.LazyExpr(new_op=(value, ufunc_map[ufunc], self))
+            return blosc2.LazyExpr(new_op=(inputs[0], ufunc_map[ufunc], inputs[1]))
 
         if ufunc in ufunc_map_1param:
             value = inputs[0]

--- a/src/blosc2/shape_utils.py
+++ b/src/blosc2/shape_utils.py
@@ -1,0 +1,267 @@
+import ast
+
+from numpy import broadcast_shapes
+
+reducers = ("sum", "prod", "min", "max", "std", "mean", "var", "any", "all", "slice")
+
+# All the available constructors and reducers necessary for the (string) expression evaluator
+constructors = (
+    "arange",
+    "linspace",
+    "fromiter",
+    "zeros",
+    "ones",
+    "empty",
+    "full",
+    "frombuffer",
+    "full_like",
+    "zeros_like",
+    "ones_like",
+    "empty_like",
+)
+# Note that, as reshape is accepted as a method too, it should always come last in the list
+constructors += ("reshape",)
+
+
+# --- Shape utilities ---
+def reduce_shape(shape, axis, keepdims):
+    """Reduce shape along given axis or axes (collapse dimensions)."""
+    if shape is None:
+        return None  # unknown shape
+
+    # full reduction
+    if axis is None:
+        return (1,) * len(shape) if keepdims else ()
+
+    # normalize to tuple
+    if isinstance(axis, int):
+        axes = (axis,)
+    else:
+        axes = tuple(axis)
+
+    # normalize negative axes
+    axes = tuple(a + len(shape) if a < 0 else a for a in axes)
+
+    if keepdims:
+        return tuple(d if i not in axes else 1 for i, d in enumerate(shape))
+    else:
+        return tuple(d for i, d in enumerate(shape) if i not in axes)
+
+
+def slice_shape(shape, slices):
+    """Infer shape after slicing."""
+    result = []
+    for dim, sl in zip(shape, slices, strict=False):
+        if isinstance(sl, int):  # indexing removes the axis
+            continue
+        if isinstance(sl, slice):
+            start = sl.start or 0
+            stop = sl.stop if sl.stop is not None else dim
+            step = sl.step or 1
+            length = max(0, (stop - start + (step - 1)) // step)
+            result.append(length)
+        else:
+            raise ValueError(f"Unsupported slice type: {sl}")
+    result.extend(shape[len(slices) :])  # untouched trailing dims
+    return tuple(result)
+
+
+def elementwise(*args):
+    """All args must broadcast elementwise."""
+    shape = args[0]
+    shape = shape if shape is not None else ()
+    for s in args[1:]:
+        shape = broadcast_shapes(shape, s) if s is not None else shape
+    return shape
+
+
+# --- Function registry ---
+FUNCTIONS = {  # ignore out arg
+    func: lambda x, axis=None, keepdims=False, out=None: reduce_shape(x, axis, keepdims)
+    for func in reducers
+    # any unknown function will default to elementwise
+}
+
+
+# --- AST Shape Inferencer ---
+class ShapeInferencer(ast.NodeVisitor):
+    def __init__(self, shapes):
+        self.shapes = shapes
+
+    def visit_Name(self, node):
+        if node.id not in self.shapes:
+            raise ValueError(f"Unknown symbol: {node.id}")
+        s = self.shapes[node.id]
+        if isinstance(s, tuple):
+            return s
+        else:  # passed a scalar value
+            return ()
+
+    def visit_Call(self, node):  # noqa : C901
+        func_name = getattr(node.func, "id", None)
+        attr_name = getattr(node.func, "attr", None)
+
+        # --- Recursive method-chain support ---
+        obj_shape = None
+        if isinstance(node.func, ast.Attribute):
+            obj_shape = self.visit(node.func.value)
+
+        # --- Parse keyword args ---
+        kwargs = {}
+        for kw in node.keywords:
+            if isinstance(kw.value, ast.Constant):
+                kwargs[kw.arg] = kw.value.value
+            elif isinstance(kw.value, ast.Tuple):
+                kwargs[kw.arg] = tuple(
+                    e.value if isinstance(e, ast.Constant) else self._lookup_value(e) for e in kw.value.elts
+                )
+            else:
+                kwargs[kw.arg] = self._lookup_value(kw.value)
+
+        # ------- handle constructors ---------------
+        if func_name in constructors or attr_name == "reshape":
+            # shape kwarg directly provided
+            if "shape" in kwargs:
+                val = kwargs["shape"]
+                return val if isinstance(val, tuple) else (val,)
+
+            # ---- array constructors like zeros, ones, full, etc. ----
+            elif func_name in (
+                "zeros",
+                "ones",
+                "empty",
+                "full",
+                "full_like",
+                "zeros_like",
+                "empty_like",
+                "ones_like",
+            ):
+                if node.args:
+                    shape_arg = node.args[0]
+                    if isinstance(shape_arg, ast.Tuple):
+                        shape = tuple(self._const_or_lookup(e) for e in shape_arg.elts)
+                    elif isinstance(shape_arg, ast.Constant):
+                        shape = (shape_arg.value,)
+                    else:
+                        shape = self._lookup_value(shape_arg)
+                        shape = shape if isinstance(shape, tuple) else (shape,)
+                    return shape
+
+            # ---- arange ----
+            elif func_name == "arange":
+                start = self._const_or_lookup(node.args[0]) if node.args else 0
+                stop = self._const_or_lookup(node.args[1]) if len(node.args) > 1 else None
+                step = self._const_or_lookup(node.args[2]) if len(node.args) > 2 else 1
+                shape = self._const_or_lookup(node.args[4]) if len(node.args) > 4 else kwargs.get("shape")
+
+                if shape is not None:
+                    return shape if isinstance(shape, tuple) else (shape,)
+
+                # Fallback to numeric difference if possible
+                if stop is None:
+                    stop, start = start, 0
+                try:
+                    NUM = int((stop - start) / step)
+                except Exception:
+                    # symbolic or non-numeric: unknown 1D
+                    return ((),)
+                return (max(NUM, 0),)
+
+            # ---- linspace ----
+            elif func_name == "linspace":
+                num = self._const_or_lookup(node.args[2]) if len(node.args) > 2 else kwargs.get("num")
+                shape = self._const_or_lookup(node.args[5]) if len(node.args) > 5 else kwargs.get("shape")
+                if shape is not None:
+                    return shape if isinstance(shape, tuple) else (shape,)
+                if num is not None:
+                    return (num,)
+                raise ValueError("linspace requires either shape or num argument")
+
+            elif func_name == "frombuffer" or func_name == "fromiter":
+                count = kwargs.get("count")
+                return (count,) if count else ()
+
+            elif func_name == "reshape" or attr_name == "reshape":
+                if node.args:
+                    shape_arg = node.args[-1]
+                    if isinstance(shape_arg, ast.Tuple):
+                        return tuple(self._const_or_lookup(e) for e in shape_arg.elts)
+                return ()
+
+            else:
+                raise ValueError(f"Unrecognized constructor or missing shape argument for {func_name}")
+
+        # --- Special-case .slice((slice(...), ...)) ---
+        if attr_name == "slice":
+            if not node.args:
+                raise ValueError(".slice() requires an argument")
+            slice_arg = node.args[0]
+            if isinstance(slice_arg, ast.Tuple):
+                slices = [self._eval_slice(s) for s in slice_arg.elts]
+            else:
+                slices = [self._eval_slice(slice_arg)]
+            return slice_shape(obj_shape, slices)
+
+        # --- Evaluate argument shapes normally ---
+        args = [self.visit(arg) for arg in node.args]
+
+        if func_name in FUNCTIONS:
+            return FUNCTIONS[func_name](*args, **kwargs)
+        if attr_name in FUNCTIONS:
+            return FUNCTIONS[attr_name](obj_shape, **kwargs)
+
+        shapes = [obj_shape] + args if obj_shape is not None else args
+        shapes = [s for s in shapes if s is not None]
+        return elementwise(*shapes) if shapes else ()
+
+    def visit_Compare(self, node):
+        shapes = [self.visit(node.left)] + [self.visit(c) for c in node.comparators]
+        return elementwise(*shapes)
+
+    def visit_BinOp(self, node):
+        left = self.visit(node.left)
+        right = self.visit(node.right)
+        left = () if left is None else left
+        right = () if right is None else right
+        return broadcast_shapes(left, right)
+
+    def _eval_slice(self, node):
+        if isinstance(node, ast.Slice):
+            return slice(
+                node.lower.value if node.lower else None,
+                node.upper.value if node.upper else None,
+                node.step.value if node.step else None,
+            )
+        elif isinstance(node, ast.Call) and getattr(node.func, "id", None) == "slice":
+            # handle explicit slice() constructor
+            args = [a.value if isinstance(a, ast.Constant) else None for a in node.args]
+            return slice(*args)
+        elif isinstance(node, ast.Constant):
+            return node.value
+        else:
+            raise ValueError(f"Unsupported slice expression: {ast.dump(node)}")
+
+    def _lookup_value(self, node):
+        """Look up a value in self.shapes if node is a variable name, else constant value."""
+        if isinstance(node, ast.Name):
+            return self.shapes.get(node.id, None)
+        elif isinstance(node, ast.Constant):
+            return node.value
+        else:
+            return None
+
+    def _const_or_lookup(self, node):
+        """Return constant value or resolve name to scalar from shapes."""
+        if isinstance(node, ast.Constant):
+            return node.value
+        elif isinstance(node, ast.Name):
+            return self.shapes.get(node.id, None)
+        else:
+            return None
+
+
+# --- Public API ---
+def infer_shape(expr, shapes):
+    tree = ast.parse(expr, mode="eval")
+    inferencer = ShapeInferencer(shapes)
+    return inferencer.visit(tree.body)

--- a/src/blosc2/shape_utils.py
+++ b/src/blosc2/shape_utils.py
@@ -79,7 +79,7 @@ elementwise_funcs = [
     "zeros_like",
 ]
 
-lin_alg_funcs = [
+linalg_funcs = [
     "concat",
     "diagonal",
     "expand_dims",
@@ -94,7 +94,7 @@ lin_alg_funcs = [
     "vecdot",
 ]
 
-lin_alg_attrs = ["T", "mT"]
+linalg_attrs = ["T", "mT"]
 reducers = ["sum", "prod", "min", "max", "std", "mean", "var", "any", "all", "count_nonzero"]
 
 # All the available constructors and reducers necessary for the (string) expression evaluator
@@ -317,7 +317,7 @@ def elementwise(*args):
 
 
 # --- Function registry ---
-FUNCTIONS = {  # ignore out arg
+REDUCTIONS = {  # ignore out arg
     func: lambda x, axis=None, keepdims=False, out=None: reduce_shape(x, axis, keepdims)
     for func in reducers
     # any unknown function will default to elementwise
@@ -391,7 +391,7 @@ class ShapeInferencer(ast.NodeVisitor):
                 kwargs[kw.arg] = self._lookup_value(kw.value)
 
         # ------- handle linear algebra ---------------
-        if base_name in lin_alg_funcs:
+        if base_name in linalg_funcs:
             return linalg_shape(base_name, args, kwargs)
 
         # ------- handle constructors ---------------
@@ -484,8 +484,8 @@ class ShapeInferencer(ast.NodeVisitor):
                 slices = [self._eval_slice(slice_arg)]
             return slice_shape(obj_shape, slices)
 
-        if base_name in FUNCTIONS:
-            return FUNCTIONS[base_name](*args, **kwargs)
+        if base_name in REDUCTIONS:
+            return REDUCTIONS[base_name](*args, **kwargs)
 
         shapes = [s for s in args if s is not None]
         if base_name not in elementwise_funcs:

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1583,3 +1583,19 @@ def test_minimal_protocol():
     lb = blosc2.lazyexpr("b + c + 1")
 
     np.testing.assert_array_equal(lb[:], a + a + 1)
+
+
+def test_not_numexpr():
+    shape = (20, 20)
+    a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
+    b = blosc2.ones((20, 1))
+    d_blosc2 = blosc2.evaluate("logaddexp(a, b) + a")
+    npa = a[()]
+    npb = b[()]
+    np.testing.assert_array_almost_equal(d_blosc2, np.logaddexp(npa, npb) + npa)
+    # TODO: Implement __add__ etc. for LazyUDF so this line works
+    # d_blosc2 = blosc2.evaluate(f"logaddexp(a, b) + clip(a, 6, 12)")
+    arr = blosc2.lazyexpr("matmul(a,b) + a ")
+    assert isinstance(arr, blosc2.LazyExpr)
+    assert arr.shape is None  # can't calculate shape for linalg funcs yet
+    np.testing.assert_array_almost_equal(arr[()], np.matmul(npa, npb) + a)

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -13,7 +13,7 @@ import pytest
 
 import blosc2
 from blosc2.lazyexpr import ne_evaluate
-from blosc2.ndarray import get_chunks_idx
+from blosc2.ndarray import get_chunks_idx, npvecdot
 
 NITEMS_SMALL = 1_000
 NITEMS = 10_000
@@ -1659,7 +1659,7 @@ def test_lazylinalg():
 
     # --- matrix_transpose ---
     out = blosc2.lazyexpr("matrix_transpose(A)")
-    npres = np.matrix_transpose(npA)
+    npres = np.matrix_transpose(npA) if np.__version__.startswith("2.") else npA.T
     assert out.shape == npres.shape
     np.testing.assert_array_almost_equal(out[()], npres)
     out = blosc2.lazyexpr("C.mT")
@@ -1708,7 +1708,7 @@ def test_lazylinalg():
 
     # --- vecdot ---
     out = blosc2.lazyexpr("vecdot(x, y)")
-    npres = np.vecdot(npx, npy)
+    npres = npvecdot(npx, npy)
     assert out.shape == npres.shape
     np.testing.assert_array_almost_equal(out[()], npres)
 

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1550,11 +1550,10 @@ def test_complex_lazy_expression_multiplication():
     theta_np = np.arctan2(Y_b2[:], X_b2[:])
     expected = np.sin(R_np * 4 - time_factor * 2) * np.cos(theta_np * 6)
 
-    # TODO: for some reason, the result is negative, so we assert against -expected
-    np.testing.assert_allclose(result, -expected, rtol=1e-14, atol=1e-14)
+    np.testing.assert_allclose(result, expected, rtol=1e-14, atol=1e-14)
 
     # Also test getitem access
-    np.testing.assert_allclose(result_expr[:], -expected, rtol=1e-14, atol=1e-14)
+    np.testing.assert_allclose(result_expr[:], expected, rtol=1e-14, atol=1e-14)
 
 
 # Test checking that objects following the blosc2.Array protocol can be operated with

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -1629,62 +1629,102 @@ def test_lazylinalg():
     npx = x[()]
     npy = y[()]
     npA = A[()]
+    npB = B[()]
+    npC = C[()]
+    npD = D[()]
 
     # --- concat ---
     out = blosc2.lazyexpr("concat((x, y), axis=0)")
-    assert out.shape == np.concat((npx, npy), axis=0).shape
+    npres = np.concatenate((npx, npy), axis=0)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- diagonal ---
     out = blosc2.lazyexpr("diagonal(A)")
-    assert out.shape == np.diagonal(npA).shape
+    npres = np.diagonal(npA)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- expand_dims ---
     out = blosc2.lazyexpr("expand_dims(x, axis=0)")
-    assert out.shape == (1,) + shapes["x"]
+    npres = np.expand_dims(npx, axis=0)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- matmul ---
     out = blosc2.lazyexpr("matmul(A, B)")
-    assert out.shape == (shapes["A"][0], shapes["B"][1])
+    npres = np.matmul(npA, npB)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- matrix_transpose ---
     out = blosc2.lazyexpr("matrix_transpose(A)")
-    assert out.shape == (shapes["A"][1], shapes["A"][0])
+    npres = np.matrix_transpose(npA)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
+    out = blosc2.lazyexpr("C.mT")
+    npres = C.mT
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
+    out = blosc2.lazyexpr("A.T")
+    npres = npA.T
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- outer ---
     out = blosc2.lazyexpr("outer(x, y)")
-    assert out.shape == shapes["x"] + shapes["y"]
+    npres = np.outer(npx, npy)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- permute_dims ---
     out = blosc2.lazyexpr("permute_dims(C, axes=(2,0,1))")
-    assert out.shape == (shapes["C"][2], shapes["C"][0], shapes["C"][1])
+    npres = np.transpose(npC, axes=(2, 0, 1))
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- squeeze ---
     out = blosc2.lazyexpr("squeeze(D)")
-    assert out.shape == (5,)
+    npres = np.squeeze(npD)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
+
     out = blosc2.lazyexpr("D.squeeze()")
-    assert out.shape == (5,)
+    npres = np.squeeze(npD)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- stack ---
     out = blosc2.lazyexpr("stack((x, y), axis=0)")
-    assert out.shape == (2,) + shapes["x"]
+    npres = np.stack((npx, npy), axis=0)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- tensordot ---
     out = blosc2.lazyexpr("tensordot(A, B, axes=1)")
-    assert out.shape[0] == shapes["A"][0]
-    assert out.shape[-1] == shapes["B"][-1]
+    npres = np.tensordot(npA, npB, axes=1)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
     # --- vecdot ---
     out = blosc2.lazyexpr("vecdot(x, y)")
-    assert out.shape == np.vecdot(x[()], y[()]).shape
+    npres = np.vecdot(npx, npy)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)
 
-    # batched matmul
+    # --- batched matmul ---
     shapes = {
         "A": (1, 3, 4),
         "B": (3, 4, 5),
     }
     s = shapes["A"]
     A = blosc2.linspace(0, np.prod(s), shape=s)
+    npA = A[()]  # actual numpy array
     s = shapes["B"]
     B = blosc2.linspace(0, np.prod(s), shape=s)
+    npB = B[()]  # actual numpy array
+
     out = blosc2.lazyexpr("matmul(A, B)")
-    assert out.shape == (3, 3, 5)
+    npres = np.matmul(npA, npB)
+    assert out.shape == npres.shape
+    np.testing.assert_array_almost_equal(out[()], npres)

--- a/tests/ndarray/test_lazyudf.py
+++ b/tests/ndarray/test_lazyudf.py
@@ -423,6 +423,10 @@ def test_clip_logaddexp(shape, chunks, blocks, slices):
     # clip is not a ufunc so will return np.ndarray
     expr = np.clip(b, np.prod(shape) // 3, npb - 10)
     assert isinstance(expr, np.ndarray)
+    # test lazyexpr interface
+    expr = blosc2.lazyexpr("clip(b, np.prod(shape) // 3, npb - 10)")
+    res = expr.compute(item=slices)
+    np.testing.assert_allclose(res[...], npc[slices])
 
     npc = np.logaddexp(npb, npa)
     expr = blosc2.logaddexp(b, a)
@@ -432,3 +436,8 @@ def test_clip_logaddexp(shape, chunks, blocks, slices):
     # (i.e. doesn't return np.ndarray)
     expr = np.logaddexp(b, a)
     assert isinstance(expr, blosc2.LazyArray)
+
+    # test lazyexpr interface
+    expr = blosc2.lazyexpr("logaddexp(a, b)")
+    res = expr.compute(item=slices)
+    np.testing.assert_allclose(res[...], npc[slices])

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -459,12 +459,10 @@ def test_reduction_index():
     assert arr.shape == newarr.shape
 
     a = blosc2.ones(shape=(0, 0))
-    arr = blosc2.lazyexpr("sum(a, axis=(0, 1, 2))", {"a": a})
     with pytest.raises(np.exceptions.AxisError):
-        newarr = arr.compute()
-    arr = blosc2.lazyexpr("sum(a, axis=(0, 0))", {"a": a})
+        arr = blosc2.lazyexpr("sum(a, axis=(0, 1, 2))", {"a": a})
     with pytest.raises(ValueError):
-        newarr = arr.compute()
+        arr = blosc2.lazyexpr("sum(a, axis=(0, 0))", {"a": a})
 
 
 @pytest.mark.parametrize("idx", [0, 1, (0,), slice(1, 2), (slice(0, 1),), slice(0, 4), (0, 2)])

--- a/tests/ndarray/test_reductions.py
+++ b/tests/ndarray/test_reductions.py
@@ -491,15 +491,15 @@ def test_slice_lazy():
 def test_slicebrackets_lazy():
     shape = (20, 20)
     a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
-    arr = blosc2.lazyexpr("anarr[10:15] + 1", {"anarr": a})
+    arr = blosc2.lazyexpr("sum(anarr[10:15], axis=0) + anarr[10:15] + arange(20) + 1", {"anarr": a})
     newarr = arr.compute()
-    np.testing.assert_allclose(newarr[:], a[10:15] + 1)
+    np.testing.assert_allclose(newarr[:], np.sum(a[10:15], axis=0) + a[10:15] + np.arange(20) + 1)
 
     # Try with getitem
     a = blosc2.linspace(0, 20, num=np.prod(shape), shape=shape)
-    arr = blosc2.lazyexpr("anarr[10:15] + 1", {"anarr": a})
+    arr = blosc2.lazyexpr("sum(anarr[10:15], axis=0) + anarr[10:15] + arange(20) + 1", {"anarr": a})
     newarr = arr[:3]
-    res = a[10:15] + 1
+    res = np.sum(a[10:15], axis=0) + a[10:15] + np.arange(20) + 1
     np.testing.assert_allclose(newarr, res[:3])
 
     # Test other cases
@@ -510,6 +510,10 @@ def test_slicebrackets_lazy():
     arr = blosc2.lazyexpr("anarr[10:15][2:9] + 1", {"anarr": a})
     newarr = arr.compute()
     np.testing.assert_allclose(newarr[:], a[10:15][2:9] + 1)
+
+    arr = blosc2.lazyexpr("sum(anarr[10:15], axis=1) + 1", {"anarr": a})
+    newarr = arr.compute()
+    np.testing.assert_allclose(newarr[:], np.sum(a[10:15], axis=1) + 1)
 
     arr = blosc2.lazyexpr("anarr[10] + 1", {"anarr": a})
     newarr = arr.compute()


### PR DESCRIPTION
Although there was no double evaluation in old versions of blosc2 for reductions as there was an ``is_inside_new_expr()`` stack check which aborted the evaluation and returned ``blosc2.zeros`` during the ``eval`` call, we have added a shape parser to avoid having to arrive at ``reduce_slices`` for reductions. In addition, this allows us to handle other non-numexpr functions without adding the same ``is_inside_newexpr()`` call. 
This PR is thus useful since 1) it adds the possibility to compute with arbitrary blosc2 functions (such as ``matmul`` or even ``logaddexp``) in a lazy imperative way via the changes to ``ne_evaluate`` and 2) adds a reasonably extensive shape parser function, which is a bit more explicit than the returning ``blosc2.zeros`` hack.

For the following benchmark:
```
import time
import blosc2

# --- Experiment Setup ---
N = 100000
X = blosc2.ones((N,N))
t0 = time.time()
blosc2.evaluate('sum(X)')
dt = time.time()
print(f"Time for blosc2.evaluate('sum(X)'):{round(dt, 3)} s")
```
one can confirm that the new method also evaluates the reduction only once on the full operands, and takes the same time as in blosc2<=3.9.1.

