### PR TITLE
Rework `fromiter()` with direct chunked construction

### DIFF
--- a/bench/ndarray/fromiter.py
+++ b/bench/ndarray/fromiter.py
@@ -1,0 +1,347 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#######################################################################
+
+"""Benchmark for blosc2.fromiter() — Phase 3 performance baseline.
+
+Covers the three Phase 3 tuning axes:
+
+  1. Chunk buffer allocation / reuse
+       Varies chunk shapes for a fixed total array size to expose allocation
+       overhead per chunk and the cost of many small vs. few large chunks.
+
+  2. Chunk traversal strategies
+       Compares c_order=True (full in-memory buffer) vs c_order=False
+       (streaming chunk-by-chunk) for the same multidimensional array.
+
+  3. On-disk vs. in-memory targets
+       Runs each case with and without a urlpath so that I/O overhead can be
+       separated from construction overhead.
+
+Usage::
+
+    python bench/ndarray/fromiter.py               # default: in-memory only
+    python bench/ndarray/fromiter.py --on-disk      # also run on-disk cases
+    python bench/ndarray/fromiter.py --nreps 5      # more repetitions
+    python bench/ndarray/fromiter.py --dtype float32
+    python bench/ndarray/fromiter.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import math
+import os
+import shutil
+import time
+
+import numpy as np
+
+import blosc2
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def make_iterator(total: int, dtype: np.dtype):
+    """Return a fresh generator of *total* values cast to *dtype*."""
+    # Use a generator so the iterable is one-shot (stress-tests the
+    # implementation's single-pass contract).
+    return (dtype.type(i % 1000) for i in range(total))
+
+
+def measure(fn, nreps: int) -> tuple[float, float]:
+    """Run *fn* *nreps* times and return (best, mean) wall-clock seconds."""
+    times = []
+    for _ in range(nreps):
+        gc.collect()
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    return min(times), sum(times) / len(times)
+
+
+def array_info(a: blosc2.NDArray) -> str:
+    nb = a.schunk.nbytes
+    cb = a.schunk.cbytes
+    return (
+        f"{nb / 2**20:8.1f} MB uncompressed  "
+        f"cratio {nb / cb:4.1f}x  "
+        f"({cb / 2**20:.1f} MB on storage)"
+    )
+
+
+def print_result(label: str, best: float, mean: float, nbytes: int) -> None:
+    gb = nbytes / 2**30
+    print(
+        f"  {label:<45s}  best {best:.3f}s ({gb / best:.2f} GB/s)"
+        f"  mean {mean:.3f}s"
+    )
+
+
+def cleanup(urlpath: str | None) -> None:
+    if urlpath is None:
+        return
+    if os.path.isdir(urlpath):
+        shutil.rmtree(urlpath)
+    elif os.path.exists(urlpath):
+        os.remove(urlpath)
+
+
+# ---------------------------------------------------------------------------
+# Benchmark sections
+# ---------------------------------------------------------------------------
+
+def bench_chunk_sizes(dtype: np.dtype, nreps: int, on_disk: bool) -> None:
+    """
+    Section 1 — Chunk buffer allocation / reuse (optimisation A).
+
+    Fixed total size, varying chunk shapes.  Exposes per-chunk allocation
+    overhead: many tiny chunks vs. a few large chunks, and shows the impact
+    of the page buffer on c_order=False.
+    """
+    print("\n" + "=" * 70)
+    print("Section 1 — Chunk buffer allocation / reuse (opt A: page buffer)")
+    print(f"  Fixed shape (1000, 1000), dtype={dtype}, nreps={nreps}")
+    print("=" * 70)
+
+    shape = (1000, 1000)
+    total = math.prod(shape)
+    nbytes = total * dtype.itemsize
+
+    chunk_configs = [
+        # (chunks, blocks, label)
+        ((10, 10),    (5, 5),     "chunks=(10,10)    — many tiny"),
+        ((50, 50),    (25, 25),   "chunks=(50,50)    — medium"),
+        ((100, 100),  (50, 50),   "chunks=(100,100)  — medium-large"),
+        ((200, 200),  (100, 100), "chunks=(200,200)  — large"),
+        ((500, 500),  (250, 250), "chunks=(500,500)  — very large"),
+        ((1000, 100), (500, 50),  "chunks=(1000,100) — full-row strip"),
+        ((1000, 1000),(500, 500), "chunks=shape      — single chunk"),
+    ]
+
+    for order_label, c_order in (("c_order=True ", True), ("c_order=False", False)):
+        print(f"\n  {order_label}")
+        for chunks, blocks, clabel in chunk_configs:
+            urlpath = "fromiter_bench.b2nd" if on_disk else None
+
+            def run(c=chunks, b=blocks, u=urlpath, co=c_order):
+                cleanup(u)
+                blosc2.fromiter(
+                    make_iterator(total, dtype),
+                    shape=shape, dtype=dtype,
+                    chunks=c, blocks=b,
+                    c_order=co,
+                    urlpath=u, mode="w" if u else None,
+                )
+
+            best, mean = measure(run, nreps)
+            cleanup(urlpath)
+            disk_tag = " [disk]" if on_disk else ""
+            print_result(f"{clabel}{disk_tag}", best, mean, nbytes)
+
+
+def bench_corder(dtype: np.dtype, nreps: int, on_disk: bool) -> None:
+    """
+    Section 2 — Chunk traversal strategies: c_order=True vs c_order=False.
+
+    Runs the same shapes/chunk configs with both orderings so that the
+    trade-off between in-memory buffering and streaming chunk fill is visible.
+    """
+    print("\n" + "=" * 70)
+    print("Section 2 — Chunk traversal: c_order=True vs c_order=False")
+    print(f"  dtype={dtype}, nreps={nreps}")
+    print("=" * 70)
+
+    cases = [
+        # (shape, chunks, blocks, label)
+        ((500, 500),        (50, 50),    (25, 25),   "2-D  (500,500)   chunks=(50,50)"),
+        ((200, 200, 200),   (20, 20, 20),(10, 10, 10),"3-D  (200,200,200) chunks=(20,20,20)"),
+        ((50, 50, 50, 50),  (10, 10, 10, 10),(5,5,5,5),"4-D  (50,50,50,50) chunks=(10,10,10,10)"),
+    ]
+
+    for shape, chunks, blocks, label in cases:
+        total = math.prod(shape)
+        nbytes = total * dtype.itemsize
+        print(f"\n  {label}  [{nbytes / 2**20:.1f} MB]")
+
+        for order_label, c_order in (("c_order=True ", True), ("c_order=False", False)):
+            for disk_label, use_disk in (("in-memory", False), ("on-disk  ", True)):
+                if use_disk and not on_disk:
+                    continue
+                urlpath = "fromiter_bench.b2nd" if use_disk else None
+
+                def run(s=shape, c=chunks, b=blocks, u=urlpath, co=c_order):
+                    cleanup(u)
+                    blosc2.fromiter(
+                        make_iterator(total, dtype),
+                        shape=s, dtype=dtype,
+                        chunks=c, blocks=b,
+                        c_order=co,
+                        urlpath=u, mode="w" if u else None,
+                    )
+
+                best, mean = measure(run, nreps)
+                cleanup(urlpath)
+                print_result(f"  {order_label}  {disk_label}", best, mean, nbytes)
+
+
+def bench_ondisk_vs_memory(dtype: np.dtype, nreps: int) -> None:
+    """
+    Section 3 — On-disk vs. in-memory targets.
+
+    Side-by-side comparison for a large-ish array so that I/O overhead
+    is clearly separated from construction cost.
+    """
+    print("\n" + "=" * 70)
+    print("Section 3 — On-disk vs. in-memory")
+    print(f"  dtype={dtype}, nreps={nreps}")
+    print("=" * 70)
+
+    shape = (2000, 2000)
+    chunks = (200, 200)
+    blocks = (100, 100)
+    total = math.prod(shape)
+    nbytes = total * dtype.itemsize
+    print(f"  shape={shape}  chunks={chunks}  [{nbytes / 2**20:.1f} MB]")
+
+    for order_label, c_order in (("c_order=True ", True), ("c_order=False", False)):
+        print(f"\n  {order_label}")
+        for disk_label, urlpath in (("in-memory", None), ("on-disk  ", "fromiter_bench.b2nd")):
+
+            def run(u=urlpath, co=c_order):
+                cleanup(u)
+                a = blosc2.fromiter(
+                    make_iterator(total, dtype),
+                    shape=shape, dtype=dtype,
+                    chunks=chunks, blocks=blocks,
+                    c_order=co,
+                    urlpath=u, mode="w" if u else None,
+                )
+                return a
+
+            best, mean = measure(run, nreps)
+            cleanup(urlpath)
+            print_result(f"  {disk_label}", best, mean, nbytes)
+
+
+def bench_large(dtype: np.dtype, nreps: int, on_disk: bool) -> None:
+    """
+    Bonus — large array for headline throughput numbers.
+
+    Includes the numpy fast path (optimisation C) when the iterable is
+    already a numpy array, which completely bypasses Python iteration.
+    """
+    print("\n" + "=" * 70)
+    print("Bonus — Large array headline throughput (opt C: numpy fast path)")
+    print(f"  dtype={dtype}, nreps={nreps}")
+    print("=" * 70)
+
+    shape = (5000, 5000)
+    chunks = (500, 500)
+    blocks = (250, 250)
+    total = math.prod(shape)
+    nbytes = total * dtype.itemsize
+    print(f"  shape={shape}  [{nbytes / 2**20:.0f} MB]")
+
+    # NumPy baseline (pure Python generator)
+    def np_run():
+        np.fromiter(make_iterator(total, dtype), dtype=dtype, count=total).reshape(shape)
+
+    best, mean = measure(np_run, nreps)
+    print_result("  NumPy fromiter+reshape (generator baseline)", best, mean, nbytes)
+
+    # blosc2 with generator
+    for order_label, c_order in (("c_order=True ", True), ("c_order=False", False)):
+        for disk_label, use_disk in (("in-memory", False), ("on-disk  ", True)):
+            if use_disk and not on_disk:
+                continue
+            urlpath = "fromiter_bench_large.b2nd" if use_disk else None
+
+            def run(s=shape, c=chunks, b=blocks, u=urlpath, co=c_order):
+                cleanup(u)
+                blosc2.fromiter(
+                    make_iterator(total, dtype),
+                    shape=s, dtype=dtype,
+                    chunks=c, blocks=b,
+                    c_order=co,
+                    urlpath=u, mode="w" if u else None,
+                )
+
+            best, mean = measure(run, nreps)
+            cleanup(urlpath)
+            print_result(f"  blosc2 generator  {order_label} {disk_label}", best, mean, nbytes)
+
+    # Optimisation C: numpy fast path — iterable is already an ndarray
+    print()
+    src = np.fromiter(make_iterator(total, dtype), dtype=dtype, count=total).reshape(shape)
+    for disk_label, use_disk in (("in-memory", False), ("on-disk  ", True)):
+        if use_disk and not on_disk:
+            continue
+        urlpath = "fromiter_bench_large.b2nd" if use_disk else None
+
+        def run_np(s=shape, c=chunks, b=blocks, u=urlpath, arr=src):
+            cleanup(u)
+            blosc2.fromiter(arr, shape=s, dtype=dtype, chunks=c, blocks=b,
+                            urlpath=u, mode="w" if u else None)
+
+        best, mean = measure(run_np, nreps)
+        cleanup(urlpath)
+        print_result(f"  blosc2 ndarray fast path         {disk_label}", best, mean, nbytes)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--dtype", default="float64", help="NumPy dtype (default: float64)")
+    p.add_argument("--nreps", type=int, default=3, help="Repetitions per measurement (default: 3)")
+    p.add_argument(
+        "--on-disk",
+        action="store_true",
+        default=False,
+        help="Also run on-disk cases (writes temporary .b2nd files)",
+    )
+    p.add_argument("--section", type=int, default=0,
+                   help="Run only section N (1-3 + bonus=4); 0 = all (default: 0)")
+    return p.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    dtype = np.dtype(args.dtype)
+    nreps = args.nreps
+    on_disk = args.on_disk
+
+    print(f"\nblosc2.fromiter() benchmark — dtype={dtype}  nreps={nreps}  on_disk={on_disk}")
+    print(f"blosc2 version: {blosc2.__version__}")
+
+    sections = {
+        1: lambda: bench_chunk_sizes(dtype, nreps, on_disk),
+        2: lambda: bench_corder(dtype, nreps, on_disk),
+        3: lambda: bench_ondisk_vs_memory(dtype, nreps) if on_disk else print(
+            "\nSection 3 skipped (use --on-disk to enable)"
+        ),
+        4: lambda: bench_large(dtype, nreps, on_disk),
+    }
+
+    if args.section == 0:
+        for fn in sections.values():
+            fn()
+    else:
+        sections[args.section]()
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -6106,11 +6106,22 @@ def fromiter(iterable, shape, dtype, c_order=True, **kwargs) -> NDArray:
         return dst
 
     if c_order or len(shape) == 1:
-        # Read the entire iterator into a numpy array, then write to the destination.
-        # This is O(total_size) in memory but requires only one pass over the
-        # iterable and avoids any temporary on-disk file.
-        buf = np.fromiter(iterable, dtype=dtype, count=total_size)
-        dst[:] = buf.reshape(shape)
+        # --- Phase 3B: chunk-row buffering ---
+        # Process one "chunk row" at a time (all chunks sharing the same
+        # first-dimension chunk coordinate).  This bounds peak memory to
+        # O(chunks[0] * prod(shape[1:])) instead of O(total_size), while
+        # still using only one np.fromiter call per chunk row.
+        #
+        # For a (5 000, 5 000) array with chunks=(500, 500) this is
+        # 10 × 20 MB reads instead of one 200 MB allocation.
+        row_h = dst.chunks[0]  # elements in dim-0 per chunk row
+        tail_nelems = math.prod(shape[1:])  # elements per row in the remaining dims
+
+        for row_start in range(0, shape[0], row_h):
+            row_end = builtins.min(row_start + row_h, shape[0])
+            n = (row_end - row_start) * tail_nelems
+            buf = np.fromiter(islice(iterable, n), dtype=dtype, count=n)
+            dst[row_start:row_end] = buf.reshape((row_end - row_start,) + shape[1:])
     else:
         # --- Optimisation A: page-buffered chunk-insertion order ---
         # Instead of calling np.fromiter once per chunk (O(n_chunks) calls),
@@ -6118,7 +6129,8 @@ def fromiter(iterable, shape, dtype, c_order=True, **kwargs) -> NDArray:
         # call overhead from O(n_chunks) to O(total / _PAGE_NELEMS), which is
         # decisive when chunks are small (e.g. (10, 10) → 10 000 chunks vs
         # ~1 page for a 1 000 × 1 000 array).
-        _PAGE_NELEMS = 1 << 20  # 1 M elements (~8 MB for float64)
+        _PAGE_BYTES = 8 << 20  # 8 MB target page size
+        _PAGE_NELEMS = builtins.max(1, _PAGE_BYTES // dtype.itemsize)
 
         page = np.empty(0, dtype=dtype)
         page_start = 0  # index of the first unread element in `page`

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -10,12 +10,11 @@ from __future__ import annotations
 import builtins
 import inspect
 import math
-import tempfile
 from abc import abstractmethod
 from collections import OrderedDict, namedtuple
 from collections.abc import Mapping
 from functools import reduce
-from itertools import product
+from itertools import islice, product
 from typing import TYPE_CHECKING, Any, NamedTuple, Protocol, runtime_checkable
 
 from numpy.exceptions import ComplexWarning
@@ -6029,20 +6028,37 @@ def eye(N, M=None, k=0, dtype=np.float64, **kwargs: Any) -> NDArray:
 def fromiter(iterable, shape, dtype, c_order=True, **kwargs) -> NDArray:
     """Create a new array from an iterable object.
 
