### PR TITLE
Fix chunks for lazyexprs with constructors

### DIFF
--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -5208,7 +5208,7 @@ def arange(
 
     if is_inside_new_expr() or NUM < 0:
         # We already have the dtype and shape, so return immediately
-        return blosc2.zeros(shape, dtype=dtype)
+        return blosc2.zeros(shape, dtype=dtype, **kwargs)
 
     lshape = (math.prod(shape),)
     lazyarr = blosc2.lazyudf(arange_fill, (start, stop, step), dtype=dtype, shape=lshape)
@@ -5309,7 +5309,7 @@ def linspace(
 
     if is_inside_new_expr() or num == 0:
         # We already have the dtype and shape, so return immediately
-        return blosc2.zeros(shape, dtype=dtype)  # will return empty array for num == 0
+        return blosc2.zeros(shape, dtype=dtype, **kwargs)  # will return empty array for num == 0
 
     inputs = (start, stop, num, endpoint)
     lazyarr = blosc2.lazyudf(linspace_fill, inputs, dtype=dtype, shape=(num,))

--- a/src/blosc2/shape_utils.py
+++ b/src/blosc2/shape_utils.py
@@ -521,6 +521,9 @@ class ShapeInferencer(ast.NodeVisitor):
     def visit_Tuple(self, node):
         return tuple(self.visit(arg) for arg in node.elts)
 
+    def visit_List(self, node):
+        return self.visit_Tuple(node)
+
     def visit_BinOp(self, node):
         left = self.visit(node.left)
         right = self.visit(node.right)


### PR DESCRIPTION
In order to have the following code function
```
a = blosc2.lazyexpr(f"linspace(0, 100, {np.prod(shape)}, shape={shape})")
b = blosc2.lazyexpr("a.T") 
```
`a` must store a `chunks` even though it is saved as a lazy constructor. This has now been done.