### PR TITLE
PEP 639 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "scikit-build-core",
+    "scikit-build-core>=0.11.0",
     "cython>=3",
     "numpy>=2.1",
 ]
@@ -12,13 +12,13 @@ description = "A fast & compressed ndarray library with a flexible compute engin
 readme = {file = "README.rst", content-type = "text/x-rst"}
 authors = [{name = "Blosc Development Team", email = "blosc@blosc.org"}]
 maintainers = [{ name = "Blosc Development Team", email = "blosc@blosc.org"}]
-license = {text = "BSD-3-Clause"}
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 6 - Mature",
     "Intended Audience :: Developers",
     "Intended Audience :: Information Technology",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
See [Version 0.11.0](https://scikit-build-core.readthedocs.io/en/latest/about/changelog.html#version-0-11-0) in Scikit-build-core [Changelog](https://scikit-build-core.readthedocs.io/en/latest/about/changelog.html):
> This version adds support for PEP 639 (license expressions) and updates the default METADATA version 2.2. Support for Python 3.7 has been removed.