### PR TITLE
Set the number of threads to 2 to reduce the test suite runtime. Fixes #535.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@
 # LICENSE file in the root directory of this source tree)
 #######################################################################
 import os
+import sys
 
 import pytest
 
@@ -14,14 +15,15 @@ import blosc2
 
 def pytest_configure(config):
     blosc2.print_versions()
-    # Using the defaults for nthreads can be very time consuming for tests.
-    # Fastest runtime (95 sec) for the whole test suite (Mac Mini M4 Pro)
-    # blosc2.set_nthreads(1)
-    # Second best runtime (101 sec), but still contained, and
-    # actually tests multithreading.
-    blosc2.set_nthreads(2)
-    # This makes the worst time (242 sec)
-    # blosc2.set_nthreads(blosc2.nthreads)  # worst runtime ()
+    if sys.platform != "emscripten":
+        # Using the defaults for nthreads can be very time consuming for tests.
+        # Fastest runtime (95 sec) for the whole test suite (Mac Mini M4 Pro)
+        # blosc2.set_nthreads(1)
+        # Second best runtime (101 sec), but still contained, and
+        # actually tests multithreading.
+        blosc2.set_nthreads(2)
+        # This makes the worst time (242 sec)
+        # blosc2.set_nthreads(blosc2.nthreads)  # worst runtime ()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
With this patch, the runtime when using latest pytest (9.x), the time is quite contained:

```
8193 passed, 7465 deselected in 101.11s (0:01:41)
```

which is pretty close the time for using 1 thread for all tests in `tests/ndarray ` (95 sec in my box).

Using 2 threads combines testing the multithreading with contained run times for the test suite.

Closes #535