### PR TITLE
Optimize chunksize for matmul and machines with L3

### DIFF
--- a/src/blosc2/linalg.py
+++ b/src/blosc2/linalg.py
@@ -99,6 +99,9 @@ def matmul(x1: blosc2.Array, x2: blosc2.NDArray, **kwargs: Any) -> blosc2.NDArra
     n, k = x1.shape[-2:]
     m = x2.shape[-1]
     result_shape = np.broadcast_shapes(x1.shape[:-2], x2.shape[:-2]) + (n, m)
+    # For matmul, we don't want to reduce the chunksize, as experiments show that
+    # the larger, the better (as long as some limits are not exceeded).
+    kwargs["_chunksize_reduc_factor"] = 1
     result = blosc2.zeros(result_shape, dtype=blosc2.result_type(x1, x2), **kwargs)
 
     if 0 not in result.shape + x1.shape + x2.shape:  # if any array is empty, return array of 0s

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -5839,6 +5839,7 @@ def _check_ndarray_kwargs(**kwargs):
         "initial_mapping_size",
         "storage",
         "out",
+        "_chunksize_reduc_factor",
     ]
     _ = kwargs.pop("device", None)  # pop device (not used, but needs to be discarded)
     for key in kwargs:


### PR DESCRIPTION
With that, matmul (at the right in roofline plots below) scales much better:

<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/1710b0d1-ba83-449b-9698-0ac026735f72" />

Compared with the original performance:

<img width="1000" height="600" alt="image" src="https://github.com/user-attachments/assets/cb8d7dc4-4ed8-4bd8-8366-4ad9680551b9" />
