### PR TITLE
Check RELEASEGIL in SChunk.__init__, append_data, set_slice, and to_cframe

### DIFF
--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -377,7 +377,7 @@ cdef extern from "blosc2.h":
     blosc2_schunk *blosc2_schunk_open_offset(const char* urlpath, int64_t offset)
     blosc2_schunk* blosc2_schunk_open_offset_udio(const char* urlpath, int64_t offset, const blosc2_io *udio)
 
-    int64_t blosc2_schunk_to_buffer(blosc2_schunk* schunk, uint8_t** cframe, c_bool* needs_free)
+    int64_t blosc2_schunk_to_buffer(blosc2_schunk* schunk, uint8_t** cframe, c_bool* needs_free) nogil
     void blosc2_schunk_avoid_cframe_free(blosc2_schunk *schunk, c_bool avoid_cframe_free)
     int64_t blosc2_schunk_to_file(blosc2_schunk* schunk, const char* urlpath)
     int64_t blosc2_schunk_free(blosc2_schunk *schunk)
@@ -1476,6 +1476,10 @@ cdef class SChunk:
         cdef int64_t index
         cdef Py_buffer buf
         cdef uint8_t *buf_ptr
+        cdef int comp_size
+        cdef int32_t csize
+        cdef uint8_t* chunk
+        cdef int32_t len_chunk
         if data is not None and len(data) > 0:
             PyObject_GetBuffer(data, &buf, PyBUF_SIMPLE)
             buf_ptr = <uint8_t *> buf.buf
@@ -1486,8 +1490,27 @@ cdef class SChunk:
                 if i == (nchunks - 1):
                     len_chunk = len_data - i * chunksize
                 index = i * chunksize
-                nchunks_ = blosc2_schunk_append_buffer(self.schunk, buf_ptr + index, len_chunk)
+                csize = <int32_t> (len_chunk + BLOSC2_MAX_OVERHEAD)
+                chunk = <uint8_t*> malloc(csize)
+                self.schunk.current_nchunk = i
+                if RELEASEGIL:
+                    with nogil:
+                        comp_size = blosc2_compress_ctx(self.schunk.cctx, buf_ptr + index, len_chunk, chunk, csize)
+                else:
+                    comp_size = blosc2_compress_ctx(self.schunk.cctx, buf_ptr + index, len_chunk, chunk, csize)
+                if comp_size < 0:
+                    free(chunk)
+                    PyBuffer_Release(&buf)
+                    raise RuntimeError("Could not compress the data")
+                elif comp_size == 0:
+                    free(chunk)
+                    PyBuffer_Release(&buf)
+                    raise RuntimeError("The result could not fit")
+                chunk = <uint8_t*> realloc(chunk, comp_size)
+                _check_comp_length('chunk', comp_size)
+                nchunks_ = blosc2_schunk_append_chunk(self.schunk, chunk, False)
                 if nchunks_ != (i + 1):
+                    free(chunk)
                     PyBuffer_Release(&buf)
                     raise RuntimeError("An error occurred while appending the chunks")
             PyBuffer_Release(&buf)
@@ -1622,10 +1645,28 @@ cdef class SChunk:
     def append_data(self, data):
         cdef Py_buffer buf
         PyObject_GetBuffer(data, &buf, PyBUF_SIMPLE)
-        rc = blosc2_schunk_append_buffer(self.schunk, buf.buf, <int32_t> buf.len)
+        cdef int size
+        cdef int32_t len_chunk = <int32_t> (buf.len + BLOSC2_MAX_OVERHEAD)
+        cdef uint8_t* chunk = <uint8_t*> malloc(len_chunk)
+        self.schunk.current_nchunk = self.schunk.nchunks
+        if RELEASEGIL:
+            with nogil:
+                size = blosc2_compress_ctx(self.schunk.cctx, buf.buf, <int32_t> buf.len, chunk, len_chunk)
+        else:
+            size = blosc2_compress_ctx(self.schunk.cctx, buf.buf, <int32_t> buf.len, chunk, len_chunk)
         PyBuffer_Release(&buf)
+        if size < 0:
+            free(chunk)
+            raise RuntimeError("Could not compress the data")
+        elif size == 0:
+            free(chunk)
+            raise RuntimeError("The result could not fit")
+        chunk = <uint8_t*> realloc(chunk, size)
+        _check_comp_length('chunk', size)
+        rc = blosc2_schunk_append_chunk(self.schunk, chunk, False)
         if rc < 0:
-            raise RuntimeError("Could not append the buffer")
+            free(chunk)
+            raise RuntimeError("Could not append the chunk")
         return rc
 
     def fill_special(self, nitems, special_value, value):
@@ -1899,6 +1940,10 @@ cdef class SChunk:
         cdef int64_t data_start
         cdef uint8_t *data
         cdef uint8_t *chunk
