### PR TITLE
Guard Windows DLL copy when using system blosc2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,11 +130,13 @@ if(UNIX)
 endif()
 
 if(WIN32)
-  add_custom_command(TARGET blosc2_ext POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            $<TARGET_FILE:blosc2_shared>
-            $<TARGET_FILE_DIR:blosc2_ext>
-  )
+  if(TARGET blosc2_shared)
+    add_custom_command(TARGET blosc2_ext POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different
+              $<TARGET_FILE:blosc2_shared>
+              $<TARGET_FILE_DIR:blosc2_ext>
+    )
+  endif()
 endif()
 
 # Python extension -> site-packages/blosc2


### PR DESCRIPTION
Description:
- Fixes a CMake error on Windows builds when USE_SYSTEM_BLOSC2=1.
- In the system-blosc2 path, blosc2_shared is not created, but the post-build step unconditionally referenced $<TARGET_FILE:blosc2_shared>.
- This resulted in: No target "blosc2_shared" during configure.

Change:
- Wrap the Windows post-build copy in if(TARGET blosc2_shared) so it only runs when the target exists.

Why:
- blosc2_shared only exists when building bundled c-blosc2 via FetchContent. With system blosc2, only imported targets exist, so the copy should be skipped.

This has been verified by conda-forge Windows build that previously failed at configure.