+    The iterable is consumed exactly once and in a defined order.  Values are
+    never re-read, so plain generators and other one-pass sources are
+    fully supported.
+
     Parameters
     ----------
     iterable: iterable
-        An iterable object providing data for the array.
+        An iterable object providing data for the array.  It must yield at
+        least ``math.prod(shape)`` values; any surplus values are ignored.
+        If the iterable is exhausted before the array is full, a
+        ``ValueError`` is raised.
+
+        As a special fast path, if *iterable* is a :class:`numpy.ndarray` the
+        element-by-element Python iteration is skipped entirely: the array is
+        cast to *dtype* and written directly to the destination.
     shape: int, tuple or list
         The shape of the final array.
     dtype: np.dtype or list str
         The data type of the array elements in NumPy format.
     c_order: bool
-        Whether to store the array in C order (row-major) or insertion order.
-        Insertion order means that iterable values will be stored in the array
-        following the order of chunks in the array; this is more memory
-        efficient, as it does not require an intermediate copy of the array.
-        Default is C order.
+        Controls the order in which values are consumed from *iterable*.
+
+        * ``True`` (default) – values are consumed in standard C / row-major
+          order, matching ``numpy.fromiter(iterable, dtype).reshape(shape)``.
+          A temporary in-memory buffer equal to the full array size is used.
+        * ``False`` – values are consumed in *chunk-insertion order*: the
+          first ``chunk_size`` values fill the first chunk, the next
+          ``chunk_size`` values fill the second chunk, and so on.  A page
+          buffer (default 1 M elements) amortises the Python iterator
+          call overhead across chunks, so the number of :func:`numpy.fromiter`
+          calls is O(total / page) rather than O(n_chunks).
 
     Other Parameters
     ----------------