+        cdef int32_t alloc_len
+        cdef int32_t chunk_nbytes
+        cdef int32_t chunksize
+        cdef int comp_rc
         if buf.len < nbytes:
             raise ValueError("Not enough data for writing the slice")
 
@@ -1922,9 +1967,13 @@ cdef class SChunk:
                 data_start = self.schunk.nbytes - (self.schunk.nchunks - 1) * self.schunk.chunksize
                 memcpy(data + data_start, buf_ptr + buf_pos, nbytes_copy)
                 chunk = <uint8_t *> malloc(chunk_nbytes + BLOSC2_MAX_OVERHEAD)
-                rc = blosc2_compress_ctx(self.schunk.cctx, data, chunk_nbytes, chunk, chunk_nbytes + BLOSC2_MAX_OVERHEAD)
+                if RELEASEGIL:
+                    with nogil:
+                        comp_rc = blosc2_compress_ctx(self.schunk.cctx, data, chunk_nbytes, chunk, chunk_nbytes + BLOSC2_MAX_OVERHEAD)
+                else:
+                    comp_rc = blosc2_compress_ctx(self.schunk.cctx, data, chunk_nbytes, chunk, chunk_nbytes + BLOSC2_MAX_OVERHEAD)
                 free(data)
-                if rc < 0:
+                if comp_rc < 0:
                     free(chunk)
                     raise RuntimeError("Error while compressing the data")
                 rc = blosc2_schunk_update_chunk(self.schunk, self.schunk.nchunks - 1, chunk, True)
@@ -1942,8 +1991,21 @@ cdef class SChunk:
                         chunksize = self.schunk.chunksize
                     else:
                         chunksize = (stop * self.schunk.typesize) % self.schunk.chunksize
-                    rc = blosc2_schunk_append_buffer(self.schunk, buf_ptr + buf_pos, chunksize)
+                    alloc_len = <int32_t> (chunksize + BLOSC2_MAX_OVERHEAD)
+                    chunk = <uint8_t*> malloc(alloc_len)
+                    self.schunk.current_nchunk = self.schunk.nchunks
+                    if RELEASEGIL:
+                        with nogil:
+                            comp_rc = blosc2_compress_ctx(self.schunk.cctx, buf_ptr + buf_pos, chunksize, chunk, alloc_len)
+                    else:
+                        comp_rc = blosc2_compress_ctx(self.schunk.cctx, buf_ptr + buf_pos, chunksize, chunk, alloc_len)
+                    if comp_rc < 0:
+                        free(chunk)
+                        raise RuntimeError("Error while compressing the chunk")
+                    chunk = <uint8_t*> realloc(chunk, comp_rc)
+                    rc = blosc2_schunk_append_chunk(self.schunk, chunk, False)
                     if rc < 0:
+                        free(chunk)
                         raise RuntimeError("Error while appending the chunk")
                     buf_pos += chunksize
         else:
@@ -1955,7 +2017,12 @@ cdef class SChunk:
     def to_cframe(self):
         cdef c_bool needs_free
         cdef uint8_t *cframe
-        cframe_len = blosc2_schunk_to_buffer(self.schunk, &cframe, &needs_free)
+        cdef int64_t cframe_len
+        if RELEASEGIL:
+            with nogil:
+                cframe_len = blosc2_schunk_to_buffer(self.schunk, &cframe, &needs_free)
+        else:
+            cframe_len = blosc2_schunk_to_buffer(self.schunk, &cframe, &needs_free)
         if cframe_len < 0:
             raise RuntimeError("Error while getting the cframe")
         out = PyBytes_FromStringAndSize(<char*>cframe, cframe_len)

--- a/src/blosc2/blosc2_ext.pyx
+++ b/src/blosc2/blosc2_ext.pyx
@@ -1963,10 +1963,12 @@ cdef class SChunk:
                 rc = blosc2_schunk_decompress_chunk(self.schunk, self.schunk.nchunks - 1, data, chunk_nbytes)
                 if rc < 0:
                     free(data)
+                    PyBuffer_Release(&buf)
                     raise RuntimeError("Error while decompressing the chunk")
                 data_start = self.schunk.nbytes - (self.schunk.nchunks - 1) * self.schunk.chunksize
                 memcpy(data + data_start, buf_ptr + buf_pos, nbytes_copy)
                 chunk = <uint8_t *> malloc(chunk_nbytes + BLOSC2_MAX_OVERHEAD)
+                self.schunk.current_nchunk = self.schunk.nchunks - 1
                 if RELEASEGIL:
                     with nogil:
                         comp_rc = blosc2_compress_ctx(self.schunk.cctx, data, chunk_nbytes, chunk, chunk_nbytes + BLOSC2_MAX_OVERHEAD)
@@ -1975,10 +1977,16 @@ cdef class SChunk:
                 free(data)
                 if comp_rc < 0:
                     free(chunk)
+                    PyBuffer_Release(&buf)
                     raise RuntimeError("Error while compressing the data")
