### PR TITLE
remove cpuinfo dependency and filesystem caching of get_cpu_info call

### DIFF
--- a/.guix/modules/python-blosc2-package.scm
+++ b/.guix/modules/python-blosc2-package.scm
@@ -94,8 +94,7 @@
                             (when tests?
                               (invoke "env" "PYTHONPATH=." "pytest")))))))
     (inputs (list c-blosc2))
-    (propagated-inputs (list python-msgpack python-ndindex python-numpy
-                             python-py-cpuinfo))
+    (propagated-inputs (list python-msgpack python-ndindex python-numpy))
     (native-inputs (list cmake-minimal pkg-config python-cython-3
                          python-pytest python-scikit-build))
     (home-page "https://github.com/blosc/python-blosc2")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,7 @@ dependencies = [
     "numpy>=1.26",
     "ndindex",
     "msgpack",
-    "platformdirs",
     "numexpr>=2.14.1; platform_machine != 'wasm32'",
-    "py-cpuinfo; platform_machine != 'wasm32'",
     "requests",
 ]
 version = "4.0.0-b2.dev0"


### PR DESCRIPTION
Fixes #356.

This PR removes the dependency on cpuinfo entirely, instead opting to implement the necessary parts of it on our own for Windows, along with the existing macOS and Linux implementations. Since all of these implementations are very performant (each taking sub 10ms), there's no longer a need to cache the result in `_USER_CACHE_DIR`, so I've removed that cache and the corresponding dependency on `platformdirs`.