@@ -6063,32 +6079,76 @@ def fromiter(iterable, shape, dtype, c_order=True, **kwargs) -> NDArray:
     >>> print(array[:])
     [0 1 2 3 4 5 6 7 8 9]
     """
-
-    def iter_fill(inputs, output, offset):
-        nout = math.prod(output.shape)
-        (iterable,) = inputs
-        output[:] = np.fromiter(iterable, dtype=output.dtype, count=nout).reshape(output.shape)
-
+    # --- Optimisation C: numpy fast path ---
+    # If the caller already holds the data in a numpy array we can bypass all
+    # Python-level element iteration and write straight to the destination.
     dtype = _check_dtype(dtype)
+    shape = tuple(shape) if not isinstance(shape, tuple) else shape
+
+    if isinstance(iterable, np.ndarray):
+        dst = empty(shape, dtype=dtype, **kwargs)
+        if math.prod(shape) > 0:
+            dst[:] = np.asarray(iterable, dtype=dtype).reshape(shape)
+        return dst
 
     if is_inside_new_expr():
         # We already have the dtype and shape, so return immediately
         return blosc2.zeros(shape, dtype=dtype)
 
-    lshape = (math.prod(shape),)
-    inputs = (iterable,)
-    lazyarr = blosc2.lazyudf(iter_fill, inputs, dtype=dtype, shape=lshape)
+    # Ensure we hold a true one-shot iterator so that re-iterable objects
+    # (e.g. range, list) are consumed sequentially across all chunks.
+    iterable = iter(iterable)
 
-    if len(shape) == 1:
-        # C order is guaranteed, and no reshape is needed
-        return lazyarr.compute(**kwargs)
+    total_size = math.prod(shape)
+    dst = empty(shape, dtype=dtype, **kwargs)
 
-    # TODO: in principle, the next should work, but tests still fail:
-    # return reshape(lazyarr, shape, c_order=c_order, **kwargs)
-    # Creating a temporary file is a workaround for the issue
-    with tempfile.NamedTemporaryFile(suffix=".b2nd", delete=True) as tmp_file:
-        larr = lazyarr.compute(urlpath=tmp_file.name, mode="w")  # intermediate array
-        return reshape(larr, shape, c_order=c_order, **kwargs)
+    if total_size == 0:
+        return dst
+
+    if c_order or len(shape) == 1:
+        # Read the entire iterator into a numpy array, then write to the destination.
+        # This is O(total_size) in memory but requires only one pass over the
+        # iterable and avoids any temporary on-disk file.
+        buf = np.fromiter(iterable, dtype=dtype, count=total_size)
+        dst[:] = buf.reshape(shape)
+    else:
+        # --- Optimisation A: page-buffered chunk-insertion order ---
+        # Instead of calling np.fromiter once per chunk (O(n_chunks) calls),
+        # we pre-read a page of _PAGE_NELEMS elements at a time.  This reduces
+        # call overhead from O(n_chunks) to O(total / _PAGE_NELEMS), which is
+        # decisive when chunks are small (e.g. (10, 10) → 10 000 chunks vs
+        # ~1 page for a 1 000 × 1 000 array).
+        _PAGE_NELEMS = 1 << 20  # 1 M elements (~8 MB for float64)
+
+        page = np.empty(0, dtype=dtype)
+        page_start = 0  # index of the first unread element in `page`
+
+        for chunk_info in dst.iterchunks_info():
+            dst_slice = tuple(
+                slice(c * s, builtins.min((c + 1) * s, sh))
+                for c, s, sh in zip(chunk_info.coords, dst.chunks, dst.shape, strict=False)
+            )
+            chunk_shape = tuple(s.stop - s.start for s in dst_slice)
+            count = math.prod(chunk_shape)
+
+            available = len(page) - page_start
+            if available < count:
+                # Compact the leftover tail, then read a new page.
+                leftover = page[page_start:] if available > 0 else None
+                to_read = builtins.max(_PAGE_NELEMS, count)
+                new_data = np.fromiter(islice(iterable, to_read), dtype=dtype)
+                if available + len(new_data) < count:
+                    raise ValueError(
+                        f"iterator exhausted: chunk at coords {chunk_info.coords} "
+                        f"requires {count} elements but only {available + len(new_data)} remain"
+                    )
+                page = np.concatenate([leftover, new_data]) if leftover is not None else new_data
+                page_start = 0
+
+            dst[dst_slice] = page[page_start : page_start + count].reshape(chunk_shape)
+            page_start += count
+
+    return dst
 
 
 def frombuffer(

--- a/tests/ndarray/test_ndarray.py
+++ b/tests/ndarray/test_ndarray.py
@@ -293,6 +293,156 @@ def test_fromiter(it, shape, dtype, chunks, blocks, c_order):
         pass
 
 
+class CountingIterator:
+    """Iterator that tracks how many values were successfully yielded."""
+
+    def __init__(self, data):
+        self._data = iter(data)
+        self.call_count = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        # Increment only on successful yield; StopIteration exits before the count
+        # so that the count reflects elements consumed, not attempts made.
+        val = next(self._data)
+        self.call_count += 1
+        return val
+
+
+def test_fromiter_single_pass():
+    """Verify the iterable is consumed exactly once (no replay / no random access)."""
+    total = 60
+    it = CountingIterator(range(total))
+    a = blosc2.fromiter(it, dtype=np.int32, shape=(3, 4, 5), chunks=(2, 2, 3), blocks=(1, 1, 2))
+    assert it.call_count == total, f"Expected {total} __next__ calls, got {it.call_count}"
+    b = np.arange(total, dtype=np.int32).reshape(3, 4, 5)
+    np.testing.assert_array_equal(a[:], b)
+
+
+def test_fromiter_single_pass_corder_false():
+    """Verify single-pass consumption with c_order=False."""
+    total = 60
+    it = CountingIterator(range(total))
+    a = blosc2.fromiter(
+        it, dtype=np.int32, shape=(3, 4, 5), chunks=(2, 2, 3), blocks=(1, 1, 2), c_order=False
+    )
+    assert it.call_count == total, f"Expected {total} __next__ calls, got {it.call_count}"
+
+
+def test_fromiter_generator_no_rewind():
+    """Plain generator (not rewindable) must work correctly."""
+
+    def gen(n):
+        yield from range(n)
+
+    shape = (4, 6)
+    a = blosc2.fromiter(gen(24), dtype=np.float64, shape=shape, chunks=(2, 3), blocks=(1, 2))
+    b = np.arange(24, dtype=np.float64).reshape(shape)
+    np.testing.assert_array_equal(a[:], b)
+
+
+def test_fromiter_corder_false_chunk_values():
+    """With c_order=False, each chunk should contain consecutive values from the iterator."""
+    shape = (4, 6)
+    chunks = (2, 3)
+    dtype = np.int32
+    total = math.prod(shape)
+
+    a = blosc2.fromiter(range(total), dtype=dtype, shape=shape, chunks=chunks, blocks=(1, 2), c_order=False)
+
+    # Build a reference array showing what chunk-insertion order looks like:
+    # chunk coords iterate as (0,0), (0,1), (1,0), (1,1) for this shape/chunk combo
+    ref = np.empty(shape, dtype=dtype)
+    dst_tmp = blosc2.empty(shape, dtype=dtype, chunks=chunks, blocks=(1, 2))
+    flat_iter = iter(range(total))
+    for chunk_info in dst_tmp.iterchunks_info():
+        dst_slice = tuple(
+            slice(c * s, min((c + 1) * s, sh))
+            for c, s, sh in zip(chunk_info.coords, dst_tmp.chunks, dst_tmp.shape, strict=False)
+        )
+        chunk_shape = tuple(s.stop - s.start for s in dst_slice)
+        count = math.prod(chunk_shape)
+        buf = np.fromiter(flat_iter, dtype=dtype, count=count)
+        ref[dst_slice] = buf.reshape(chunk_shape)
+
+    np.testing.assert_array_equal(a[:], ref)
+
+
+@pytest.mark.parametrize(
+    ("shape", "dtype", "chunks", "blocks"),
+    [
+        ((10,), np.int32, (5,), (2,)),
+        ((4, 6), np.float32, (2, 3), (1, 2)),
+        ((2, 3, 4), np.int8, (2, 2, 2), (1, 1, 2)),
+        ((2, 3, 4, 2), np.uint8, (2, 2, 2, 2), (1, 1, 2, 1)),
+    ],
+)
+def test_fromiter_exhausted_iterator_raises(shape, dtype, chunks, blocks):
+    """fromiter() must raise when the iterator runs out before the array is full."""
+    total = math.prod(shape)
+    short_iter = range(total - 1)  # one element too few
+    with pytest.raises((ValueError, StopIteration)):
+        blosc2.fromiter(short_iter, dtype=dtype, shape=shape, chunks=chunks, blocks=blocks)
+
+
+def test_fromiter_empty_shape():
+    """fromiter() with a zero-size shape should return an empty array without consuming anything."""
+    it = CountingIterator(range(100))
+    a = blosc2.fromiter(it, dtype=np.int32, shape=(0,))
+    assert a.shape == (0,)
+    assert it.call_count == 0
+
+
+def test_fromiter_structured_dtype_2d():
+    """fromiter() should handle structured dtypes for multidimensional arrays."""
+    dtype = np.dtype([("x", np.int32), ("y", np.float32)])
+    data = [(i, float(i) * 0.5) for i in range(12)]
+    a = blosc2.fromiter(iter(data), dtype=dtype, shape=(3, 4), chunks=(2, 2), blocks=(1, 1))
+    b = np.array(data, dtype=dtype).reshape(3, 4)
+    np.testing.assert_array_equal(a[:], b)
+
+
+@pytest.mark.parametrize("c_order", [True, False])
+def test_fromiter_higher_dims(c_order):
+    """fromiter() for 3-D and 4-D with various chunk/block configs."""
+    shape3 = (3, 5, 7)
+    data3 = range(math.prod(shape3))
+    a3 = blosc2.fromiter(
+        data3, dtype=np.int16, shape=shape3, chunks=(2, 3, 4), blocks=(1, 2, 2), c_order=c_order
+    )
+    if c_order:
+        b3 = np.arange(math.prod(shape3), dtype=np.int16).reshape(shape3)
+        np.testing.assert_array_equal(a3[:], b3)
+
+    shape4 = (2, 3, 4, 5)
+    data4 = range(math.prod(shape4))
+    a4 = blosc2.fromiter(
+        data4, dtype=np.float32, shape=shape4, chunks=(2, 2, 2, 3), blocks=(1, 1, 2, 2), c_order=c_order
+    )
+    if c_order:
+        b4 = np.arange(math.prod(shape4), dtype=np.float32).reshape(shape4)
+        np.testing.assert_array_equal(a4[:], b4)
+
+
+@pytest.mark.parametrize("c_order", [True, False])
+@pytest.mark.parametrize(
+    ("shape", "chunks", "blocks"),
+    [
+        ((10,), (5,), (2,)),
+        ((4, 6), (2, 3), (1, 2)),
+        ((3, 4, 5), (2, 2, 3), (1, 1, 2)),
+    ],
+)
+def test_fromiter_numpy_fast_path(shape, chunks, blocks, c_order):
+    """fromiter() with a numpy ndarray input should bypass generator overhead."""
+    dtype = np.float32
+    src = np.arange(math.prod(shape), dtype=dtype).reshape(shape)
+    a = blosc2.fromiter(src, dtype=dtype, shape=shape, chunks=chunks, blocks=blocks, c_order=c_order)
+    np.testing.assert_array_equal(a[:], src)
+
+
 @pytest.mark.parametrize("order", ["f0", "f1", "f2", None])
 def test_sort(order):
     it = ((x + 1, x - 2, -x) for x in range(10))


### PR DESCRIPTION
### Problem

The old `fromiter()` implementation built multi-dimensional arrays by:
1. Wrapping the iterable in a 1-D lazy UDF
2. Computing a temporary `.b2nd` file
3. Reshaping that temp file into the final shape

This architecture treated a one-pass iterator as if it were a random-access lazy source — a semantic mismatch that required temporary disk materialization, obscured the true contract of `fromiter()`, and contained a latent correctness bug: re-iterable objects like `range` or `list` would silently **restart from zero** on each chunk request in the `c_order=False` path, producing wrong values with no error.

### What changed

**Direct chunked construction** — the iterable is consumed exactly once, in a defined order, and written directly into the destination `NDArray`. No temporary files, no reshape, no hidden replay assumptions.

#### `c_order=True` — chunk-row buffering (Phase 3B)
Elements arrive in C-order. Instead of allocating one `O(total_size)` buffer, we process one chunk-row at a time:
- Peak memory: `chunks[0] × prod(shape[1:]) × itemsize`
- For a `(5000, 5000)` float64 array with `chunks=(500, 500)`: **20 MB** per chunk-row instead of **200 MB** for the whole array

#### `c_order=False` — page-buffered insertion order (Phase 3A)
Elements arrive chunk-by-chunk. A page buffer of `_PAGE_BYTES = 8 MB` (adjusted by `dtype.itemsize`) reduces `np.fromiter` calls from O(n\_chunks) to O(total / page\_size):
```python
_PAGE_BYTES = 8 << 20
_PAGE_NELEMS = max(1, _PAGE_BYTES // dtype.itemsize)
```
This is dtype-aware — the 8 MB budget is constant regardless of element size.

#### NumPy array fast path (Phase 3C)
If the input is already a `numpy.ndarray`, all iteration is skipped entirely:
```python
if isinstance(iterable, np.ndarray):
    dst[:] = np.asarray(iterable, dtype=dtype).reshape(shape)
    return dst
```
Benchmark on a `(5000, 5000)` float64 array: **~63× faster** (4+ GB/s vs 0.07 GB/s for a generator).

#### Extra trailing values
Following NumPy's own precedent (`np.fromiter` with `count=` silently truncates), excess iterator values are ignored without error.

### Correctness fixes

- **`range`-restart bug fixed**: `iter(iterable)` is called up-front, ensuring re-iterable objects are consumed sequentially across all chunks rather than restarting per chunk.
- **Exhausted iterator error**: clear `ValueError` with chunk coordinates when the iterator runs out before the array is full.

### Tests

18 new tests added to `tests/ndarray/test_ndarray.py` (289 total, all passing):
- Single-pass consumption with a `CountingIterator` (both `c_order` values)
- Generator no-rewind guarantee
- Chunk-value correctness for `c_order=False`
- Exhausted iterator raises
- Empty shape
- Structured dtype 2-D
- Higher-dimensional (3-D, 4-D) shapes
- NumPy fast-path (6 parametrized cases: 3 shapes × 2 `c_order` values)

### Benchmark

New script `bench/ndarray/fromiter.py` with four sections:
- Chunk allocation/reuse across chunk sizes
- `c_order=True` vs `c_order=False` traversal for 2-D/3-D/4-D
- On-disk vs in-memory (via `--on-disk`)
- Large array headline throughput vs NumPy baseline, including numpy fast-path row

```
blosc2 generator  c_order=True   in-memory   2.48s (0.08 GB/s)
blosc2 generator  c_order=False  in-memory   2.59s (0.07 GB/s)
blosc2 ndarray fast path         in-memory   0.036s (5.15 GB/s)
```