+                elif comp_rc == 0:
+                    free(chunk)
+                    PyBuffer_Release(&buf)
+                    raise RuntimeError("The result could not fit")
                 rc = blosc2_schunk_update_chunk(self.schunk, self.schunk.nchunks - 1, chunk, True)
                 free(chunk)
                 if rc < 0:
+                    PyBuffer_Release(&buf)
                     raise RuntimeError("Error while updating the chunk")
                 buf_pos += nbytes_copy
             # Append data if needed
@@ -2001,11 +2009,18 @@ cdef class SChunk:
                         comp_rc = blosc2_compress_ctx(self.schunk.cctx, buf_ptr + buf_pos, chunksize, chunk, alloc_len)
                     if comp_rc < 0:
                         free(chunk)
+                        PyBuffer_Release(&buf)
                         raise RuntimeError("Error while compressing the chunk")
+                    elif comp_rc == 0:
+                        free(chunk)
+                        PyBuffer_Release(&buf)
+                        raise RuntimeError("The result could not fit")
                     chunk = <uint8_t*> realloc(chunk, comp_rc)
+                    _check_comp_length('chunk', comp_rc)
                     rc = blosc2_schunk_append_chunk(self.schunk, chunk, False)
                     if rc < 0:
                         free(chunk)
+                        PyBuffer_Release(&buf)
                         raise RuntimeError("Error while appending the chunk")
                     buf_pos += chunksize
         else:


### PR DESCRIPTION
## Summary

`set_releasegil(True)` releases the GIL for `compress2()`, `decompress2()`, `insert_data()`, and `update_data()`, but has no effect on `SChunk.__init__`, `append_data()`, `set_slice()`, or `to_cframe()`. Since `pack_tensor` / `pack_array2` go through `SChunk.__init__` + `to_cframe`, the primary serialization path holds the GIL for its entire duration — preventing any thread-level parallelism.

This PR applies the same pattern already used by `insert_data` and `update_data`: split `blosc2_schunk_append_buffer` (monolithic compress+append) into `blosc2_compress_ctx` (inside `with nogil:` when `RELEASEGIL` is set) followed by `blosc2_schunk_append_chunk` (GIL held). For `to_cframe`, `blosc2_schunk_to_buffer` is declared `nogil` and wrapped with the `RELEASEGIL` check.

## Benchmark

8 Python threads, `blosc2.set_nthreads(1)`, 200x512x512 int16 array, zstd clevel=3:

|  | serial | threaded (8w) | speedup |
|--|--------|---------------|---------|
| `compress2` (baseline) | 1.18 s/job | 0.21 s/job | 5.7x |
| `pack_tensor` **before** | 1.33 s/job | 1.47 s/job | 0.9x |
| `pack_tensor` **after** | 1.34 s/job | 0.25 s/job | 5.4x |

## Commits

### 1. Check RELEASEGIL in SChunk.\_\_init\_\_, append_data, set_slice, and to_cframe

Purely mechanical — applies the `insert_data`/`update_data` GIL release pattern to all four methods:

- **`SChunk.__init__` data loop**: compress each chunk via `blosc2_compress_ctx` with GIL release, then `blosc2_schunk_append_chunk`
- **`append_data()`**: same transformation
- **`set_slice()`**: wrap existing `blosc2_compress_ctx` call in `RELEASEGIL` check; replace `blosc2_schunk_append_buffer` in append loop with compress + append_chunk
- **`to_cframe()`**: declare `blosc2_schunk_to_buffer` as `nogil`, wrap call with `RELEASEGIL` check

### 2. Fix pre-existing issues in set_slice error handling

Separate commit for correctness fixes noticed while working on `set_slice`:

- Set `current_nchunk` before `compress_ctx` in the update-chunk path (needed by prefilters, was missing unlike all other compress sites)
- Add `PyBuffer_Release` on error paths that were leaking the buffer
- Add `comp_rc == 0` and `_check_comp_length` guards for consistency with `insert_data`/`update_data`

## Test plan

- [x] All existing SChunk tests pass (773 passed, 0 failed)
- [x] Correctness verified with `RELEASEGIL=True`: serial and threaded (8w x 32 jobs) `pack_tensor` roundtrips produce identical arrays
- [x] `append_data`, `to_cframe`, `set_slice` roundtrips verified with `RELEASEGIL=True`

## Notes

- The new code follows the same `realloc(chunk, comp_size)` pattern used by `insert_data`/`update_data` without checking for `realloc` NULL return. Unreachable in practice (shrinking realloc), but could be hardened across all sites in a follow-up.
- Similarly, `_check_comp_length` can theoretically raise and leak the chunk buffer — same as in `insert_data`/`update_data`. Also unreachable (compress always produces >=16-byte headers).
- The new code adds `free(chunk)` on the `comp_size < 0` error path, which is missing in the existing `insert_data`/`update_data`.