### PR TITLE
Containers tutorial

### DIFF
--- a/doc/getting_started/tutorials.rst
+++ b/doc/getting_started/tutorials.rst
@@ -17,4 +17,6 @@ Tutorials
    tutorials/09.ucodecs-ufilters
    tutorials/10.prefilters
    tutorials/11.vlarray
+   tutorials/12.batcharray
+   tutorials/13.containers
    tutorials/14.indexing-arrays

--- a/doc/getting_started/tutorials/12.batcharray.ipynb
+++ b/doc/getting_started/tutorials/12.batcharray.ipynb
@@ -5,11 +5,11 @@
    "id": "2c822501cae3b91d",
    "metadata": {},
    "source": [
-    "# Working with BatchStore\n",
+    "# Working with BatchArray\n",
     "\n",
-    "A `BatchStore` is a batch-oriented container for variable-length Python items backed by a single `SChunk`. Each batch is stored in one compressed chunk, and each chunk may contain one or more internal variable-length blocks.\n",
+    "A `BatchArray` is a batch-oriented container for variable-length Python items backed by a single `SChunk`. Each batch is stored in one compressed chunk, and each chunk may contain one or more internal variable-length blocks.\n",
     "\n",
-    "This makes `BatchStore` a good fit when data arrives naturally in batches and you want efficient batch append/update operations together with occasional item-level access inside each batch."
+    "This makes `BatchArray` a good fit when data arrives naturally in batches and you want efficient batch append/update operations together with occasional item-level access inside each batch."
    ]
   },
   {
@@ -37,8 +37,8 @@
     "    print(f\"{label}: {value}\")\n",
     "\n",
     "\n",
-    "urlpath = \"batchstore_tutorial.b2b\"\n",
-    "copy_path = \"batchstore_tutorial_copy.b2b\"\n",
+    "urlpath = \"batcharray_tutorial.b2b\"\n",
+    "copy_path = \"batcharray_tutorial_copy.b2b\"\n",
     "blosc2.remove_urlpath(urlpath)\n",
     "blosc2.remove_urlpath(copy_path)"
    ]
@@ -48,9 +48,9 @@
    "id": "dda38c56e3e63ec1",
    "metadata": {},
    "source": [
-    "## Creating and populating a BatchStore\n",
+    "## Creating and populating a BatchArray\n",
     "\n",
-    "A `BatchStore` is indexed by batch. Batches can be appended one by one with `append()` or in bulk with `extend()`. Here we set a small `max_blocksize` just so the internal block structure is easy to observe in `.info`."
+    "A `BatchArray` is indexed by batch. Batches can be appended one by one with `append()` or in bulk with `extend()`. Here we set a small `items_per_block` just so the internal block structure is easy to observe in `.info`."
    ]
   },
   {
@@ -80,7 +80,7 @@
     }
    ],
    "source": [
-    "store = blosc2.BatchStore(urlpath=urlpath, mode=\"w\", contiguous=True, max_blocksize=2)\n",
+    "store = blosc2.BatchArray(urlpath=urlpath, mode=\"w\", contiguous=True, items_per_block=2)\n",
     "store.append(\n",
     "    [\n",
     "        {\"name\": \"alpha\", \"count\": 1},\n",
@@ -212,7 +212,7 @@
    "source": [
     "## Iteration and summary info\n",
     "\n",
-    "Iterating a `BatchStore` yields batches. The `.info` summary reports both batch-level and internal block-level statistics."
+    "Iterating a `BatchArray` yields batches. The `.info` summary reports both batch-level and internal block-level statistics."
    ]
   },
   {
@@ -237,7 +237,7 @@
      "output_type": "stream",
      "text": [
       "Batches via iteration: [[{'name': 'alpha*', 'count': 10}, {'name': 'beta*', 'count': 20}], [{'name': 'delta*', 'count': 40}, {'name': 'epsilon*', 'count': 50}], [{'name': 'between-a', 'count': 99}, {'name': 'between-b', 'count': 100}], [{'name': 'eta', 'count': 7}, {'name': 'theta', 'count': 8}], [{'name': 'iota', 'count': 9}, {'name': 'kappa', 'count': 10}, {'name': 'lambda', 'count': 11}]]\n",
-      "type       : BatchStore\n",
+      "type       : BatchArray\n",
       "serializer : msgpack\n",
       "nbatches   : 5 (items per batch: mean=2.20, max=3, min=2)\n",
       "nblocks    : 6 (items per block: mean=1.83, max=2, min=1)\n",
@@ -267,7 +267,7 @@
    "source": [
     "## Copying and changing storage settings\n",
     "\n",
-    "Like other Blosc2 containers, `BatchStore.copy()` can write a new persistent store while changing storage or compression settings."
+    "Like other Blosc2 containers, `BatchArray.copy()` can write a new persistent store while changing storage or compression settings."
    ]
   },
   {
@@ -316,7 +316,7 @@
    "source": [
     "## Round-tripping through cframes and reopening from disk\n",
     "\n",
-    "Tagged persistent stores automatically reopen as `BatchStore`, and a serialized cframe buffer does too."
+    "Tagged persistent stores automatically reopen as `BatchArray`, and a serialized cframe buffer does too."
    ]
   },
   {
@@ -340,9 +340,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "from_cframe type: BatchStore\n",
+      "from_cframe type: BatchArray\n",
       "from_cframe batches: [[{'name': 'alpha*', 'count': 10}, {'name': 'beta*', 'count': 20}], [{'name': 'delta*', 'count': 40}, {'name': 'epsilon*', 'count': 50}], [{'name': 'between-a', 'count': 99}, {'name': 'between-b', 'count': 100}], [{'name': 'eta', 'count': 7}, {'name': 'theta', 'count': 8}], [{'name': 'iota', 'count': 9}, {'name': 'kappa', 'count': 10}, {'name': 'lambda', 'count': 11}]]\n",
-      "Reopened type: BatchStore\n",
+      "Reopened type: BatchArray\n",
       "Reopened batches: [[{'name': 'alpha*', 'count': 10}, {'name': 'beta*', 'count': 20}], [{'name': 'delta*', 'count': 40}, {'name': 'epsilon*', 'count': 50}], [{'name': 'between-a', 'count': 99}, {'name': 'between-b', 'count': 100}], [{'name': 'eta', 'count': 7}, {'name': 'theta', 'count': 8}], [{'name': 'iota', 'count': 9}, {'name': 'kappa', 'count': 10}, {'name': 'lambda', 'count': 11}]]\n"
      ]
     }
@@ -412,7 +412,7 @@
    "source": [
     "## Flat item access with `.items`\n",
     "\n",
-    "The main `BatchStore` API remains batch-oriented, but the `.items` accessor offers a read-only flat view across all items. Integer indexing returns one item and slicing returns a Python list."
+    "The main `BatchArray` API remains batch-oriented, but the `.items` accessor offers a read-only flat view across all items. Integer indexing returns one item and slicing returns a Python list."
    ]
   },
   {

--- a/doc/getting_started/tutorials/13.containers.ipynb
+++ b/doc/getting_started/tutorials/13.containers.ipynb
@@ -2,21 +2,21 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "a8a4840c0a8f4a01",
+   "id": "cell-01",
    "metadata": {},
    "source": [
     "# Working with Containers\n",
     "\n",
-    "This notebook is a guided tour of the main data containers provided by `python-blosc2`.\n",
+    "This notebook is a guided tour of the main data containers in `python-blosc2`.\n",
     "\n",
-    "The goal is to build a practical mental model first: what each container is, how it is implemented, what features it provides, and when it is the right tool for the job.\n",
+    "The goal is to build a practical mental model first: what each container is, how the containers relate, and when each one is the right tool.\n",
     "\n",
     "We will cover these containers in this order:\n",
     "\n",
     "1. `SChunk`\n",
     "2. `NDArray`\n",
     "3. `VLArray`\n",
-    "4. `BatchStore`\n",
+    "4. `BatchArray`\n",
     "5. `EmbedStore`\n",
     "6. `DictStore`\n",
     "7. `TreeStore`\n",
@@ -25,18 +25,58 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "257ca99ef3ba4f66",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 1,
+   "id": "cell-02",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:02.857758Z",
+     "start_time": "2026-04-12T06:55:02.544675Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "workdir: /var/folders/r3/bycghmsx079bmglqt_2xmlt00000gn/T/blosc2-containers-iv9daz3u\n"
+     ]
+    }
+   ],
    "source": [
+    "import shutil\n",
+    "import tempfile\n",
+    "from contextlib import suppress\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "import blosc2\n",
+    "\n",
+    "np.set_printoptions(edgeitems=4, linewidth=100)\n",
+    "\n",
+    "WORKDIR = Path(tempfile.mkdtemp(prefix=\"blosc2-containers-\"))\n",
+    "\n",
+    "\n",
     "def show(label, value):\n",
-    "    print(f\"{label}: {value}\")"
+    "    print(f\"{label}: {value}\")\n",
+    "\n",
+    "\n",
+    "def path(name):\n",
+    "    return str(WORKDIR / name)\n",
+    "\n",
+    "\n",
+    "def reset(name):\n",
+    "    with suppress(Exception):\n",
+    "        blosc2.remove_urlpath(path(name))\n",
+    "    return path(name)\n",
+    "\n",
+    "\n",
+    "show(\"workdir\", WORKDIR)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2a45cb5434df44e8",
+   "id": "cell-03",
    "metadata": {},
    "source": [
     "## The Big Picture\n",
@@ -45,339 +85,477 @@
     "\n",
     "- `NDArray` adds N-dimensional array semantics on top of chunked compressed storage.\n",
     "- `VLArray` stores one variable-length serialized item per entry.\n",
-    "- `BatchStore` stores batches of variable-length items.\n",
+    "- `BatchArray` stores batches of variable-length items.\n",
     "- `EmbedStore`, `DictStore`, and `TreeStore` organize multiple containers together.\n",
     "- `C2Array` is different: it is a remote array handle rather than a local storage container.\n",
     "\n",
     "<img src=\"images/containers/overview.svg\" width=\"1000\"/>\n",
     "\n",
-    "Later iterations of this notebook will replace the remaining placeholders with small SVG diagrams."
+    "For more info on each of these containers, keep reading."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "1782f3ac19324d4f",
+   "id": "cell-04",
    "metadata": {},
    "source": [
     "## `SChunk`: The Foundation\n",
     "\n",
     "`SChunk` is the low-level compressed storage container in Blosc2. Conceptually, it is a sequence of compressed chunks plus metadata.\n",
     "\n",
-    "It is useful when you want direct control over chunk-oriented storage, chunk append/update operations, or persistent compressed payloads without array semantics.\n",
-    "\n",
-    "Implementation notes:\n",
-    "\n",
-    "- stores data as compressed chunks\n",
-    "- can live in memory or on disk\n",
-    "- supports metadata and variable-length metadata\n",
-    "- acts as the basis for higher-level containers such as `NDArray`, `VLArray`, and `BatchStore`\n",
-    "\n",
-    "> Figure placeholder: `images/containers/schunk.svg`"
+    "Use it when you want direct control over chunk-oriented storage, chunk append/update operations, or persistent compressed payloads without array semantics."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "bdac78b9f4194d23",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "id": "cell-05",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:02.876641Z",
+     "start_time": "2026-04-12T06:55:02.858557Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "nchunks: 3\n",
+      "nbytes: 48\n",
+      "slice [2:7]: [2 3 4 5 6]\n",
+      "chunk ratios: [0.333, 0.333, 0.333]\n",
+      "special flags: ['NOT_SPECIAL', 'NOT_SPECIAL', 'NOT_SPECIAL']\n"
+     ]
+    }
+   ],
    "source": [
-    "# TODO: add a compact SChunk example.\n",
-    "# Suggested topics:\n",
-    "# - create an empty SChunk\n",
-    "# - append a couple of chunks\n",
-    "# - inspect nchunks, nbytes, cbytes, and metadata\n",
-    "# - optionally reopen from disk"
+    "data = np.arange(12, dtype=np.int32)\n",
+    "schunk = blosc2.SChunk(\n",
+    "    chunksize=4 * data.dtype.itemsize,\n",
+    "    data=data,\n",
+    "    cparams=blosc2.CParams(typesize=data.dtype.itemsize),\n",
+    ")\n",
+    "\n",
+    "out = np.empty(5, dtype=np.int32)\n",
+    "schunk.get_slice(start=2, stop=7, out=out)\n",
+    "chunk_info = list(schunk.iterchunks_info())\n",
+    "\n",
+    "show(\"nchunks\", schunk.nchunks)\n",
+    "show(\"nbytes\", schunk.nbytes)\n",
+    "show(\"slice [2:7]\", out)\n",
+    "show(\"chunk ratios\", [round(float(info.cratio), 3) for info in chunk_info])\n",
+    "show(\"special flags\", [info.special.name for info in chunk_info])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2ca3bf2bdf0348af",
+   "id": "cell-06",
    "metadata": {},
    "source": [
     "## `NDArray`: Compressed N-D Arrays\n",
     "\n",
     "`NDArray` is the main dense-array container in `python-blosc2`. It adds array semantics such as shape, dtype, slicing, chunking, and persistence on top of an underlying `SChunk`.\n",
     "\n",
-    "It is useful for dense numeric data when you want array operations together with compressed storage.\n",
-    "\n",
-    "Implementation notes:\n",
-    "\n",
-    "- built on top of `SChunk`\n",
-    "- stores shape/chunk/block layout as array metadata\n",
-    "- supports in-memory and persistent arrays\n",
-    "- integrates with slicing and higher-level compute workflows\n",
-    "\n",
-    "> Figure placeholder: `images/containers/ndarray.svg`"
+    "Use it for dense numeric data when you want array operations together with compressed storage."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "504a31637d23412c",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 3,
+   "id": "cell-07",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:02.895128Z",
+     "start_time": "2026-04-12T06:55:02.878075Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "shape: (3, 4)\n",
+      "chunks: (2, 2)\n",
+      "blocks: (1, 2)\n",
+      "slice [:, 1:3]: [[ 1  2]\n",
+      " [ 5  6]\n",
+      " [ 9 10]]\n",
+      "reopened type: NDArray\n"
+     ]
+    }
+   ],
    "source": [
-    "# TODO: add a compact NDArray example.\n",
-    "# Suggested topics:\n",
-    "# - create a small array\n",
-    "# - persist it to disk\n",
-    "# - show shape, chunks, and blocks\n",
-    "# - read a small slice"
+    "arr_path = reset(\"demo_array.b2nd\")\n",
+    "a = blosc2.asarray(\n",
+    "    np.arange(12).reshape(3, 4),\n",
+    "    urlpath=arr_path,\n",
+    "    mode=\"w\",\n",
+    "    chunks=(2, 2),\n",
+    "    blocks=(1, 2),\n",
+    ")\n",
+    "reopened = blosc2.open(arr_path, mode=\"r\")\n",
+    "\n",
+    "show(\"shape\", a.shape)\n",
+    "show(\"chunks\", a.chunks)\n",
+    "show(\"blocks\", a.blocks)\n",
+    "show(\"slice [:, 1:3]\", a[:, 1:3])\n",
+    "show(\"reopened type\", type(reopened).__name__)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "7ba5b920f4ef4b44",
+   "id": "cell-08",
    "metadata": {},
    "source": [
     "## `VLArray`: Variable-Length Items\n",
     "\n",
     "`VLArray` is a list-like container for variable-length Python values. Each entry is serialized and stored as its own compressed chunk in a backing `SChunk`.\n",
     "\n",
-    "It is useful for ragged or heterogeneous values such as strings, dictionaries, tuples, lists, and byte payloads.\n",
-    "\n",
-    "Implementation notes:\n",
-    "\n",
-    "- backed by a single `SChunk`\n",
-    "- each logical entry is stored independently\n",
-    "- uses serialization before compression\n",
-    "- offers list-like indexing, insertion, deletion, and persistence\n",
-    "\n",
-    "> Figure placeholder: `images/containers/vlarray.svg`"
+    "Use it for ragged or heterogeneous values such as strings, dictionaries, tuples, lists, and byte payloads."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "31498db3cd074a23",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 4,
+   "id": "cell-09",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:02.915305Z",
+     "start_time": "2026-04-12T06:55:02.896338Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "entries: [{'kind': 'alpha', 'count': 1}, ['x', 'y'], b'abc']\n",
+      "entry types: ['dict', 'list', 'bytes']\n",
+      "reopened type: VLArray\n",
+      "reopened[1]: ['x', 'y']\n"
+     ]
+    }
+   ],
    "source": [
-    "# TODO: add a compact VLArray example.\n",
-    "# Suggested topics:\n",
-    "# - append variable-length values\n",
-    "# - read entries and slices\n",
-    "# - show that values can have different sizes"
+    "vl_path = reset(\"notes.b2frame\")\n",
+    "vla = blosc2.VLArray(urlpath=vl_path, mode=\"w\", contiguous=True)\n",
+    "vla.extend(\n",
+    "    [\n",
+    "        {\"kind\": \"alpha\", \"count\": 1},\n",
+    "        [\"x\", \"y\"],\n",
+    "        b\"abc\",\n",
+    "    ]\n",
+    ")\n",
+    "reopened = blosc2.open(vl_path, mode=\"r\")\n",
+    "\n",
+    "show(\"entries\", list(vla))\n",
+    "show(\"entry types\", [type(v).__name__ for v in vla])\n",
+    "show(\"reopened type\", type(reopened).__name__)\n",
+    "show(\"reopened[1]\", reopened[1])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "95fbfd33c36742b6",
+   "id": "cell-10",
    "metadata": {},
    "source": [
-    "## `BatchStore`: Batched Variable-Length Data\n",
+    "## `BatchArray`: Batched Variable-Length Data\n",
     "\n",
-    "`BatchStore` is designed for batch-oriented variable-length data. Instead of storing one item per chunk, it stores one batch per chunk, with optional internal subdivision for more efficient item access inside a batch.\n",
+    "`BatchArray` is designed for batch-oriented variable-length data. Instead of storing one item per chunk, it stores one batch per chunk, with optional internal subdivision for more efficient item access inside a batch.\n",
     "\n",
-    "It is useful when data arrives or is processed in batches and batch-level append/update operations are the natural API.\n",
-    "\n",
-    "Implementation notes:\n",
-    "\n",
-    "- backed by a single `SChunk`\n",
-    "- each chunk stores one batch\n",
-    "- batches may contain multiple internal variable-length blocks\n",
-    "- indexing the store returns batches; a `Batch` object acts as the lazy per-batch view\n",
-    "\n",
-    "> Figure placeholder: `images/containers/vlarray-batchstore.svg`"
+    "Use it when data arrives or is processed in batches and batch-level append/update operations are the natural API."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "c4b3c26ea6ab4560",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "id": "cell-11",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:02.933652Z",
+     "start_time": "2026-04-12T06:55:02.916565Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "batches: 2\n",
+      "first batch: [{'x': 1}, {'x': 2}, {'x': 3}]\n",
+      "first four items: [{'x': 1}, {'x': 2}, {'x': 3}, {'x': 4}]\n",
+      "reopened type: BatchArray\n"
+     ]
+    }
+   ],
    "source": [
-    "# TODO: add a compact BatchStore example.\n",
-    "# Suggested topics:\n",
-    "# - append a few batches\n",
-    "# - index by batch\n",
-    "# - iterate items with iter_items()\n",
-    "# - inspect summary info"
+    "batch_path = reset(\"batches.b2b\")\n",
+    "store = blosc2.BatchArray(urlpath=batch_path, mode=\"w\", contiguous=True, items_per_block=2)\n",
+    "store.append([{\"x\": 1}, {\"x\": 2}, {\"x\": 3}])\n",
+    "store.append([{\"x\": 4}, {\"x\": 5}])\n",
+    "reopened = blosc2.open(batch_path, mode=\"r\")\n",
+    "\n",
+    "show(\"batches\", len(store))\n",
+    "show(\"first batch\", list(store[0]))\n",
+    "show(\"first four items\", list(store.iter_items())[:4])\n",
+    "show(\"reopened type\", type(reopened).__name__)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9030af26d7c5448f",
+   "id": "cell-12",
    "metadata": {},
    "source": [
     "## `EmbedStore`: Bundle Several Containers Into One Store\n",
     "\n",
     "`EmbedStore` is a dictionary-like container that stores several Blosc2 objects as embedded nodes inside one backing store.\n",
     "\n",
-    "It is useful when you want to package several arrays or container objects into one portable object or file.\n",
-    "\n",
-    "Implementation notes:\n",
-    "\n",
-    "- stores serialized nodes inside one internal backing container\n",
-    "- can embed arrays and chunked containers together\n",
-    "- may keep lightweight references for remote `C2Array` entries\n",
-    "- focuses on compact bundling rather than hierarchical organization\n",
-    "\n",
-    "> Figure placeholder: `images/containers/embedstore.svg`"
+    "Use it when you want to package several arrays or container objects into one portable object or file."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "fe76ea0f3a3042f2",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 6,
+   "id": "cell-13",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:02.953315Z",
+     "start_time": "2026-04-12T06:55:02.936170Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "keys: ['/arr', '/ones']\n",
+      "type(/arr): NDArray\n",
+      "/arr: [0 1 2 3 4]\n",
+      "type(/ones): NDArray\n"
+     ]
+    }
+   ],
    "source": [
-    "# TODO: add a compact EmbedStore example.\n",
-    "# Suggested topics:\n",
-    "# - create a store\n",
-    "# - add a small NDArray and SChunk-like object\n",
-    "# - retrieve them back"
+    "embed_path = reset(\"bundle.b2e\")\n",
+    "estore = blosc2.EmbedStore(urlpath=embed_path, mode=\"w\")\n",
+    "estore[\"/arr\"] = np.arange(5)\n",
+    "estore[\"/ones\"] = blosc2.ones(3, dtype=np.int16)\n",
+    "\n",
+    "show(\"keys\", sorted(estore.keys()))\n",
+    "show(\"type(/arr)\", type(estore[\"/arr\"]).__name__)\n",
+    "show(\"/arr\", estore[\"/arr\"][:])\n",
+    "show(\"type(/ones)\", type(estore[\"/ones\"]).__name__)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "d0a6ef00e242499c",
+   "id": "cell-14",
    "metadata": {},
    "source": [
-    "## `DictStore`: Key-Value Collection of Containers\n",
+    "## `DictStore`: Key-Value Collection Of Containers\n",
     "\n",
     "`DictStore` is a directory- or zip-backed key-value collection for Blosc2 objects.\n",
     "\n",
-    "It is useful when you want to organize a dataset made of several named arrays or containers, while keeping storage portable.\n",
-    "\n",
-    "Implementation notes:\n",
-    "\n",
-    "- manages multiple objects under string keys\n",
-    "- can use embedded storage for small objects and external leaves for larger ones\n",
-    "- supports `.b2d` directory stores and `.b2z` zip stores\n",
-    "- is the non-hierarchical basis for `TreeStore`\n",
-    "\n",
-    "> Figure placeholder: `images/containers/dictstore.svg`"
+    "Use it when you want to organize a dataset made of several named arrays or containers while keeping storage portable."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "0f1fa0f8501647f0",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 7,
+   "id": "cell-15",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:02.984367Z",
+     "start_time": "2026-04-12T06:55:02.955277Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "written keys: ['/group/grid', '/raw']\n",
+      "reopened type: DictStore\n",
+      "keys: ['/group/grid', '/raw']\n",
+      "/group/grid: [[0 1 2]\n",
+      " [3 4 5]]\n"
+     ]
+    }
+   ],
    "source": [
-    "# TODO: add a compact DictStore example.\n",
-    "# Suggested topics:\n",
-    "# - create a .b2d or .b2z store\n",
-    "# - assign a couple of named entries\n",
-    "# - list the keys and reopen the store"
+    "dict_path = reset(\"dataset.b2z\")\n",
+    "with blosc2.DictStore(dict_path, mode=\"w\") as dstore:\n",
+    "    dstore[\"/raw\"] = np.arange(4)\n",
+    "    dstore[\"/group/grid\"] = blosc2.asarray(np.arange(6).reshape(2, 3))\n",
+    "    show(\"written keys\", sorted(dstore.keys()))\n",
+    "\n",
+    "with blosc2.DictStore(dict_path, mode=\"r\") as dstore:\n",
+    "    show(\"reopened type\", type(dstore).__name__)\n",
+    "    show(\"keys\", sorted(dstore.keys()))\n",
+    "    show(\"/group/grid\", dstore[\"/group/grid\"][:])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "fa05969f76bf4db6",
+   "id": "cell-16",
    "metadata": {},
    "source": [
     "## `TreeStore`: Hierarchical Datasets\n",
     "\n",
-    "`TreeStore` extends `DictStore` with hierarchical keys such as `/group/subgroup/node`.\n",
+    "`TreeStore` extends `DictStore` with stricter hierarchical semantics and subtree navigation.\n",
     "\n",
-    "It is useful when your data naturally forms a tree, and you want subtree traversal or path-based organization.\n",
-    "\n",
-    "Implementation notes:\n",
-    "\n",
-    "- built on top of `DictStore`\n",
-    "- validates and manages hierarchical paths\n",
-    "- supports subtree traversal and structural organization\n",
-    "- keeps the same storage ideas as `DictStore`, but with a tree model\n",
-    "\n",
-    "> Figure placeholder: `images/containers/stores.svg`"
+    "Use it when your dataset is naturally tree-structured and you want path-based organization plus subtree-level operations."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "733b6a87fe0a4317",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 8,
+   "id": "cell-17",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:03.005880Z",
+     "start_time": "2026-04-12T06:55:02.985661Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "subtree keys: ['/run1', '/run1/data', '/run2', '/run2/data']\n",
+      "walk(/): [('/', ['run1', 'run2'], []), ('/run1', [], ['data']), ('/run2', [], ['data'])]\n",
+      "reopened type: TreeStore\n",
+      "/exp/run2/data: [3 4 5]\n"
+     ]
+    }
+   ],
    "source": [
-    "# TODO: add a compact TreeStore example.\n",
-    "# Suggested topics:\n",
-    "# - assign arrays under hierarchical paths\n",
-    "# - walk a subtree\n",
-    "# - show the difference from DictStore"
+    "tree_path = reset(\"tree.b2z\")\n",
+    "with blosc2.TreeStore(tree_path, mode=\"w\") as tstore:\n",
+    "    tstore[\"/exp/run1/data\"] = np.arange(3)\n",
+    "    tstore[\"/exp/run2/data\"] = np.arange(3, 6)\n",
+    "    subtree = tstore.get_subtree(\"/exp\")\n",
+    "    show(\"subtree keys\", sorted(subtree.keys()))\n",
+    "    show(\"walk(/)\", list(subtree.walk(\"/\")))\n",
+    "\n",
+    "with blosc2.TreeStore(tree_path, mode=\"r\") as tstore:\n",
+    "    show(\"reopened type\", type(tstore).__name__)\n",
+    "    show(\"/exp/run2/data\", tstore[\"/exp/run2/data\"][:])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6df8a77948de4848",
+   "id": "cell-18",
    "metadata": {},
    "source": [
     "## `C2Array`: Remote Arrays\n",
     "\n",
     "`C2Array` is a remote array handle for Caterva2-hosted arrays. Unlike the local containers above, it does not primarily manage local storage; instead, it exposes remote metadata and remote slice access.\n",
     "\n",
-    "It is useful when the array lives on a remote service and you want to read metadata or fetch slices without managing the full local dataset yourself.\n",
-    "\n",
-    "Implementation notes:\n",
-    "\n",
-    "- acts as a remote handle rather than a local chunk store\n",
-    "- fetches metadata and slices over HTTP\n",
-    "- can be referenced by local higher-level stores such as `EmbedStore`\n",
-    "- is best presented as the remote-facing member of the container family\n",
-    "\n",
-    "> Figure placeholder: `images/containers/c2array.svg`"
+    "For an offline-safe tutorial, the cell below shows the pattern without performing the network access by default."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "5a43542cf9dc49d2",
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 9,
+   "id": "cell-19",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:03.022641Z",
+     "start_time": "2026-04-12T06:55:03.006769Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "remote URLPath: <blosc2.c2array.URLPath object at 0x10f0aa660>\n",
+      "Set RUN_REMOTE = True to open a live C2Array from a Caterva2 service.\n"
+     ]
+    }
+   ],
    "source": [
-    "# TODO: add a compact C2Array example.\n",
-    "# Suggested topics:\n",
-    "# - open a small remote array\n",
-    "# - inspect metadata\n",
-    "# - fetch a tiny slice\n",
-    "# Note: this cell may require network access."
+    "RUN_REMOTE = False\n",
+    "remote_urlpath = blosc2.URLPath(\"@public/examples/ds-1d.b2nd\", \"https://cat2.cloud/demo\")\n",
+    "\n",
+    "show(\"remote URLPath\", remote_urlpath)\n",
+    "if RUN_REMOTE:\n",
+    "    remote = blosc2.open(remote_urlpath, mode=\"r\")\n",
+    "    show(\"remote type\", type(remote).__name__)\n",
+    "    show(\"remote slice [:5]\", remote[:5])\n",
+    "else:\n",
+    "    print(\"Set RUN_REMOTE = True to open a live C2Array from a Caterva2 service.\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "3dc203d6be094c30",
+   "id": "cell-20",
    "metadata": {},
    "source": [
-    "## Choosing the Right Container\n",
+    "## Choosing The Right Container\n",
     "\n",
-    "| Container | Implemented on top of | Main strengths | Best for |\n",
-    "| --- | --- | --- | --- |\n",
-    "| `SChunk` | native chunk container | direct chunk control, metadata, persistence | chunk-oriented storage |\n",
-    "| `NDArray` | `SChunk` | array semantics, slicing, persistence | dense numeric arrays |\n",
-    "| `VLArray` | `SChunk` | variable-length entries | ragged or heterogeneous items |\n",
-    "| `BatchStore` | `SChunk` | batch append/update, item access inside batches | batched variable-length data |\n",
-    "| `EmbedStore` | internal backing store | compact bundling of several objects | portable bundles |\n",
-    "| `DictStore` | `EmbedStore` + external leaves | named collections | multi-object datasets |\n",
-    "| `TreeStore` | `DictStore` | hierarchy and subtree traversal | structured datasets |\n",
-    "| `C2Array` | remote service | remote metadata and slicing | remote arrays |\n",
+    "| Container | Backing idea | Best for |\n",
+    "| --- | --- | --- |\n",
+    "| `SChunk` | raw compressed chunks | direct chunk-level storage control |\n",
+    "| `NDArray` | `SChunk` plus array metadata | dense numeric arrays |\n",
+    "| `VLArray` | one variable-length entry per chunk | ragged or heterogeneous Python values |\n",
+    "| `BatchArray` | one batch per chunk | batch-oriented ingestion and access |\n",
+    "| `EmbedStore` | one bundled object store | packaging a few Blosc2 objects together |\n",
+    "| `DictStore` | keyed collection of leaves | portable multi-object datasets |\n",
+    "| `TreeStore` | hierarchical keyed collection | tree-structured datasets |\n",
+    "| `C2Array` | remote array handle | arrays hosted by a remote Caterva2 service |\n",
     "\n",
-    "This table should stay near the end of the notebook, after the reader has already seen each container in context."
+    "A simple rule of thumb is:\n",
+    "\n",
+    "- start with `NDArray` for dense numeric data\n",
+    "- drop down to `SChunk` if you need chunk-level control\n",
+    "- use `VLArray` or `BatchArray` for variable-length Python objects\n",
+    "- use `EmbedStore`, `DictStore`, or `TreeStore` when your dataset contains multiple objects"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "878cad4d2bb34057",
+   "id": "cell-21",
    "metadata": {},
    "source": [
     "## Final Notes\n",
     "\n",
     "This notebook is intentionally organized from low-level storage to higher-level organization:\n",
     "\n",
-    "- start with `SChunk` to understand the storage basis\n",
-    "- move to array and variable-length abstractions built on top of it\n",
-    "- finish with collection-oriented stores and remote access\n",
+    "- understand `SChunk` first\n",
+    "- use `NDArray` for most dense numeric workloads\n",
+    "- move to `VLArray` or `BatchArray` when entries stop being fixed-size arrays\n",
+    "- use `EmbedStore`, `DictStore`, or `TreeStore` when you need to package multiple objects together\n",
+    "- use `C2Array` when the data lives on a remote service\n",
     "\n",
-    "Next iterations should replace the placeholders with:\n",
-    "\n",
-    "- polished short explanations\n",
-    "- runnable compact examples\n",
-    "- SVG diagrams under `images/containers/`\n",
-    "- small transitions between sections so the narrative reads continuously"
+    "For deeper details on a specific class, continue with the reference docs and the dedicated tutorials for `VLArray`, `BatchArray`, and indexing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "cell-22",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2026-04-12T06:55:03.039886Z",
+     "start_time": "2026-04-12T06:55:03.024025Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "removed workdir: /var/folders/r3/bycghmsx079bmglqt_2xmlt00000gn/T/blosc2-containers-iv9daz3u\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Cleanup for repeated local runs of this notebook.\n",
+    "shutil.rmtree(WORKDIR)\n",
+    "show(\"removed workdir\", WORKDIR)"
    ]
   }
  ],

--- a/doc/getting_started/tutorials/13.containers.ipynb
+++ b/doc/getting_started/tutorials/13.containers.ipynb
@@ -1,0 +1,405 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a8a4840c0a8f4a01",
+   "metadata": {},
+   "source": [
+    "# Working with Containers\n",
+    "\n",
+    "This notebook is a guided tour of the main data containers provided by `python-blosc2`.\n",
+    "\n",
+    "The goal is to build a practical mental model first: what each container is, how it is implemented, what features it provides, and when it is the right tool for the job.\n",
+    "\n",
+    "We will cover these containers in this order:\n",
+    "\n",
+    "1. `SChunk`\n",
+    "2. `NDArray`\n",
+    "3. `VLArray`\n",
+    "4. `BatchStore`\n",
+    "5. `EmbedStore`\n",
+    "6. `DictStore`\n",
+    "7. `TreeStore`\n",
+    "8. `C2Array`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "257ca99ef3ba4f66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show(label, value):\n",
+    "    print(f\"{label}: {value}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a45cb5434df44e8",
+   "metadata": {},
+   "source": [
+    "## The Big Picture\n",
+    "\n",
+    "`SChunk` is the storage foundation. Higher-level containers either wrap it to provide a more convenient programming model, or use it as a building block inside larger stores.\n",
+    "\n",
+    "- `NDArray` adds N-dimensional array semantics on top of chunked compressed storage.\n",
+    "- `VLArray` stores one variable-length serialized item per entry.\n",
+    "- `BatchStore` stores batches of variable-length items.\n",
+    "- `EmbedStore`, `DictStore`, and `TreeStore` organize multiple containers together.\n",
+    "- `C2Array` is different: it is a remote array handle rather than a local storage container.\n",
+    "\n",
+    "<img src=\"images/containers/overview.svg\" width=\"1000\"/>\n",
+    "\n",
+    "Later iterations of this notebook will replace the remaining placeholders with small SVG diagrams."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1782f3ac19324d4f",
+   "metadata": {},
+   "source": [
+    "## `SChunk`: The Foundation\n",
+    "\n",
+    "`SChunk` is the low-level compressed storage container in Blosc2. Conceptually, it is a sequence of compressed chunks plus metadata.\n",
+    "\n",
+    "It is useful when you want direct control over chunk-oriented storage, chunk append/update operations, or persistent compressed payloads without array semantics.\n",
+    "\n",
+    "Implementation notes:\n",
+    "\n",
+    "- stores data as compressed chunks\n",
+    "- can live in memory or on disk\n",
+    "- supports metadata and variable-length metadata\n",
+    "- acts as the basis for higher-level containers such as `NDArray`, `VLArray`, and `BatchStore`\n",
+    "\n",
+    "> Figure placeholder: `images/containers/schunk.svg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bdac78b9f4194d23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add a compact SChunk example.\n",
+    "# Suggested topics:\n",
+    "# - create an empty SChunk\n",
+    "# - append a couple of chunks\n",
+    "# - inspect nchunks, nbytes, cbytes, and metadata\n",
+    "# - optionally reopen from disk"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ca3bf2bdf0348af",
+   "metadata": {},
+   "source": [
+    "## `NDArray`: Compressed N-D Arrays\n",
+    "\n",
+    "`NDArray` is the main dense-array container in `python-blosc2`. It adds array semantics such as shape, dtype, slicing, chunking, and persistence on top of an underlying `SChunk`.\n",
+    "\n",
+    "It is useful for dense numeric data when you want array operations together with compressed storage.\n",
+    "\n",
+    "Implementation notes:\n",
+    "\n",
+    "- built on top of `SChunk`\n",
+    "- stores shape/chunk/block layout as array metadata\n",
+    "- supports in-memory and persistent arrays\n",
+    "- integrates with slicing and higher-level compute workflows\n",
+    "\n",
+    "> Figure placeholder: `images/containers/ndarray.svg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504a31637d23412c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add a compact NDArray example.\n",
+    "# Suggested topics:\n",
+    "# - create a small array\n",
+    "# - persist it to disk\n",
+    "# - show shape, chunks, and blocks\n",
+    "# - read a small slice"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ba5b920f4ef4b44",
+   "metadata": {},
+   "source": [
+    "## `VLArray`: Variable-Length Items\n",
+    "\n",
+    "`VLArray` is a list-like container for variable-length Python values. Each entry is serialized and stored as its own compressed chunk in a backing `SChunk`.\n",
+    "\n",
+    "It is useful for ragged or heterogeneous values such as strings, dictionaries, tuples, lists, and byte payloads.\n",
+    "\n",
+    "Implementation notes:\n",
+    "\n",
+    "- backed by a single `SChunk`\n",
+    "- each logical entry is stored independently\n",
+    "- uses serialization before compression\n",
+    "- offers list-like indexing, insertion, deletion, and persistence\n",
+    "\n",
+    "> Figure placeholder: `images/containers/vlarray.svg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31498db3cd074a23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add a compact VLArray example.\n",
+    "# Suggested topics:\n",
+    "# - append variable-length values\n",
+    "# - read entries and slices\n",
+    "# - show that values can have different sizes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95fbfd33c36742b6",
+   "metadata": {},
+   "source": [
+    "## `BatchStore`: Batched Variable-Length Data\n",
+    "\n",
+    "`BatchStore` is designed for batch-oriented variable-length data. Instead of storing one item per chunk, it stores one batch per chunk, with optional internal subdivision for more efficient item access inside a batch.\n",
+    "\n",
+    "It is useful when data arrives or is processed in batches and batch-level append/update operations are the natural API.\n",
+    "\n",
+    "Implementation notes:\n",
+    "\n",
+    "- backed by a single `SChunk`\n",
+    "- each chunk stores one batch\n",
+    "- batches may contain multiple internal variable-length blocks\n",
+    "- indexing the store returns batches; a `Batch` object acts as the lazy per-batch view\n",
+    "\n",
+    "> Figure placeholder: `images/containers/vlarray-batchstore.svg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c4b3c26ea6ab4560",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add a compact BatchStore example.\n",
+    "# Suggested topics:\n",
+    "# - append a few batches\n",
+    "# - index by batch\n",
+    "# - iterate items with iter_items()\n",
+    "# - inspect summary info"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9030af26d7c5448f",
+   "metadata": {},
+   "source": [
+    "## `EmbedStore`: Bundle Several Containers Into One Store\n",
+    "\n",
+    "`EmbedStore` is a dictionary-like container that stores several Blosc2 objects as embedded nodes inside one backing store.\n",
+    "\n",
+    "It is useful when you want to package several arrays or container objects into one portable object or file.\n",
+    "\n",
+    "Implementation notes:\n",
+    "\n",
+    "- stores serialized nodes inside one internal backing container\n",
+    "- can embed arrays and chunked containers together\n",
+    "- may keep lightweight references for remote `C2Array` entries\n",
+    "- focuses on compact bundling rather than hierarchical organization\n",
+    "\n",
+    "> Figure placeholder: `images/containers/embedstore.svg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe76ea0f3a3042f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add a compact EmbedStore example.\n",
+    "# Suggested topics:\n",
+    "# - create a store\n",
+    "# - add a small NDArray and SChunk-like object\n",
+    "# - retrieve them back"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d0a6ef00e242499c",
+   "metadata": {},
+   "source": [
+    "## `DictStore`: Key-Value Collection of Containers\n",
+    "\n",
+    "`DictStore` is a directory- or zip-backed key-value collection for Blosc2 objects.\n",
+    "\n",
+    "It is useful when you want to organize a dataset made of several named arrays or containers, while keeping storage portable.\n",
+    "\n",
+    "Implementation notes:\n",
+    "\n",
+    "- manages multiple objects under string keys\n",
+    "- can use embedded storage for small objects and external leaves for larger ones\n",
+    "- supports `.b2d` directory stores and `.b2z` zip stores\n",
+    "- is the non-hierarchical basis for `TreeStore`\n",
+    "\n",
+    "> Figure placeholder: `images/containers/dictstore.svg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f1fa0f8501647f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add a compact DictStore example.\n",
+    "# Suggested topics:\n",
+    "# - create a .b2d or .b2z store\n",
+    "# - assign a couple of named entries\n",
+    "# - list the keys and reopen the store"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa05969f76bf4db6",
+   "metadata": {},
+   "source": [
+    "## `TreeStore`: Hierarchical Datasets\n",
+    "\n",
+    "`TreeStore` extends `DictStore` with hierarchical keys such as `/group/subgroup/node`.\n",
+    "\n",
+    "It is useful when your data naturally forms a tree, and you want subtree traversal or path-based organization.\n",
+    "\n",
+    "Implementation notes:\n",
+    "\n",
+    "- built on top of `DictStore`\n",
+    "- validates and manages hierarchical paths\n",
+    "- supports subtree traversal and structural organization\n",
+    "- keeps the same storage ideas as `DictStore`, but with a tree model\n",
+    "\n",
+    "> Figure placeholder: `images/containers/stores.svg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "733b6a87fe0a4317",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add a compact TreeStore example.\n",
+    "# Suggested topics:\n",
+    "# - assign arrays under hierarchical paths\n",
+    "# - walk a subtree\n",
+    "# - show the difference from DictStore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6df8a77948de4848",
+   "metadata": {},
+   "source": [
+    "## `C2Array`: Remote Arrays\n",
+    "\n",
+    "`C2Array` is a remote array handle for Caterva2-hosted arrays. Unlike the local containers above, it does not primarily manage local storage; instead, it exposes remote metadata and remote slice access.\n",
+    "\n",
+    "It is useful when the array lives on a remote service and you want to read metadata or fetch slices without managing the full local dataset yourself.\n",
+    "\n",
+    "Implementation notes:\n",
+    "\n",
+    "- acts as a remote handle rather than a local chunk store\n",
+    "- fetches metadata and slices over HTTP\n",
+    "- can be referenced by local higher-level stores such as `EmbedStore`\n",
+    "- is best presented as the remote-facing member of the container family\n",
+    "\n",
+    "> Figure placeholder: `images/containers/c2array.svg`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5a43542cf9dc49d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: add a compact C2Array example.\n",
+    "# Suggested topics:\n",
+    "# - open a small remote array\n",
+    "# - inspect metadata\n",
+    "# - fetch a tiny slice\n",
+    "# Note: this cell may require network access."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3dc203d6be094c30",
+   "metadata": {},
+   "source": [
+    "## Choosing the Right Container\n",
+    "\n",
+    "| Container | Implemented on top of | Main strengths | Best for |\n",
+    "| --- | --- | --- | --- |\n",
+    "| `SChunk` | native chunk container | direct chunk control, metadata, persistence | chunk-oriented storage |\n",
+    "| `NDArray` | `SChunk` | array semantics, slicing, persistence | dense numeric arrays |\n",
+    "| `VLArray` | `SChunk` | variable-length entries | ragged or heterogeneous items |\n",
+    "| `BatchStore` | `SChunk` | batch append/update, item access inside batches | batched variable-length data |\n",
+    "| `EmbedStore` | internal backing store | compact bundling of several objects | portable bundles |\n",
+    "| `DictStore` | `EmbedStore` + external leaves | named collections | multi-object datasets |\n",
+    "| `TreeStore` | `DictStore` | hierarchy and subtree traversal | structured datasets |\n",
+    "| `C2Array` | remote service | remote metadata and slicing | remote arrays |\n",
+    "\n",
+    "This table should stay near the end of the notebook, after the reader has already seen each container in context."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "878cad4d2bb34057",
+   "metadata": {},
+   "source": [
+    "## Final Notes\n",
+    "\n",
+    "This notebook is intentionally organized from low-level storage to higher-level organization:\n",
+    "\n",
+    "- start with `SChunk` to understand the storage basis\n",
+    "- move to array and variable-length abstractions built on top of it\n",
+    "- finish with collection-oriented stores and remote access\n",
+    "\n",
+    "Next iterations should replace the placeholders with:\n",
+    "\n",
+    "- polished short explanations\n",
+    "- runnable compact examples\n",
+    "- SVG diagrams under `images/containers/`\n",
+    "- small transitions between sections so the narrative reads continuously"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/doc/getting_started/tutorials/images/containers/README.md
+++ b/doc/getting_started/tutorials/images/containers/README.md
@@ -1,0 +1,34 @@
+# Containers Tutorial Assets
+
+Planned image files for `13.containers.ipynb`:
+
+- `overview.svg`
+- `schunk.svg`
+- `ndarray.svg`
+- `vlarray.svg`
+- `vlarray-batchstore.svg`
+- `embedstore.svg`
+- `dictstore.svg`
+- `stores.svg`
+- `c2array.svg`
+
+These assets are intended to be simple SVG diagrams with a consistent visual language based on the Blosc2 logo palette:
+
+- deep blue: `#002a64`
+- dark yellow: `#df9e00`
+- light blue: `#007a86`
+
+Suggested mapping:
+
+- deep blue (`#002a64`): container outlines, titles, and main structure
+- dark yellow (`#df9e00`): compressed chunks and highlighted payload/storage blocks
+- light blue (`#007a86`): metadata bands, secondary structure, and remote/reference accents
+
+Visual grammar:
+
+- deep blue outline: container
+- dark yellow blocks: compressed chunks or payload pieces
+- light blue strip: metadata
+- dashed light blue arrows: references or remote access
+
+The notebook currently uses text placeholders that point to these planned paths.

--- a/doc/getting_started/tutorials/images/containers/README.md
+++ b/doc/getting_started/tutorials/images/containers/README.md
@@ -1,34 +1,20 @@
 # Containers Tutorial Assets
 
-Planned image files for `13.containers.ipynb`:
+V1 of `13.containers.ipynb` intentionally keeps the asset set small.
 
-- `overview.svg`
-- `schunk.svg`
-- `ndarray.svg`
-- `vlarray.svg`
-- `vlarray-batchstore.svg`
-- `embedstore.svg`
-- `dictstore.svg`
-- `stores.svg`
-- `c2array.svg`
+Current assets:
 
-These assets are intended to be simple SVG diagrams with a consistent visual language based on the Blosc2 logo palette:
+- `overview.svg`: family-level map of the main `python-blosc2` containers
 
-- deep blue: `#002a64`
-- dark yellow: `#df9e00`
-- light blue: `#007a86`
+Design goals:
 
-Suggested mapping:
+- concept-first, not decorative
+- crisp SVG rendering inside the notebook
+- consistent palette with the Blosc2 visual identity
 
-- deep blue (`#002a64`): container outlines, titles, and main structure
-- dark yellow (`#df9e00`): compressed chunks and highlighted payload/storage blocks
-- light blue (`#007a86`): metadata bands, secondary structure, and remote/reference accents
+If the tutorial expands later, this directory can grow with more focused
+diagrams for:
 
-Visual grammar:
-
-- deep blue outline: container
-- dark yellow blocks: compressed chunks or payload pieces
-- light blue strip: metadata
-- dashed light blue arrows: references or remote access
-
-The notebook currently uses text placeholders that point to these planned paths.
+- local containers
+- store containers
+- remote containers

--- a/doc/getting_started/tutorials/images/containers/overview.svg
+++ b/doc/getting_started/tutorials/images/containers/overview.svg
@@ -1,0 +1,783 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="1200"
+   height="820"
+   viewBox="0 0 1200 820"
+   role="img"
+   aria-labelledby="title desc"
+   version="1.1"
+   id="svg68"
+   sodipodi:docname="overview.svg"
+   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview68"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="0.9625"
+     inkscape:cx="600"
+     inkscape:cy="410.38961"
+     inkscape:window-width="1712"
+     inkscape:window-height="1045"
+     inkscape:window-x="0"
+     inkscape:window-y="34"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg68" />
+  <title
+     id="title">python-blosc2 container family overview</title>
+  <desc
+     id="desc">A layered overview showing stores at the top, NDArray, VLArray, and BatchStore in the middle, SChunk as the storage foundation at the bottom, and C2Array attached to NDArray for remote access.</desc>
+  <defs
+     id="defs2">
+    <marker
+       style="overflow:visible"
+       id="Triangle"
+       refX="0"
+       refY="0"
+       orient="auto-start-reverse"
+       inkscape:stockid="Triangle arrow"
+       markerWidth="1"
+       markerHeight="1"
+       viewBox="0 0 1 1"
+       inkscape:isstock="true"
+       inkscape:collect="always"
+       preserveAspectRatio="xMidYMid">
+      <path
+         transform="scale(0.5)"
+         style="fill:context-stroke;fill-rule:evenodd;stroke:context-stroke;stroke-width:1pt"
+         d="M 5.77,0 -2.88,5 V -5 Z"
+         id="path135" />
+    </marker>
+    <style
+       id="style1">
+      .title { font: 700 30px &quot;DejaVu Sans&quot;, Arial, sans-serif; fill: #002a64; }
+      .subtitle { font: 400 15px &quot;DejaVu Sans&quot;, Arial, sans-serif; fill: #24457a; }
+      .section { font: 700 18px &quot;DejaVu Sans&quot;, Arial, sans-serif; fill: #002a64; }
+      .label { font: 700 20px &quot;DejaVu Sans&quot;, Arial, sans-serif; fill: #002a64; }
+      .body { font: 400 14px &quot;DejaVu Sans&quot;, Arial, sans-serif; fill: #173866; }
+      .small { font: 400 13px &quot;DejaVu Sans&quot;, Arial, sans-serif; fill: #305185; }
+      .tiny { font: 700 11px &quot;DejaVu Sans&quot;, Arial, sans-serif; fill: #002a64; }
+      .box { fill: #f7fafc; stroke: #002a64; stroke-width: 3; rx: 18; ry: 18; }
+      .box-soft { fill: #fbfcfd; stroke: #002a64; stroke-width: 2.5; rx: 18; ry: 18; }
+      .meta { fill: #007a86; }
+      .chunk { fill: #df9e00; }
+      .accent { fill: #e7f5f7; stroke: #007a86; stroke-width: 2; rx: 12; ry: 12; }
+      .arrow { stroke: #002a64; stroke-width: 3.5; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+      .arrow-dashed { stroke: #007a86; stroke-width: 3.5; fill: none; stroke-dasharray: 10 10; stroke-linecap: round; stroke-linejoin: round; }
+    </style>
+    <marker
+       id="arrowhead-blue"
+       markerWidth="10"
+       markerHeight="10"
+       refX="8"
+       refY="5"
+       orient="auto">
+      <path
+         d="M 0 0 L 10 5 L 0 10 z"
+         fill="#002a64"
+         id="path1" />
+    </marker>
+    <marker
+       id="arrowhead-cyan"
+       markerWidth="10"
+       markerHeight="10"
+       refX="8"
+       refY="5"
+       orient="auto">
+      <path
+         d="M 0 0 L 10 5 L 0 10 z"
+         fill="#007a86"
+         id="path2" />
+    </marker>
+  </defs>
+  <text
+     x="372"
+     y="60"
+     class="title"
+     id="text2"
+     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:30px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif"><tspan
+       style="font-size:32px"
+       id="tspan69">Python-Blosc2 container family</tspan></text>
+  <text
+     x="402"
+     y="96"
+     class="subtitle"
+     id="text3"
+     style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:15px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif"><tspan
+       style="font-size:24px"
+       id="tspan68">Different abstractions for diverse needs</tspan></text>
+  <text
+     x="150"
+     y="150"
+     class="section"
+     id="text8"
+     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:18px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">Organization</text>
+  <text
+     x="132"
+     y="370"
+     class="section"
+     id="text9"
+     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:18px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">Specialized Containers</text>
+  <text
+     x="450"
+     y="628"
+     class="section"
+     id="text10"
+     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:18px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">Storage foundation</text>
+  <g
+     transform="translate(95 170)"
+     id="g19">
+    <rect
+       x="0"
+       y="0"
+       width="270"
+       height="118"
+       class="box-soft"
+       id="rect10" />
+    <rect
+       x="20"
+       y="24"
+       width="46"
+       height="18"
+       class="meta"
+       rx="7"
+       ry="7"
+       id="rect11" />
+    <rect
+       x="20"
+       y="54"
+       width="46"
+       height="24"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect12" />
+    <rect
+       x="78"
+       y="54"
+       width="46"
+       height="24"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect13" />
+    <text
+       x="140"
+       y="40"
+       class="label"
+       id="text13"
+       style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:20px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">EmbedStore</text>
+    <text
+       x="140"
+       y="64"
+       class="body"
+       id="text14"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">embedded nodes</text>
+    <text
+       x="140"
+       y="84"
+       class="body"
+       id="text15"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">single bundled store</text>
+    <rect
+       x="20"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect15" />
+    <rect
+       x="52"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect16" />
+    <rect
+       x="84"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect17" />
+    <text
+       x="27"
+       y="100"
+       class="tiny"
+       id="text17">ND</text>
+    <text
+       x="60"
+       y="100"
+       class="tiny"
+       id="text18">VL</text>
+    <text
+       x="90"
+       y="100"
+       class="tiny"
+       id="text19">BS</text>
+  </g>
+  <g
+     transform="translate(415 170)"
+     id="g27">
+    <rect
+       x="0"
+       y="0"
+       width="270"
+       height="118"
+       class="box-soft"
+       id="rect19" />
+    <path
+       d="M 17.833308,35.833308 H 61.107182 L 70.060397,47.91332 H 126.76409 V 86.166692 H 17.833308 Z"
+       fill="#e7f5f7"
+       stroke="#002a64"
+       stroke-width="2.16662"
+       id="path19" />
+    <rect
+       x="34"
+       y="72"
+       width="26"
+       height="16"
+       class="chunk"
+       rx="5"
+       ry="5"
+       id="rect20" />
+    <rect
+       x="66"
+       y="72"
+       width="20"
+       height="16"
+       class="meta"
+       rx="5"
+       ry="5"
+       id="rect21" />
+    <text
+       x="142"
+       y="40"
+       class="label"
+       id="text21"
+       style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:20px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">DictStore</text>
+    <text
+       x="142"
+       y="64"
+       class="body"
+       id="text22"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">named collection</text>
+    <text
+       x="142"
+       y="84"
+       class="body"
+       id="text23"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">flat keys, .b2d / .b2z</text>
+    <rect
+       x="20"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect23" />
+    <rect
+       x="52"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect24" />
+    <rect
+       x="84"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect25" />
+    <text
+       x="27"
+       y="100"
+       class="tiny"
+       id="text25">ND</text>
+    <text
+       x="60"
+       y="100"
+       class="tiny"
+       id="text26">VL</text>
+    <text
+       x="90"
+       y="100"
+       class="tiny"
+       id="text27">BS</text>
+  </g>
+  <g
+     transform="translate(735 170)"
+     id="g38">
+    <rect
+       x="0"
+       y="0"
+       width="270"
+       height="118"
+       class="box-soft"
+       id="rect27" />
+    <line
+       x1="26"
+       y1="26"
+       x2="26"
+       y2="82"
+       stroke="#002a64"
+       stroke-width="3"
+       id="line27" />
+    <line
+       x1="26"
+       y1="26"
+       x2="57.454544"
+       y2="26"
+       stroke="#002a64"
+       stroke-width="2.48076"
+       id="line28" />
+    <line
+       x1="26"
+       y1="54"
+       x2="57.454544"
+       y2="54"
+       stroke="#002a64"
+       stroke-width="2.48076"
+       id="line29" />
+    <line
+       x1="56"
+       y1="54"
+       x2="102"
+       y2="54"
+       stroke="#002a64"
+       stroke-width="3"
+       id="line30" />
+    <rect
+       x="58"
+       y="18"
+       width="18"
+       height="16"
+       class="chunk"
+       rx="4"
+       ry="4"
+       id="rect30" />
+    <rect
+       x="58"
+       y="46"
+       width="18"
+       height="16"
+       class="chunk"
+       rx="4"
+       ry="4"
+       id="rect31" />
+    <rect
+       x="100"
+       y="46"
+       width="18"
+       height="16"
+       class="chunk"
+       rx="4"
+       ry="4"
+       id="rect32" />
+    <text
+       x="134"
+       y="40"
+       class="label"
+       id="text32"
+       style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:20px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">TreeStore</text>
+    <text
+       x="134"
+       y="64"
+       class="body"
+       id="text33"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">hierarchical collection</text>
+    <text
+       x="134"
+       y="84"
+       class="body"
+       id="text34"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">paths and subtrees</text>
+    <rect
+       x="20"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect34" />
+    <rect
+       x="52"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect35" />
+    <rect
+       x="84"
+       y="88"
+       width="26"
+       height="16"
+       class="accent"
+       id="rect36" />
+    <text
+       x="27"
+       y="100"
+       class="tiny"
+       id="text36">ND</text>
+    <text
+       x="60"
+       y="100"
+       class="tiny"
+       id="text37">VL</text>
+    <text
+       x="90"
+       y="100"
+       class="tiny"
+       id="text38">BS</text>
+  </g>
+  <g
+     transform="translate(95 390)"
+     id="g45">
+    <rect
+       x="0"
+       y="0"
+       width="270"
+       height="118"
+       class="box-soft"
+       id="rect39" />
+    <rect
+       x="20"
+       y="26"
+       width="36"
+       height="36"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect40" />
+    <rect
+       x="60"
+       y="26"
+       width="36"
+       height="36"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect41" />
+    <rect
+       x="20"
+       y="66"
+       width="36"
+       height="36"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect42" />
+    <rect
+       x="60"
+       y="66"
+       width="36"
+       height="36"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect43" />
+    <text
+       x="124"
+       y="40"
+       class="label"
+       id="text43">NDArray</text>
+    <text
+       x="124"
+       y="64"
+       class="body"
+       id="text44">N-D array semantics</text>
+    <text
+       x="124"
+       y="84"
+       class="body"
+       id="text45">shape, dtype, slices</text>
+  </g>
+  <g
+     transform="translate(415 390)"
+     id="g50">
+    <rect
+       x="0"
+       y="0"
+       width="270"
+       height="118"
+       class="box-soft"
+       id="rect45" />
+    <rect
+       x="20"
+       y="28"
+       width="74"
+       height="16"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect46" />
+    <rect
+       x="20"
+       y="54"
+       width="42"
+       height="16"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect47" />
+    <rect
+       x="20"
+       y="80"
+       width="92"
+       height="16"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect48" />
+    <text
+       x="132"
+       y="40"
+       class="label"
+       id="text48">VLArray</text>
+    <text
+       x="132"
+       y="64"
+       class="body"
+       id="text49">variable-length entries</text>
+    <text
+       x="132"
+       y="84"
+       class="body"
+       id="text50">one item per entry</text>
+  </g>
+  <g
+     transform="translate(735 390)"
+     id="g55">
+    <rect
+       x="0"
+       y="0"
+       width="270"
+       height="118"
+       class="box-soft"
+       id="rect50" />
+    <rect
+       x="18"
+       y="24"
+       width="98"
+       height="22"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect51" />
+    <line
+       x1="50"
+       y1="24"
+       x2="50"
+       y2="46"
+       stroke="#ffffff"
+       stroke-width="3"
+       id="line51" />
+    <line
+       x1="82"
+       y1="24"
+       x2="82"
+       y2="46"
+       stroke="#ffffff"
+       stroke-width="3"
+       id="line52" />
+    <rect
+       x="18"
+       y="58"
+       width="82"
+       height="22"
+       class="chunk"
+       rx="8"
+       ry="8"
+       id="rect52" />
+    <line
+       x1="59"
+       y1="58"
+       x2="59"
+       y2="80"
+       stroke="#ffffff"
+       stroke-width="3"
+       id="line53" />
+    <rect
+       x="18"
+       y="92"
+       width="110"
+       height="10"
+       class="meta"
+       rx="5"
+       ry="5"
+       id="rect53" />
+    <text
+       x="132"
+       y="40"
+       class="label"
+       id="text53">BatchStore</text>
+    <text
+       x="132"
+       y="64"
+       class="body"
+       id="text54">batch-oriented entries</text>
+    <text
+       x="132"
+       y="84"
+       class="body"
+       id="text55">one batch per chunk</text>
+  </g>
+  <g
+     transform="translate(43,590)"
+     id="g57">
+    <rect
+       x="0"
+       y="0"
+       width="206"
+       height="70"
+       class="accent"
+       id="rect55" />
+    <rect
+       x="18"
+       y="22"
+       width="62"
+       height="26"
+       fill="#f1f7fb"
+       stroke="#007a86"
+       stroke-width="2.5"
+       rx="10"
+       ry="10"
+       id="rect56" />
+    <line
+       x1="28"
+       y1="34"
+       x2="70"
+       y2="34"
+       stroke="#007a86"
+       stroke-width="2.5"
+       id="line56" />
+    <text
+       x="96"
+       y="30"
+       class="label"
+       font-size="18px"
+       id="text56"
+       style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:20px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">C2Array</text>
+    <text
+       x="96"
+       y="50"
+       class="body"
+       id="text57"
+       style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif"><tspan
+         sodipodi:role="line"
+         id="tspan70"
+         x="96"
+         y="50">remote NDArray</tspan><tspan
+         sodipodi:role="line"
+         id="tspan71"
+         x="96"
+         y="67.5">handle</tspan></text>
+  </g>
+  <rect
+     x="340.1279"
+     y="633.12793"
+     width="539.7442"
+     height="176.75716"
+     class="box"
+     id="rect57" />
+  <rect
+     x="362"
+     y="653"
+     width="496"
+     height="28"
+     class="meta"
+     rx="10"
+     ry="10"
+     id="rect58" />
+  <text
+     x="378"
+     y="673"
+     font-family="'DejaVu Sans', Arial, sans-serif"
+     font-size="14px"
+     font-weight="700"
+     fill="#ffffff"
+     id="text58">meta / vlmeta</text>
+  <rect
+     x="382"
+     y="711"
+     width="94"
+     height="52"
+     class="chunk"
+     rx="12"
+     ry="12"
+     id="rect59" />
+  <rect
+     x="486"
+     y="711"
+     width="94"
+     height="52"
+     class="chunk"
+     rx="12"
+     ry="12"
+     id="rect60" />
+  <rect
+     x="590"
+     y="711"
+     width="94"
+     height="52"
+     class="chunk"
+     rx="12"
+     ry="12"
+     id="rect61" />
+  <rect
+     x="694"
+     y="711"
+     width="94"
+     height="52"
+     class="chunk"
+     rx="12"
+     ry="12"
+     id="rect62" />
+  <text
+     x="372"
+     y="791"
+     class="label"
+     id="text62"
+     style="font-style:normal;font-variant:normal;font-weight:700;font-stretch:normal;font-size:20px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">SChunk</text>
+  <text
+     x="490"
+     y="779"
+     class="body"
+     id="text63"
+     style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">compressed chunks + metadata</text>
+  <text
+     x="490"
+     y="801"
+     class="body"
+     id="text64"
+     style="font-style:normal;font-variant:normal;font-weight:400;font-stretch:normal;font-size:14px;line-height:normal;font-family:'DejaVu Sans', Arial, sans-serif">persistent or in-memory foundation</text>
+  <path
+     d="M 230 508 L 230 556 L 465 556 L 465 605"
+     class="arrow"
+     marker-end="url(#arrowhead-blue)"
+     id="path65" />
+  <path
+     d="M 550 508 L 550 605"
+     class="arrow"
+     marker-end="url(#arrowhead-blue)"
+     id="path66" />
+  <path
+     d="M 870 508 L 870 556 L 635 556 L 635 605"
+     class="arrow"
+     marker-end="url(#arrowhead-blue)"
+     id="path67" />
+  <path
+     d="m 130.25974,578.84398 v -34.2331"
+     class="arrow-dashed"
+     marker-end="url(#arrowhead-cyan)"
+     id="path68"
+     style="stroke-dasharray:none;marker-end:url(#Triangle)" />
+</svg>

--- a/doc/getting_started/tutorials/images/containers/overview.svg
+++ b/doc/getting_started/tutorials/images/containers/overview.svg
@@ -35,7 +35,7 @@
   <title
      id="title">python-blosc2 container family overview</title>
   <desc
-     id="desc">A layered overview showing stores at the top, NDArray, VLArray, and BatchStore in the middle, SChunk as the storage foundation at the bottom, and C2Array attached to NDArray for remote access.</desc>
+     id="desc">A layered overview showing stores at the top, NDArray, VLArray, and BatchArray in the middle, SChunk as the storage foundation at the bottom, and C2Array attached to NDArray for remote access.</desc>
   <defs
      id="defs2">
     <marker
@@ -223,7 +223,7 @@
        x="90"
        y="100"
        class="tiny"
-       id="text19">BS</text>
+       id="text19">BA</text>
   </g>
   <g
      transform="translate(415 170)"
@@ -312,7 +312,7 @@
        x="90"
        y="100"
        class="tiny"
-       id="text27">BS</text>
+       id="text27">BA</text>
   </g>
   <g
      transform="translate(735 170)"
@@ -436,7 +436,7 @@
        x="90"
        y="100"
        class="tiny"
-       id="text38">BS</text>
+       id="text38">BA</text>
   </g>
   <g
      transform="translate(95 390)"
@@ -618,7 +618,7 @@
        x="132"
        y="40"
        class="label"
-       id="text53">BatchStore</text>
+       id="text53">BatchArray</text>
     <text
        x="132"
        y="64"

--- a/doc/reference/batch_array.rst
+++ b/doc/reference/batch_array.rst
@@ -1,11 +1,11 @@
-.. _BatchStore:
+.. _BatchArray:
 
-BatchStore
+BatchArray
 ==========
 
 Overview
 --------
-BatchStore is a batch-oriented container for variable-length Python items
+BatchArray is a batch-oriented container for variable-length Python items
 backed by a single Blosc2 ``SChunk``.
 
 Each batch is stored in one compressed chunk:
@@ -13,9 +13,9 @@ Each batch is stored in one compressed chunk:
 - batches contain one or more Python items
 - each chunk may contain one or more internal variable-length blocks
 - the store itself is indexed by batch
-- item-wise traversal is available via :meth:`BatchStore.iter_items`
+- item-wise traversal is available via :meth:`BatchArray.iter_items`
 
-BatchStore is a good fit when data arrives naturally in batches and you want:
+BatchArray is a good fit when data arrives naturally in batches and you want:
 
 - efficient batch append/update operations
 - persistent ``.b2b`` stores
@@ -25,40 +25,11 @@ BatchStore is a good fit when data arrives naturally in batches and you want:
 Serializer support
 ------------------
 
-BatchStore currently supports two serializers:
+BatchArray currently supports two serializers:
 
 - ``"msgpack"``: the default and general-purpose choice for Python items
 - ``"arrow"``: optional and requires ``pyarrow``; mainly useful when data is
   already Arrow-shaped before ingestion
-
-For ``"msgpack"``, python-blosc2 supports both ordinary msgpack-safe Python
-values and selected Blosc2 objects.
-
-Blosc2 objects serialized by value via :meth:`to_cframe` /
-:func:`blosc2.from_cframe`:
-
-- ``NDArray``
-- ``SChunk``
-- ``VLArray``
-- ``BatchStore``
-- ``EmbedStore``
-
-Structured reference-style Blosc2 objects currently supported:
-
-- ``C2Array``
-- ``LazyExpr``
-- ``LazyUDF`` backed by ``@blosc2.dsl_kernel``
-
-``LazyExpr`` values and supported ``LazyUDF`` values preserve reference
-semantics and are serialized as a recipe plus durable operand references.
-Supported operands are:
-
-- persistent local Blosc2 operands reopenable from ``urlpath``
-- remote ``C2Array`` operands
-- ``DictStore`` members reopenable from ``(.b2d|.b2z, key)``
-
-Purely in-memory operands are intentionally not supported. Plain Python
-``LazyUDF`` callables are not serialized by msgpack.
 
 Quick example
 -------------
@@ -67,7 +38,7 @@ Quick example
 
     import blosc2
 
-    store = blosc2.BatchStore(urlpath="example_batch_store.b2b", mode="w", contiguous=True)
+    store = blosc2.BatchArray(urlpath="example_batch_array.b2b", mode="w", contiguous=True)
     store.append([{"red": 1, "green": 2, "blue": 3}, {"red": 4, "green": 5, "blue": 6}])
     store.append([{"red": 7, "green": 8, "blue": 9}])
 
@@ -75,17 +46,17 @@ Quick example
     print(store[0][1])  # second item in first batch
     print(list(store.iter_items()))
 
-    reopened = blosc2.open("example_batch_store.b2b", mode="r")
+    reopened = blosc2.open("example_batch_array.b2b", mode="r")
     print(type(reopened).__name__)
     print(reopened.info)
 
 .. note::
-   BatchStore is batch-oriented by design. ``store[i]`` returns a batch, not a
-   single item. Use :meth:`BatchStore.iter_items` for flat item-wise traversal.
+   BatchArray is batch-oriented by design. ``store[i]`` returns a batch, not a
+   single item. Use :meth:`BatchArray.iter_items` for flat item-wise traversal.
 
 .. currentmodule:: blosc2
 
-.. autoclass:: BatchStore
+.. autoclass:: BatchArray
 
     Constructors
     ------------

--- a/doc/reference/classes.rst
+++ b/doc/reference/classes.rst
@@ -17,7 +17,7 @@ Main Classes
     DictStore
     TreeStore
     EmbedStore
-    BatchStore
+    BatchArray
     VLArray
     Ref
     Proxy
@@ -38,7 +38,7 @@ Main Classes
     dict_store
     tree_store
     embed_store
-    batch_store
+    batch_array
     vlarray
     ref
     proxy

--- a/doc/reference/schunk.rst
+++ b/doc/reference/schunk.rst
@@ -14,7 +14,7 @@ variable-length metadata can store not only ordinary msgpack-safe Python
 values, but also the currently supported Blosc2 objects and references,
 including:
 
-- ``NDArray``, ``SChunk``, ``VLArray``, ``BatchStore``, ``EmbedStore``
+- ``NDArray``, ``SChunk``, ``VLArray``, ``BatchArray``, ``EmbedStore``
 - ``Ref``
 - ``C2Array``
 - ``LazyExpr``

--- a/examples/batch_array.py
+++ b/examples/batch_array.py
@@ -11,7 +11,7 @@ import random
 
 import blosc2
 
-URLPATH = "example_batch_store.b2b"
+URLPATH = "example_batch_array.b2b"
 NBATCHES = 100
 OBJECTS_PER_BATCH = 100
 BLOCKSIZE_MAX = 32
@@ -36,19 +36,19 @@ def main() -> None:
     blosc2.remove_urlpath(URLPATH)
 
     storage = blosc2.Storage(urlpath=URLPATH, mode="w", contiguous=True)
-    with blosc2.BatchStore(storage=storage, max_blocksize=BLOCKSIZE_MAX) as store:
+    with blosc2.BatchArray(storage=storage, items_per_block=BLOCKSIZE_MAX) as store:
         for batch_index in range(NBATCHES):
             store.append(make_batch(batch_index))
 
         total_objects = sum(len(batch) for batch in store)
-        print("Created BatchStore")
+        print("Created BatchArray")
         print(f"  batches: {len(store)}")
         print(f"  objects: {total_objects}")
-        print(f"  max_blocksize: {store.max_blocksize}")
+        print(f"  items_per_block: {store.items_per_block}")
 
-    # Reopen with the same max_blocksize hint so scalar reads can use the
+    # Reopen with the same items_per_block hint so scalar reads can use the
     # VL-block path instead of decoding the entire batch.
-    reopened = blosc2.BatchStore(urlpath=URLPATH, mode="r", contiguous=True, max_blocksize=BLOCKSIZE_MAX)
+    reopened = blosc2.BatchArray(urlpath=URLPATH, mode="r", contiguous=True, items_per_block=BLOCKSIZE_MAX)
 
     print()
     print(reopened.info)
@@ -66,7 +66,7 @@ def main() -> None:
     print(f"  reopened.items[0] -> {reopened.items[0]}")
     print(f"  reopened.items[150:153] -> {reopened.items[150:153]}")
 
-    print(f"BatchStore file at: {reopened.urlpath}")
+    print(f"BatchArray file at: {reopened.urlpath}")
 
 
 if __name__ == "__main__":

--- a/plans/containers-tutorial.md
+++ b/plans/containers-tutorial.md
@@ -1,0 +1,110 @@
+# Plan: Containers Tutorial
+
+Target notebook:
+`doc/getting_started/tutorials/13.containers.ipynb`
+
+## Goal
+
+Land a solid v1 tutorial that gives users a practical mental map of the main
+`python-blosc2` containers, with short runnable examples and a small number of
+supporting diagrams.
+
+This tutorial should answer:
+
+- what each container is
+- how the containers relate to each other
+- which container to choose for a given workflow
+
+## Scope For V1
+
+Included sections:
+
+1. `SChunk`
+2. `NDArray`
+3. `VLArray`
+4. `BatchArray`
+5. `EmbedStore`
+6. `DictStore`
+7. `TreeStore`
+8. `C2Array`
+
+V1 constraints:
+
+- every local-container section gets a short runnable example
+- `C2Array` remains offline-safe by default and does not fetch remote data
+- only a small number of diagrams are required
+- the notebook must be linked from `doc/getting_started/tutorials.rst`
+
+## Current Status
+
+- `13.containers.ipynb` now has runnable v1 content for the local containers
+- `overview.svg` is now present under `doc/getting_started/tutorials/images/containers/`
+- `doc/getting_started/tutorials.rst` now indexes tutorials `12`, `13`, and `14`
+- the notebook keeps `C2Array` offline-safe by default
+
+## Implementation Plan
+
+### Phase 1: Make The Tutorial Landable
+
+- add `plans/containers-tutorial.md` as the live plan and progress record
+- index `12.batcharray`, `13.containers`, and `14.indexing-arrays` in
+  `doc/getting_started/tutorials.rst`
+- keep the tutorial focused on current APIs only
+
+### Phase 2: Replace Placeholder Cells
+
+- add a shared setup cell for imports, temp paths, and cleanup helpers
+- replace every `TODO` code cell with a compact runnable example
+- use local temp paths so repeated notebook runs stay deterministic
+
+Planned examples:
+
+- `SChunk`: create, append chunks, inspect chunk counts and metadata
+- `NDArray`: create, persist, slice, reopen
+- `VLArray`: append variable-length values, inspect entries, reopen
+- `BatchArray`: append batches, inspect per-batch and item-level access
+- `EmbedStore`: bundle a couple of objects in one container
+- `DictStore`: store named leaves and reopen them
+- `TreeStore`: create a small hierarchy and walk a subtree
+- `C2Array`: show the URLPath/open pattern with remote access disabled by default
+
+### Phase 3: Trim The Visual Scope
+
+- keep `overview.svg` as the main family diagram
+- add one lightweight store-oriented diagram if needed
+- remove per-section placeholder figure text that would otherwise make the
+  notebook feel unfinished
+
+### Phase 4: Verify
+
+- run the notebook or equivalent code path checks locally
+- confirm that all image paths resolve
+- confirm that the tutorial appears in the rendered docs index
+
+## Benefits
+
+This tutorial is worth continuing because it fills a real gap:
+
+- current docs have single-feature tutorials, but not a family overview
+- users can see how `SChunk`, array containers, and store containers fit together
+- the comparison section helps users choose the right container earlier
+- it should reduce confusion around when to use `VLArray`, `BatchArray`,
+  `EmbedStore`, `DictStore`, or `TreeStore`
+
+## Progress Log
+
+### 2026-04-12
+
+- decided to keep a narrow v1 scope
+- decided to favor runnable examples over a large diagram set
+- decided to keep `C2Array` offline-safe by default
+- completed:
+  - added `plans/containers-tutorial.md`
+  - indexed `12.batcharray`, `13.containers`, and `14.indexing-arrays`
+  - replaced placeholder cells in `13.containers.ipynb` with runnable examples
+  - added `images/containers/overview.svg`
+  - added a reduced-scope asset README
+- verification:
+  - all notebook code cells executed successfully in a direct Python pass
+  - `jupyter nbconvert --execute` could not be used in the sandbox because the
+    Jupyter kernel could not bind local ports

--- a/plans/containters-tutorial.md
+++ b/plans/containters-tutorial.md
@@ -13,7 +13,7 @@ The tutorial will cover these main containers, in this order:
 1. `SChunk`
 2. `NDArray`
 3. `VLArray`
-4. `BatchStore`
+4. `BatchArray`
 5. `EmbedStore`
 6. `DictStore`
 7. `TreeStore`
@@ -22,8 +22,8 @@ The tutorial will cover these main containers, in this order:
 Notes:
 
 - `SChunk` comes first because it is the basis for the higher-level local containers.
-- `Batch` is not part of the main list because it is a view returned by `BatchStore`, not a top-level container.
-- `Batch` can still be mentioned briefly inside the `BatchStore` section.
+- `Batch` is not part of the main list because it is a view returned by `BatchArray`, not a top-level container.
+- `Batch` can still be mentioned briefly inside the `BatchArray` section.
 
 ## Proposed Table of Contents
 
@@ -45,7 +45,7 @@ Notes:
    Explain that it stores one serialized variable-length item per entry.
    Position it as the ragged/object-like container.
 
-6. `BatchStore`: Batched Variable-Length Data
+6. `BatchArray`: Batched Variable-Length Data
    Explain that it stores batches in compressed chunks, with optional block-local reads inside each batch.
    Position it for batch-oriented ingestion and access.
 
@@ -131,7 +131,7 @@ The figures do not need to use only these colors, but these three should define 
 Recommended first-pass figure list:
 
 1. Overview map
-   Show the relationships among `SChunk`, `NDArray`, `VLArray`, `BatchStore`, `EmbedStore`, `DictStore`, `TreeStore`, and `C2Array`.
+   Show the relationships among `SChunk`, `NDArray`, `VLArray`, `BatchArray`, `EmbedStore`, `DictStore`, `TreeStore`, and `C2Array`.
 
 2. `SChunk`
    Show a sequence of compressed chunks plus metadata.
@@ -139,10 +139,10 @@ Recommended first-pass figure list:
 3. `NDArray`
    Show array semantics on top of chunked compressed storage.
 
-4. `VLArray` vs `BatchStore`
+4. `VLArray` vs `BatchArray`
    Side-by-side comparison:
    `VLArray` as one variable-sized item per entry;
-   `BatchStore` as one chunk per batch with internal subdivision.
+   `BatchArray` as one chunk per batch with internal subdivision.
 
 5. `EmbedStore` / `DictStore` / `TreeStore`
    Show the progression from embedded bundle to key-value store to hierarchical tree.
@@ -165,7 +165,7 @@ Suggested asset location:
 - `doc/getting_started/tutorials/images/containers/overview.svg`
 - `doc/getting_started/tutorials/images/containers/schunk.svg`
 - `doc/getting_started/tutorials/images/containers/ndarray.svg`
-- `doc/getting_started/tutorials/images/containers/vlarray-batchstore.svg`
+- `doc/getting_started/tutorials/images/containers/vlarray-batcharray.svg`
 - `doc/getting_started/tutorials/images/containers/stores.svg`
 
 ## Collaboration Workflow For Images
@@ -212,7 +212,7 @@ Examples should demonstrate:
 - `SChunk`: append/get/decompress or basic chunk operations
 - `NDArray`: create, persist, slice
 - `VLArray`: append and retrieve variable-length items
-- `BatchStore`: append a batch, iterate batches or items
+- `BatchArray`: append a batch, iterate batches or items
 - `EmbedStore`: put/get a couple of nodes
 - `DictStore`: assign named entries
 - `TreeStore`: assign hierarchical paths and traverse
@@ -243,17 +243,17 @@ Purpose:
 Core message:
 
 - `SChunk` is the storage foundation.
-- `NDArray`, `VLArray`, and `BatchStore` build on top of it.
+- `NDArray`, `VLArray`, and `BatchArray` build on top of it.
 - `EmbedStore`, `DictStore`, and `TreeStore` organize multiple containers.
 - `C2Array` is the remote-facing member of the family.
 
 Suggested layout:
 
 - One central `SChunk` box.
-- Three boxes above or to the right: `NDArray`, `VLArray`, `BatchStore`.
+- Three boxes above or to the right: `NDArray`, `VLArray`, `BatchArray`.
 - Three store boxes further out: `EmbedStore`, `DictStore`, `TreeStore`.
 - One separate remote box: `C2Array`.
-- Solid arrows from `SChunk` to `NDArray`, `VLArray`, `BatchStore`.
+- Solid arrows from `SChunk` to `NDArray`, `VLArray`, `BatchArray`.
 - Solid arrow from `DictStore` to `TreeStore`.
 - Dashed arrow between stores and `C2Array` to indicate references/remote links.
 
@@ -262,7 +262,7 @@ Suggested labels inside boxes:
 - `SChunk`: “compressed chunks + metadata”
 - `NDArray`: “N-D array semantics”
 - `VLArray`: “one variable-length item per entry”
-- `BatchStore`: “one batch per chunk”
+- `BatchArray`: “one batch per chunk”
 - `EmbedStore`: “embedded nodes”
 - `DictStore`: “named collection”
 - `TreeStore`: “hierarchical collection”
@@ -357,16 +357,16 @@ Visual note:
 
 - Different block widths are important here to visually reinforce variable-length storage.
 
-### 5. `vlarray-batchstore.svg`
+### 5. `vlarray-batcharray.svg`
 
 Purpose:
 
-- Compare `VLArray` and `BatchStore` directly.
+- Compare `VLArray` and `BatchArray` directly.
 
 Core message:
 
 - `VLArray`: one item per chunk.
-- `BatchStore`: one batch per chunk, possibly subdivided internally.
+- `BatchArray`: one batch per chunk, possibly subdivided internally.
 
 Suggested layout:
 
@@ -379,7 +379,7 @@ Left panel:
 
 Right panel:
 
-- `BatchStore`
+- `BatchArray`
 - Three logical batches, each mapping to one larger orange block.
 - Inside each batch block, draw smaller subdivisions to suggest internal blocks/items.
 
@@ -408,7 +408,7 @@ Suggested layout:
 - Inside it:
   one small `NDArray` node,
   one `SChunk` node,
-  one `VLArray` or `BatchStore` node,
+  one `VLArray` or `BatchArray` node,
   one dashed-link node for `C2Array` reference.
 - A green map/index strip on one side labeled `key -> offset/length`.
 

--- a/plans/containters-tutorial.md
+++ b/plans/containters-tutorial.md
@@ -1,0 +1,517 @@
+# Containers Tutorial Plan
+
+Target notebook:
+`doc/getting_started/tutorials/13.containers.ipynb`
+
+Goal:
+Create a small but comprehensive tutorial for the main `python-blosc2` data containers, designed for reading and running as a Jupyter notebook. The style should be concept-first, visual, and practical, similar in spirit to the FFmpeg libav tutorial referenced by the user: short explanations, clear mental models, small runnable examples, and lightweight but expressive figures.
+
+## Scope
+
+The tutorial will cover these main containers, in this order:
+
+1. `SChunk`
+2. `NDArray`
+3. `VLArray`
+4. `BatchStore`
+5. `EmbedStore`
+6. `DictStore`
+7. `TreeStore`
+8. `C2Array`
+
+Notes:
+
+- `SChunk` comes first because it is the basis for the higher-level local containers.
+- `Batch` is not part of the main list because it is a view returned by `BatchStore`, not a top-level container.
+- `Batch` can still be mentioned briefly inside the `BatchStore` section.
+
+## Proposed Table of Contents
+
+1. Introduction
+   Explain what “container” means in `python-blosc2` and what the tutorial covers.
+
+2. The Big Picture
+   Present a family overview of the containers and how they relate.
+
+3. `SChunk`: The Foundation
+   Explain that it is a sequence of compressed chunks plus metadata.
+   Show why it is the storage basis for higher-level containers.
+
+4. `NDArray`: Compressed N-D Arrays
+   Explain that it builds array semantics on top of an `SChunk`.
+   Cover slicing, chunking, persistence, and typical array workflows.
+
+5. `VLArray`: Variable-Length Items
+   Explain that it stores one serialized variable-length item per entry.
+   Position it as the ragged/object-like container.
+
+6. `BatchStore`: Batched Variable-Length Data
+   Explain that it stores batches in compressed chunks, with optional block-local reads inside each batch.
+   Position it for batch-oriented ingestion and access.
+
+7. `EmbedStore`: Bundle Several Containers Into One Store
+   Explain how it embeds serialized containers/nodes into one backing store.
+   Position it for portability and packaging.
+
+8. `DictStore`: Key-Value Collection of Containers
+   Explain the directory/zip-backed keyed collection model.
+   Position it for multi-object datasets.
+
+9. `TreeStore`: Hierarchical Datasets
+   Explain it as a hierarchical extension of `DictStore`.
+   Position it for tree-structured datasets.
+
+10. `C2Array`: Remote Arrays
+    Explain it as a remote handle over Caterva2/HTTP.
+    Position it for remote array access without full local copies.
+
+11. Choosing the Right Container
+    Provide a compact comparison table across the containers.
+
+12. Final Notes
+    Summarize common usage patterns and point to deeper documentation.
+
+## Per-Section Template
+
+Each main container section should follow the same pattern:
+
+1. Short description
+2. How it is implemented
+3. What features it provides
+4. What it is useful for
+5. Small runnable code example
+6. Small figure
+
+This repetition should make the notebook predictable and easy to scan.
+
+## Content Style
+
+The notebook should aim for:
+
+- short paragraphs
+- direct language
+- minimal theory beyond what is needed to build intuition
+- small examples that run quickly
+- progressive complexity
+- visuals that reinforce the mental model rather than decorate the page
+
+The notebook should avoid:
+
+- long API reference dumps
+- too many parameters in each example
+- overly abstract prose
+- figures that try to encode too much information at once
+
+## Image Strategy
+
+Images should be simple, consistent, and expressive.
+
+Recommended visual grammar:
+
+- deep blue outline: container
+- dark yellow blocks: compressed chunks / payload pieces
+- light blue strip: metadata
+- dashed arrows: references or remote access
+- folder/zip shapes only for store-like containers
+
+Preferred palette, based on the Blosc2 logo:
+
+- dark yellow: `#df9e00`
+- light blue: `#007a86`
+- deep blue: `#002a64`
+
+Suggested mapping:
+
+- deep blue (`#002a64`) for container outlines, titles, and main structural elements
+- dark yellow (`#df9e00`) for chunk payload blocks and highlighted storage pieces
+- light blue (`#007a86`) for metadata bands, secondary structure, and remote/reference accents
+
+The figures do not need to use only these colors, but these three should define the visual identity of the container diagrams.
+
+Recommended first-pass figure list:
+
+1. Overview map
+   Show the relationships among `SChunk`, `NDArray`, `VLArray`, `BatchStore`, `EmbedStore`, `DictStore`, `TreeStore`, and `C2Array`.
+
+2. `SChunk`
+   Show a sequence of compressed chunks plus metadata.
+
+3. `NDArray`
+   Show array semantics on top of chunked compressed storage.
+
+4. `VLArray` vs `BatchStore`
+   Side-by-side comparison:
+   `VLArray` as one variable-sized item per entry;
+   `BatchStore` as one chunk per batch with internal subdivision.
+
+5. `EmbedStore` / `DictStore` / `TreeStore`
+   Show the progression from embedded bundle to key-value store to hierarchical tree.
+
+This should be enough to make the notebook visual without overproducing assets.
+
+## Asset Format
+
+Preferred format: SVG
+
+Reasons:
+
+- crisp rendering in notebooks
+- easy to version-control
+- easy to tweak
+- lightweight and portable
+
+Suggested asset location:
+
+- `doc/getting_started/tutorials/images/containers/overview.svg`
+- `doc/getting_started/tutorials/images/containers/schunk.svg`
+- `doc/getting_started/tutorials/images/containers/ndarray.svg`
+- `doc/getting_started/tutorials/images/containers/vlarray-batchstore.svg`
+- `doc/getting_started/tutorials/images/containers/stores.svg`
+
+## Collaboration Workflow For Images
+
+Proposed workflow:
+
+1. Draft a one-line image spec for each figure.
+2. Review the metaphor and emphasis with the user.
+3. Produce a simple SVG draft.
+4. Review for clarity first, polish second.
+5. Revise if the figure is visually clean but conceptually ambiguous.
+
+The goal is not artistic polish. The goal is instant comprehension.
+
+## Suggested Notebook Flow
+
+The notebook itself should likely be built from cells in this order:
+
+1. Title and short intro
+2. Overview diagram
+3. One short “family map” section
+4. One section per container
+5. Comparison table
+6. Closing notes
+
+For each container section:
+
+- markdown cell with description and use cases
+- markdown cell or callout with implementation notes
+- code cell with tiny example
+- markdown cell with figure
+
+## Small Example Guidelines
+
+Examples should be:
+
+- short enough to fit in one notebook cell
+- independent where possible
+- fast to run
+- focused on one idea
+
+Examples should demonstrate:
+
+- `SChunk`: append/get/decompress or basic chunk operations
+- `NDArray`: create, persist, slice
+- `VLArray`: append and retrieve variable-length items
+- `BatchStore`: append a batch, iterate batches or items
+- `EmbedStore`: put/get a couple of nodes
+- `DictStore`: assign named entries
+- `TreeStore`: assign hierarchical paths and traverse
+- `C2Array`: open remote metadata and retrieve a small slice
+
+For `C2Array`, the example may need extra care because it depends on remote access; if needed, keep it lightweight and make clear that it requires network access.
+
+## Open Decisions For Next Iteration
+
+These should be settled next:
+
+1. Exact section titles and tone of the notebook.
+2. The first-pass image specs, one by one.
+3. Whether all code examples should be executable offline except `C2Array`.
+4. Whether to include one summary table near the top, near the end, or both.
+5. Whether to add one “common patterns” section showing how containers compose.
+
+## First-Pass SVG Image Specs
+
+These specs are meant to be simple enough to implement quickly, but concrete enough that the figures will already be useful in a first draft.
+
+### 1. `overview.svg`
+
+Purpose:
+
+- Give the reader a fast mental map of the container family.
+
+Core message:
+
+- `SChunk` is the storage foundation.
+- `NDArray`, `VLArray`, and `BatchStore` build on top of it.
+- `EmbedStore`, `DictStore`, and `TreeStore` organize multiple containers.
+- `C2Array` is the remote-facing member of the family.
+
+Suggested layout:
+
+- One central `SChunk` box.
+- Three boxes above or to the right: `NDArray`, `VLArray`, `BatchStore`.
+- Three store boxes further out: `EmbedStore`, `DictStore`, `TreeStore`.
+- One separate remote box: `C2Array`.
+- Solid arrows from `SChunk` to `NDArray`, `VLArray`, `BatchStore`.
+- Solid arrow from `DictStore` to `TreeStore`.
+- Dashed arrow between stores and `C2Array` to indicate references/remote links.
+
+Suggested labels inside boxes:
+
+- `SChunk`: “compressed chunks + metadata”
+- `NDArray`: “N-D array semantics”
+- `VLArray`: “one variable-length item per entry”
+- `BatchStore`: “one batch per chunk”
+- `EmbedStore`: “embedded nodes”
+- `DictStore`: “named collection”
+- `TreeStore`: “hierarchical collection”
+- `C2Array`: “remote array handle”
+
+Visual note:
+
+- This should be the least detailed figure, optimized for orientation.
+
+### 2. `schunk.svg`
+
+Purpose:
+
+- Show what an `SChunk` physically/conceptually looks like.
+
+Core message:
+
+- `SChunk` is a sequence of compressed chunks plus metadata.
+
+Suggested layout:
+
+- One large horizontal container box labeled `SChunk`.
+- Green strip at the top or left labeled `meta / vlmeta`.
+- Several orange rectangular blocks inside labeled `chunk 0`, `chunk 1`, `chunk 2`, `...`.
+- Optional small caption under the box: “persistent or in-memory”.
+
+Suggested callouts:
+
+- “append/update/delete chunks”
+- “compressed payload”
+- “basis for higher-level containers”
+
+Visual note:
+
+- This should be the simplest figure of the set.
+
+### 3. `ndarray.svg`
+
+Purpose:
+
+- Show that `NDArray` is an array interface over chunked compressed storage.
+
+Core message:
+
+- `NDArray` provides shape/dtype/slicing semantics on top of an `SChunk`.
+
+Suggested layout:
+
+- Top layer: a blue `NDArray` box with small labels:
+  `shape`, `dtype`, `chunks`, `blocks`
+- Under it: a simplified grid or 1D strip labeled “logical array view”.
+- Under that: an `SChunk` box with orange chunk blocks.
+- Arrow from `NDArray` to `SChunk`.
+
+Suggested callouts:
+
+- “array semantics”
+- “slicing”
+- “persistent `.b2nd` or in-memory”
+
+Visual note:
+
+- Show the distinction between logical array view and physical chunk storage.
+
+### 4. `vlarray.svg`
+
+Purpose:
+
+- Show how `VLArray` differs from `NDArray` and why it fits variable-length values.
+
+Core message:
+
+- One logical entry maps to one independently compressed serialized payload.
+
+Suggested layout:
+
+- Left side: a vertical list labeled `VLArray` with entries like:
+  `{"a": 1}`
+  `"hello"`
+  `[1, 2, 3, 4]`
+  `b"..."`
+- Right side: an `SChunk` with orange blocks of visibly different lengths.
+- Arrows from each logical entry to one chunk block.
+
+Suggested callouts:
+
+- “serialize”
+- “compress”
+- “independent entries”
+
+Visual note:
+
+- Different block widths are important here to visually reinforce variable-length storage.
+
+### 5. `vlarray-batchstore.svg`
+
+Purpose:
+
+- Compare `VLArray` and `BatchStore` directly.
+
+Core message:
+
+- `VLArray`: one item per chunk.
+- `BatchStore`: one batch per chunk, possibly subdivided internally.
+
+Suggested layout:
+
+- Two panels side by side.
+
+Left panel:
+
+- `VLArray`
+- Three logical entries, each mapping to one orange block.
+
+Right panel:
+
+- `BatchStore`
+- Three logical batches, each mapping to one larger orange block.
+- Inside each batch block, draw smaller subdivisions to suggest internal blocks/items.
+
+Suggested callouts:
+
+- left: “fine-grained item storage”
+- right: “batch-oriented storage”
+
+Visual note:
+
+- This should make the contrast obvious at a glance.
+
+### 6. `embedstore.svg`
+
+Purpose:
+
+- Show that `EmbedStore` bundles different nodes into one backing store.
+
+Core message:
+
+- Multiple containers are embedded into one portable store.
+
+Suggested layout:
+
+- One big blue outer box labeled `EmbedStore`.
+- Inside it:
+  one small `NDArray` node,
+  one `SChunk` node,
+  one `VLArray` or `BatchStore` node,
+  one dashed-link node for `C2Array` reference.
+- A green map/index strip on one side labeled `key -> offset/length`.
+
+Suggested callouts:
+
+- “single bundled store”
+- “embedded serialized nodes”
+- “remote references possible”
+
+Visual note:
+
+- Keep it compact; this image is about bundling, not hierarchy.
+
+### 7. `dictstore.svg`
+
+Purpose:
+
+- Show `DictStore` as a named collection with embedded and external leaves.
+
+Core message:
+
+- `DictStore` organizes multiple named objects in a directory/zip-like structure.
+
+Suggested layout:
+
+- Folder or zip-shaped outer boundary labeled `DictStore`.
+- Inside:
+  one embedded file-like box labeled `embed.b2e`,
+  a few external leaves with names like `a.b2nd`, `b.b2b`, `c.b2f`.
+- A short list of sample keys on the left:
+  `/a`, `/b`, `/c`
+
+Suggested callouts:
+
+- “named collection”
+- “embedded + external storage”
+- “`.b2d` / `.b2z`”
+
+Visual note:
+
+- This figure should emphasize storage organization rather than data layout.
+
+### 8. `stores.svg`
+
+Purpose:
+
+- Show the progression from `EmbedStore` to `DictStore` to `TreeStore`.
+
+Core message:
+
+- The stores differ mainly in how they organize multiple objects.
+
+Suggested layout:
+
+- Three panels left-to-right:
+  `EmbedStore` -> `DictStore` -> `TreeStore`
+- `EmbedStore`: simple bundle
+- `DictStore`: flat named collection
+- `TreeStore`: hierarchical `/group/subgroup/node`
+
+Suggested callouts:
+
+- `EmbedStore`: “bundle”
+- `DictStore`: “flat keys”
+- `TreeStore`: “hierarchical keys”
+
+Visual note:
+
+- This should help readers understand why both `DictStore` and `TreeStore` exist.
+
+### 9. `c2array.svg`
+
+Purpose:
+
+- Show `C2Array` as a remote array handle.
+
+Core message:
+
+- `C2Array` does not own local storage in the same way; it points to remote array data and fetches metadata/slices on demand.
+
+Suggested layout:
+
+- Left: local client box labeled `C2Array`.
+- Middle: dashed network arrow labeled `HTTP`.
+- Right: remote service/cloud box containing a remote array rectangle.
+- Optional small metadata card near the client:
+  `shape`, `dtype`, `chunks`
+
+Suggested callouts:
+
+- “remote metadata”
+- “remote slice fetch”
+- “Caterva2-backed”
+
+Visual note:
+
+- Keep this visually distinct from the local-storage figures.
+
+## Recommended Next Steps
+
+1. Finalize the exact notebook outline and section titles.
+2. Review and refine these image specs.
+3. Create the notebook skeleton with markdown headings and placeholder figure cells.
+4. Fill in the runnable examples.
+5. Add the SVG assets.
+6. Refine the narrative and transitions between sections.

--- a/src/blosc2/__init__.py
+++ b/src/blosc2/__init__.py
@@ -559,7 +559,7 @@ from .ndarray import (
 from .embed_store import EmbedStore, estore_from_cframe
 from .dict_store import DictStore
 from .tree_store import TreeStore
-from .batch_store import Batch, BatchStore
+from .batch_array import Batch, BatchArray
 from .vlarray import VLArray, vlarray_from_cframe
 from .ref import Ref
 from .b2objects import open_b2object
@@ -748,7 +748,7 @@ __all__ = [  # noqa : RUF022
     "C2Array",
     "CParams",
     "Batch",
-    "BatchStore",
+    "BatchArray",
     # Enums
     "Codec",
     "DParams",

--- a/src/blosc2/batch_array.py
+++ b/src/blosc2/batch_array.py
@@ -21,9 +21,9 @@ import blosc2
 from blosc2.info import InfoReporter, format_nbytes_info
 from blosc2.msgpack_utils import msgpack_packb, msgpack_unpackb
 
-_BATCHSTORE_META = {"version": 1, "serializer": "msgpack", "items_per_block": None, "arrow_schema": None}
+_BATCHARRAY_META = {"version": 1, "serializer": "msgpack", "items_per_block": None, "arrow_schema": None}
 _SUPPORTED_SERIALIZERS = {"msgpack", "arrow"}
-_BATCHSTORE_VLMETA_KEY = "_batch_store_metadata"
+_BATCHARRAY_VLMETA_KEY = "_batch_array_metadata"
 
 
 def _check_serialized_size(buffer: bytes) -> None:
@@ -32,17 +32,17 @@ def _check_serialized_size(buffer: bytes) -> None:
 
 
 class Batch(Sequence[Any]):
-    """A lazy sequence representing one batch in a :class:`BatchStore`.
+    """A lazy sequence representing one batch in a :class:`BatchArray`.
 
     ``Batch`` provides sequence-style access to the items stored in a single
     batch. Integer indexing can use block-local reads when possible, while
     slicing materializes the full batch into Python items.
 
-    Batch instances are normally obtained via :class:`BatchStore` indexing or
+    Batch instances are normally obtained via :class:`BatchArray` indexing or
     iteration rather than constructed directly.
     """
 
-    def __init__(self, parent: BatchStore, nbatch: int, lazybatch: bytes) -> None:
+    def __init__(self, parent: BatchArray, nbatch: int, lazybatch: bytes) -> None:
         self._parent = parent
         self._nbatch = nbatch
         self._lazybatch = lazybatch
@@ -126,10 +126,10 @@ class Batch(Sequence[Any]):
         return f"Batch(len={len(self)}, nbytes={self.nbytes}, cbytes={self.cbytes})"
 
 
-class BatchStoreItems(Sequence[Any]):
-    """A read-only flat view over the items stored in a :class:`BatchStore`."""
+class BatchArrayItems(Sequence[Any]):
+    """A read-only flat view over the items stored in a :class:`BatchArray`."""
 
-    def __init__(self, parent: BatchStore) -> None:
+    def __init__(self, parent: BatchArray) -> None:
         self._parent = parent
 
     def __getitem__(self, index: int | slice) -> Any | list[Any]:
@@ -139,10 +139,10 @@ class BatchStoreItems(Sequence[Any]):
         return self._parent._get_total_item_count()
 
 
-class BatchStore:
+class BatchArray:
     """A batched container for variable-length Python items.
 
-    BatchStore stores data as a sequence of *batches*, where each batch contains
+    BatchArray stores data as a sequence of *batches*, where each batch contains
     one or more Python items. Each batch is stored in one compressed chunk, and
     each chunk is internally split into one or more variable-length blocks for
     efficient item access.
@@ -153,7 +153,7 @@ class BatchStore:
     - iterating the store yields batches
     - :meth:`iter_items` provides flat item-wise traversal
 
-    BatchStore is a good fit when:
+    BatchArray is a good fit when:
 
     - data arrives naturally in batches
     - batch-level append/update operations are important
@@ -169,7 +169,7 @@ class BatchStore:
         Serializer used for batch payloads. ``"msgpack"`` is the default and is
         the general-purpose choice for Python items, including nested Blosc2
         containers such as :class:`blosc2.NDArray`, :class:`blosc2.SChunk`,
-        :class:`blosc2.VLArray`, :class:`blosc2.BatchStore`, and
+        :class:`blosc2.VLArray`, :class:`blosc2.BatchArray`, and
         :class:`blosc2.EmbedStore`, which are serialized transparently via
         :meth:`to_cframe` / :func:`blosc2.from_cframe`. Msgpack also supports
         structured Blosc2 reference objects, currently
@@ -182,7 +182,7 @@ class BatchStore:
         are not serialized by msgpack. ``"arrow"`` is optional and requires
         ``pyarrow``.
     _from_schunk : blosc2.SChunk, optional
-        Internal hook used when reopening an already-tagged BatchStore.
+        Internal hook used when reopening an already-tagged BatchArray.
     **kwargs
         Storage, compression, and decompression arguments accepted by the
         constructor.
@@ -225,24 +225,24 @@ class BatchStore:
     @staticmethod
     def _validate_storage(storage: blosc2.Storage) -> None:
         if storage.mmap_mode not in (None, "r"):
-            raise ValueError("For BatchStore containers, mmap_mode must be None or 'r'")
+            raise ValueError("For BatchArray containers, mmap_mode must be None or 'r'")
         if storage.mmap_mode == "r" and storage.mode != "r":
-            raise ValueError("For BatchStore containers, mmap_mode='r' requires mode='r'")
+            raise ValueError("For BatchArray containers, mmap_mode='r' requires mode='r'")
 
     def _attach_schunk(self, schunk: blosc2.SChunk) -> None:
         self.schunk = schunk
         self.mode = schunk.mode
         self.mmap_mode = getattr(schunk, "mmap_mode", None)
         try:
-            batchstore_meta = self.schunk.meta["batchstore"]
+            batcharray_meta = self.schunk.meta["batcharray"]
         except KeyError:
-            batchstore_meta = {}
-        self._serializer = batchstore_meta.get("serializer", self._serializer)
-        self._items_per_block = batchstore_meta.get("items_per_block", self._items_per_block)
-        self._arrow_schema = batchstore_meta.get("arrow_schema", self._arrow_schema)
+            batcharray_meta = {}
+        self._serializer = batcharray_meta.get("serializer", self._serializer)
+        self._items_per_block = batcharray_meta.get("items_per_block", self._items_per_block)
+        self._arrow_schema = batcharray_meta.get("arrow_schema", self._arrow_schema)
         self._arrow_schema_obj = None
         self._batch_lengths = self._load_batch_lengths()
-        self._items = BatchStoreItems(self)
+        self._items = BatchArrayItems(self)
         self._item_prefix_sums: np.ndarray | None = None
         self._validate_tag()
 
@@ -272,16 +272,16 @@ class BatchStore:
         _from_schunk: blosc2.SChunk | None = None,
         **kwargs: Any,
     ) -> None:
-        """Create a new BatchStore or reopen an existing one.
+        """Create a new BatchArray or reopen an existing one.
 
-        When a persistent ``urlpath`` points to an existing BatchStore and the
+        When a persistent ``urlpath`` points to an existing BatchArray and the
         mode is ``"r"`` or ``"a"``, the container is reopened automatically.
         Otherwise a new empty store is created.
         """
         if items_per_block is not None and items_per_block <= 0:
             raise ValueError("items_per_block must be a positive integer")
         if serializer not in _SUPPORTED_SERIALIZERS:
-            raise ValueError(f"Unsupported BatchStore serializer: {serializer!r}")
+            raise ValueError(f"Unsupported BatchArray serializer: {serializer!r}")
         self._items_per_block: int | None = items_per_block
         self._serializer = serializer
         self._arrow_schema: bytes | None = None
@@ -300,7 +300,7 @@ class BatchStore:
 
         if kwargs:
             unexpected = ", ".join(sorted(kwargs))
-            raise ValueError(f"Unsupported BatchStore keyword argument(s): {unexpected}")
+            raise ValueError(f"Unsupported BatchArray keyword argument(s): {unexpected}")
 
         self._validate_storage(storage)
         cparams = self._set_typesize_one(cparams)
@@ -312,8 +312,8 @@ class BatchStore:
             return
 
         fixed_meta = dict(storage.meta or {})
-        fixed_meta["batchstore"] = {
-            **_BATCHSTORE_META,
+        fixed_meta["batcharray"] = {
+            **_BATCHARRAY_META,
             "serializer": self._serializer,
             "items_per_block": self._items_per_block,
             "arrow_schema": self._arrow_schema,
@@ -323,10 +323,10 @@ class BatchStore:
         self._attach_schunk(schunk)
 
     def _validate_tag(self) -> None:
-        if "batchstore" not in self.schunk.meta:
-            raise ValueError("The supplied SChunk is not tagged as a BatchStore")
+        if "batcharray" not in self.schunk.meta:
+            raise ValueError("The supplied SChunk is not tagged as a BatchArray")
         if self._serializer not in _SUPPORTED_SERIALIZERS:
-            raise ValueError(f"Unsupported BatchStore serializer in metadata: {self._serializer!r}")
+            raise ValueError(f"Unsupported BatchArray serializer in metadata: {self._serializer!r}")
         if self._serializer == "arrow":
             self._require_pyarrow()
 
@@ -337,25 +337,25 @@ class BatchStore:
             import pyarrow as pa
             import pyarrow.ipc as pa_ipc
         except ImportError as exc:
-            raise ImportError("BatchStore serializer='arrow' requires pyarrow") from exc
+            raise ImportError("BatchArray serializer='arrow' requires pyarrow") from exc
         return pa, pa_ipc
 
     def _check_writable(self) -> None:
         if self.mode == "r":
-            raise ValueError("Cannot modify a BatchStore opened in read-only mode")
+            raise ValueError("Cannot modify a BatchArray opened in read-only mode")
 
     def _normalize_index(self, index: int) -> int:
         if not isinstance(index, int):
-            raise TypeError("BatchStore indices must be integers")
+            raise TypeError("BatchArray indices must be integers")
         if index < 0:
             index += len(self)
         if index < 0 or index >= len(self):
-            raise IndexError("BatchStore index out of range")
+            raise IndexError("BatchArray index out of range")
         return index
 
     def _normalize_insert_index(self, index: int) -> int:
         if not isinstance(index, int):
-            raise TypeError("BatchStore indices must be integers")
+            raise TypeError("BatchArray indices must be integers")
         if index < 0:
             index += len(self)
             if index < 0:
@@ -372,7 +372,7 @@ class BatchStore:
 
     def _load_batch_lengths(self) -> list[int] | None:
         try:
-            metadata = self.schunk.vlmeta[_BATCHSTORE_VLMETA_KEY]
+            metadata = self.schunk.vlmeta[_BATCHARRAY_VLMETA_KEY]
         except KeyError:
             return None
         batch_lengths = metadata.get("batch_lengths")
@@ -384,10 +384,10 @@ class BatchStore:
         if self._batch_lengths is None:
             return
         if len(self._batch_lengths) == 0:
-            if _BATCHSTORE_VLMETA_KEY in self.vlmeta:
-                del self.vlmeta[_BATCHSTORE_VLMETA_KEY]
+            if _BATCHARRAY_VLMETA_KEY in self.vlmeta:
+                del self.vlmeta[_BATCHARRAY_VLMETA_KEY]
             return
-        self.schunk.vlmeta[_BATCHSTORE_VLMETA_KEY] = {"batch_lengths": list(self._batch_lengths)}
+        self.schunk.vlmeta[_BATCHARRAY_VLMETA_KEY] = {"batch_lengths": list(self._batch_lengths)}
 
     def _get_batch_lengths(self) -> list[int] | None:
         return self._batch_lengths
@@ -428,12 +428,12 @@ class BatchStore:
         if isinstance(index, slice):
             return [self._get_flat_item(i) for i in range(*index.indices(self._get_total_item_count()))]
         if not isinstance(index, int):
-            raise TypeError("BatchStore item indices must be integers")
+            raise TypeError("BatchArray item indices must be integers")
         nitems = self._get_total_item_count()
         if index < 0:
             index += nitems
         if index < 0 or index >= nitems:
-            raise IndexError("BatchStore item index out of range")
+            raise IndexError("BatchArray item index out of range")
 
         prefix_sums = self._get_item_prefix_sums()
         batch_index = int(np.searchsorted(prefix_sums, index, side="right") - 1)
@@ -475,16 +475,16 @@ class BatchStore:
         return total
 
     def _user_vlmeta_items(self) -> dict[str, Any]:
-        return {key: value for key, value in self.vlmeta.getall().items() if key != _BATCHSTORE_VLMETA_KEY}
+        return {key: value for key, value in self.vlmeta.getall().items() if key != _BATCHARRAY_VLMETA_KEY}
 
     def _normalize_msgpack_batch(self, value: object) -> list[Any]:
         if isinstance(value, (str, bytes, bytearray, memoryview)):
-            raise TypeError("BatchStore entries must be sequences of Python objects")
+            raise TypeError("BatchArray entries must be sequences of Python objects")
         if not isinstance(value, Sequence):
-            raise TypeError("BatchStore entries must be sequences of Python objects")
+            raise TypeError("BatchArray entries must be sequences of Python objects")
         values = list(value)
         if len(values) == 0:
-            raise ValueError("BatchStore entries cannot be empty")
+            raise ValueError("BatchArray entries cannot be empty")
         return values
 
     def _normalize_arrow_batch(self, value: object):
@@ -493,16 +493,16 @@ class BatchStore:
             value = value.combine_chunks()
         elif isinstance(value, pa.RecordBatch):
             if value.num_columns != 1:
-                raise TypeError("Arrow RecordBatch inputs for BatchStore must have exactly one column")
+                raise TypeError("Arrow RecordBatch inputs for BatchArray must have exactly one column")
             value = value.column(0)
         elif not isinstance(value, pa.Array):
             if isinstance(value, (str, bytes, bytearray, memoryview)):
-                raise TypeError("BatchStore entries must be Arrow arrays or sequences of Python objects")
+                raise TypeError("BatchArray entries must be Arrow arrays or sequences of Python objects")
             if not isinstance(value, Sequence):
-                raise TypeError("BatchStore entries must be Arrow arrays or sequences of Python objects")
+                raise TypeError("BatchArray entries must be Arrow arrays or sequences of Python objects")
             value = pa.array(list(value))
         if len(value) == 0:
-            raise ValueError("BatchStore entries cannot be empty")
+            raise ValueError("BatchArray entries cannot be empty")
         self._ensure_arrow_schema(value)
         return value
 
@@ -517,7 +517,7 @@ class BatchStore:
             return
         existing_schema = self._get_arrow_schema()
         if not existing_schema.equals(schema):
-            raise TypeError("All Arrow batches in a BatchStore must share the same schema")
+            raise TypeError("All Arrow batches in a BatchArray must share the same schema")
 
     def _get_arrow_schema(self):
         if self._serializer != "arrow":
@@ -562,8 +562,8 @@ class BatchStore:
         user_vlmeta = self._user_vlmeta_items() if len(self.vlmeta) > 0 else {}
         storage = self._make_storage()
         fixed_meta = dict(storage.meta or {})
-        fixed_meta["batchstore"] = {
-            **dict(fixed_meta.get("batchstore", {})),
+        fixed_meta["batcharray"] = {
+            **dict(fixed_meta.get("batcharray", {})),
             "items_per_block": self._items_per_block,
             "serializer": self._serializer,
             "arrow_schema": self._arrow_schema,
@@ -584,7 +584,7 @@ class BatchStore:
 
     def _guess_blocksize(self, payload_sizes: list[int]) -> int:
         if not payload_sizes:
-            raise ValueError("BatchStore entries cannot be empty")
+            raise ValueError("BatchArray entries cannot be empty")
         clevel = self.cparams.clevel
         if clevel == 9:
             return len(payload_sizes)
@@ -650,7 +650,7 @@ class BatchStore:
 
     def _compress_batch(self, batch: Any) -> bytes:
         if self._items_per_block is None:
-            raise RuntimeError("BatchStore items_per_block is not initialized")
+            raise RuntimeError("BatchArray items_per_block is not initialized")
         blocks = [
             self._serialize_block(batch[i : i + self._items_per_block])
             for i in range(0, self._batch_len(batch), self._items_per_block)
@@ -714,7 +714,7 @@ class BatchStore:
         """Remove and return the batch at ``index`` as a Python list."""
         self._check_writable()
         if isinstance(index, slice):
-            raise NotImplementedError("Slicing is not supported for BatchStore")
+            raise NotImplementedError("Slicing is not supported for BatchArray")
         index = self._normalize_index(index)
         value = self[index][:]
         self.delete(index)
@@ -840,7 +840,7 @@ class BatchStore:
         return self._items_per_block
 
     @property
-    def items(self) -> BatchStoreItems:
+    def items(self) -> BatchArrayItems:
         return self._items
 
     @property
@@ -910,7 +910,7 @@ class BatchStore:
         """Serialize the full store to a Blosc2 cframe buffer."""
         return self.schunk.to_cframe()
 
-    def copy(self, **kwargs: Any) -> BatchStore:
+    def copy(self, **kwargs: Any) -> BatchArray:
         """Create a copy of the store with optional constructor overrides."""
         if "meta" in kwargs:
             raise ValueError("meta should not be passed to copy")
@@ -933,20 +933,20 @@ class BatchStore:
             if "urlpath" in kwargs and "mode" not in kwargs:
                 kwargs["mode"] = "w"
 
-        out = BatchStore(**kwargs)
+        out = BatchArray(**kwargs)
         for key, value in user_vlmeta.items():
             out.vlmeta[key] = value
         out.extend(self)
         return out
 
-    def __enter__(self) -> BatchStore:
+    def __enter__(self) -> BatchArray:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
         return False
 
     def __repr__(self) -> str:
-        return f"BatchStore(len={len(self)}, urlpath={self.urlpath!r})"
+        return f"BatchArray(len={len(self)}, urlpath={self.urlpath!r})"
 
     @property
     def serializer(self) -> str:

--- a/src/blosc2/core.py
+++ b/src/blosc2/core.py
@@ -1922,10 +1922,10 @@ def ndarray_from_cframe(cframe: bytes | str, copy: bool = False) -> blosc2.NDArr
 def from_cframe(
     cframe: bytes | str, copy: bool = True
 ) -> (
-    blosc2.EmbedStore | blosc2.NDArray | blosc2.SChunk | blosc2.BatchStore | blosc2.VLArray | blosc2.C2Array
+    blosc2.EmbedStore | blosc2.NDArray | blosc2.SChunk | blosc2.BatchArray | blosc2.VLArray | blosc2.C2Array
 ):
     """Create a :ref:`EmbedStore <EmbedStore>`, :ref:`NDArray <NDArray>`, :ref:`SChunk <SChunk>`,
-    :ref:`BatchStore <BatchStore>` or :ref:`VLArray <VLArray>` instance
+    :ref:`BatchArray <BatchArray>` or :ref:`VLArray <VLArray>` instance
     from a contiguous frame buffer.
 
     Parameters
@@ -1943,7 +1943,7 @@ def from_cframe(
     Returns
     -------
     out: :ref:`EmbedStore <EmbedStore>`, :ref:`NDArray <NDArray>`, :ref:`SChunk <SChunk>`,
-         :ref:`BatchStore <BatchStore>` or :ref:`VLArray <VLArray>`
+         :ref:`BatchArray <BatchArray>` or :ref:`VLArray <VLArray>`
         A new instance of the appropriate type containing the data passed.
 
     See Also
@@ -1957,8 +1957,8 @@ def from_cframe(
     # Check the metalayer to determine the type
     if "b2embed" in schunk.meta:
         return blosc2.estore_from_cframe(cframe, copy=copy)
-    if "batchstore" in schunk.meta:
-        return blosc2.BatchStore(_from_schunk=schunk_from_cframe(cframe, copy=copy))
+    if "batcharray" in schunk.meta:
+        return blosc2.BatchArray(_from_schunk=schunk_from_cframe(cframe, copy=copy))
     if "vlarray" in schunk.meta:
         return blosc2.vlarray_from_cframe(cframe, copy=copy)
     if "b2o" in schunk.meta:

--- a/src/blosc2/dict_store.py
+++ b/src/blosc2/dict_store.py
@@ -37,7 +37,7 @@ class DictStore:
       are stored as .b2nd files.
     - blosc2.SChunk: super-chunks. When persisted externally they are stored
       as .b2f files.
-    - blosc2.BatchStore: batched variable-length containers. When persisted
+    - blosc2.BatchArray: batched variable-length containers. When persisted
       externally they are stored as .b2b files.
     - blosc2.C2Array: columnar containers. These are always kept inside the
       embedded store (never externalized).
@@ -94,7 +94,7 @@ class DictStore:
     Notes
     -----
     - External persistence uses the following file extensions:
-      .b2nd for NDArray, .b2f for SChunk, and .b2b for BatchStore.
+      .b2nd for NDArray, .b2f for SChunk, and .b2b for BatchArray.
       These suffixes are a naming convention for newly written leaves; when
       reopening an existing store, leaf typing is resolved from object
       metadata instead of trusting the suffix alone.
@@ -216,14 +216,14 @@ class DictStore:
         """Return the canonical write-time suffix for a supported external leaf kind."""
         if kind == "ndarray":
             return ".b2nd"
-        if kind == "batchstore":
+        if kind == "batcharray":
             return ".b2b"
         return ".b2f"
 
     @classmethod
     def _opened_external_kind(
         cls,
-        opened: blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore | C2Array | Any,
+        opened: blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray | C2Array | Any,
         rel_path: str,
     ) -> str | None:
         """Return the supported external leaf kind for an already opened object."""
@@ -237,8 +237,8 @@ class DictStore:
         else:
             processed = process_opened_object(opened)
             processed_name = type(processed).__name__
-            if isinstance(processed, blosc2.BatchStore):
-                kind = "batchstore"
+            if isinstance(processed, blosc2.BatchArray):
+                kind = "batcharray"
             elif isinstance(processed, blosc2.VLArray):
                 kind = "vlarray"
             elif isinstance(processed, blosc2.NDArray):
@@ -341,7 +341,7 @@ class DictStore:
     def _annotate_external_value(
         self,
         key: str,
-        value: blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore | C2Array,
+        value: blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray | C2Array,
     ):
         """Attach DictStore origin metadata so structured msgpack can preserve member identity."""
         value._blosc2_ref = blosc2.Ref.dictstore_key(self.localpath, key)
@@ -353,27 +353,27 @@ class DictStore:
         return self._estore
 
     @staticmethod
-    def _value_nbytes(value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchStore) -> int:
-        if isinstance(value, blosc2.VLArray | blosc2.BatchStore):
+    def _value_nbytes(value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchArray) -> int:
+        if isinstance(value, blosc2.VLArray | blosc2.BatchArray):
             return value.schunk.nbytes
         return value.nbytes
 
     @staticmethod
-    def _is_external_value(value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchStore) -> bool:
-        return isinstance(value, blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore) and bool(
+    def _is_external_value(value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchArray) -> bool:
+        return isinstance(value, blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray) and bool(
             getattr(value, "urlpath", None)
         )
 
     @staticmethod
-    def _external_ext(value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchStore) -> str:
+    def _external_ext(value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchArray) -> str:
         if isinstance(value, blosc2.NDArray):
             return ".b2nd"
-        if isinstance(value, blosc2.BatchStore):
+        if isinstance(value, blosc2.BatchArray):
             return ".b2b"
         return ".b2f"
 
     def __setitem__(
-        self, key: str, value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchStore
+        self, key: str, value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchArray
     ) -> None:
         """Add a node to the DictStore."""
         if isinstance(value, np.ndarray):
@@ -413,7 +413,7 @@ class DictStore:
                 elif hasattr(value, "save"):
                     value.save(urlpath=dest_path)
                 else:
-                    # SChunk, VLArray and BatchStore can all be persisted via their cframe.
+                    # SChunk, VLArray and BatchArray can all be persisted via their cframe.
                     with open(dest_path, "wb") as f:
                         f.write(value.to_cframe())
             else:
@@ -433,7 +433,7 @@ class DictStore:
 
     def __getitem__(
         self, key: str
-    ) -> blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore | C2Array:
+    ) -> blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray | C2Array:
         """Retrieve a node from the DictStore."""
         # Check map_tree first
         if key in self.map_tree:
@@ -468,7 +468,7 @@ class DictStore:
 
     def get(
         self, key: str, default: Any = None
-    ) -> blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore | C2Array | Any:
+    ) -> blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray | C2Array | Any:
         """Retrieve a node, or default if not found."""
         try:
             return self[key]

--- a/src/blosc2/embed_store.py
+++ b/src/blosc2/embed_store.py
@@ -174,7 +174,7 @@ class EmbedStore:
             self._store.resize((new_size,))
 
     def __setitem__(
-        self, key: str, value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchStore
+        self, key: str, value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchArray
     ) -> None:
         """Add a node to the embed store."""
         if self.mode == "r":
@@ -198,7 +198,7 @@ class EmbedStore:
             self._embed_map[key] = {"offset": offset, "length": data_len}
         self._save_metadata()
 
-    def __getitem__(self, key: str) -> blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore:
+    def __getitem__(self, key: str) -> blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray:
         """Retrieve a node from the embed store."""
         if key not in self._embed_map:
             raise KeyError(f"Key '{key}' not found in the embed store.")
@@ -216,7 +216,7 @@ class EmbedStore:
 
     def get(
         self, key: str, default: Any = None
-    ) -> blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore | Any:
+    ) -> blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray | Any:
         """Retrieve a node, or default if not found."""
         return self[key] if key in self._embed_map else default
 
@@ -243,12 +243,12 @@ class EmbedStore:
         """Return all keys."""
         return self._embed_map.keys()
 
-    def values(self) -> Iterator[blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore]:
+    def values(self) -> Iterator[blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray]:
         """Iterate over all values."""
         for key in self._embed_map:
             yield self[key]
 
-    def items(self) -> Iterator[tuple[str, blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchStore]]:
+    def items(self) -> Iterator[tuple[str, blosc2.NDArray | SChunk | blosc2.VLArray | blosc2.BatchArray]]:
         """Iterate over (key, value) pairs."""
         for key in self._embed_map:
             yield key, self[key]

--- a/src/blosc2/msgpack_utils.py
+++ b/src/blosc2/msgpack_utils.py
@@ -59,7 +59,7 @@ def _encode_msgpack_ext(obj):
     import blosc2
 
     if isinstance(
-        obj, blosc2.NDArray | blosc2.SChunk | blosc2.VLArray | blosc2.BatchStore | blosc2.EmbedStore
+        obj, blosc2.NDArray | blosc2.SChunk | blosc2.VLArray | blosc2.BatchArray | blosc2.EmbedStore
     ):
         return ExtType(_BLOSC2_EXT_CODE, obj.to_cframe())
     structured = _encode_structured_reference(obj)

--- a/src/blosc2/schunk.py
+++ b/src/blosc2/schunk.py
@@ -34,7 +34,7 @@ class vlmeta(MutableMapping, blosc2_ext.vlmeta):
 
     - CFrame-backed Blosc2 objects such as :class:`blosc2.NDArray`,
       :class:`blosc2.SChunk`, :class:`blosc2.VLArray`,
-      :class:`blosc2.BatchStore`, and :class:`blosc2.EmbedStore`
+      :class:`blosc2.BatchArray`, and :class:`blosc2.EmbedStore`
     - structured references and lazy objects such as :class:`blosc2.Ref`,
       :class:`blosc2.C2Array`, :class:`blosc2.LazyExpr`, and
       :class:`blosc2.LazyUDF` backed by :func:`blosc2.dsl_kernel`
@@ -1642,10 +1642,10 @@ def process_opened_object(res):
 
         return VLArray(_from_schunk=getattr(res, "schunk", res))
 
-    if "batchstore" in meta:
-        from blosc2.batch_store import BatchStore
+    if "batcharray" in meta:
+        from blosc2.batch_array import BatchArray
 
-        return BatchStore(_from_schunk=getattr(res, "schunk", res))
+        return BatchArray(_from_schunk=getattr(res, "schunk", res))
 
     if isinstance(res, blosc2.NDArray) and "LazyArray" in res.schunk.meta:
         return blosc2.open_lazyarray(res)
@@ -1658,7 +1658,7 @@ def open(
 ) -> (
     blosc2.SChunk
     | blosc2.NDArray
-    | blosc2.BatchStore
+    | blosc2.BatchArray
     | blosc2.VLArray
     | blosc2.C2Array
     | blosc2.LazyArray

--- a/src/blosc2/tree_store.py
+++ b/src/blosc2/tree_store.py
@@ -227,7 +227,7 @@ class TreeStore(DictStore):
         return key
 
     def __setitem__(
-        self, key: str, value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchStore
+        self, key: str, value: blosc2.Array | SChunk | blosc2.VLArray | blosc2.BatchArray
     ) -> None:
         """Add a node with hierarchical key validation.
 
@@ -272,7 +272,7 @@ class TreeStore(DictStore):
 
     def __getitem__(
         self, key: str
-    ) -> NDArray | C2Array | SChunk | blosc2.VLArray | blosc2.BatchStore | TreeStore:
+    ) -> NDArray | C2Array | SChunk | blosc2.VLArray | blosc2.BatchArray | TreeStore:
         """Retrieve a node or subtree view.
 
         If the key points to a subtree (intermediate path with children),
@@ -286,7 +286,7 @@ class TreeStore(DictStore):
 
         Returns
         -------
-        out : blosc2.NDArray or blosc2.C2Array or blosc2.SChunk or blosc2.VLArray or blosc2.BatchStore or TreeStore
+        out : blosc2.NDArray or blosc2.C2Array or blosc2.SChunk or blosc2.VLArray or blosc2.BatchArray or TreeStore
             The stored array/chunk if key is a leaf node, or a TreeStore subtree view
             if key is an intermediate path with children.
 

--- a/src/blosc2/vlarray.py
+++ b/src/blosc2/vlarray.py
@@ -34,7 +34,7 @@ class VLArray:
     Entries are serialized with msgpack before compression. Standard Python
     objects are supported, and Blosc2 containers such as
     :class:`blosc2.NDArray`, :class:`blosc2.SChunk`, :class:`blosc2.VLArray`,
-    :class:`blosc2.BatchStore`, and :class:`blosc2.EmbedStore` are serialized
+    :class:`blosc2.BatchArray`, and :class:`blosc2.EmbedStore` are serialized
     transparently via :meth:`to_cframe` / :func:`blosc2.from_cframe`.
 
     Msgpack also supports structured Blosc2 reference objects. Currently this

--- a/tests/test_batch_array.py
+++ b/tests/test_batch_array.py
@@ -8,7 +8,7 @@
 import pytest
 
 import blosc2
-from blosc2._msgpack_utils import msgpack_packb, msgpack_unpackb
+from blosc2.msgpack_utils import msgpack_packb, msgpack_unpackb
 
 BATCHES = [
     [b"bytes\x00payload", "plain text", 42],

--- a/tests/test_batch_array.py
+++ b/tests/test_batch_array.py
@@ -5,23 +5,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #######################################################################
 
-import numpy as np
 import pytest
 
 import blosc2
-import blosc2.c2array as blosc2_c2array
-from blosc2.msgpack_utils import msgpack_packb, msgpack_unpackb
-
-
-@blosc2.dsl_kernel
-def _kernel_add_twice(x, y):
-    return x + y * 2
-
-
-def _python_udf_add(inputs_tuple, output, offset):
-    x, y = inputs_tuple
-    output[:] = x + y
-
+from blosc2._msgpack_utils import msgpack_packb, msgpack_unpackb
 
 BATCHES = [
     [b"bytes\x00payload", "plain text", 42],
@@ -40,79 +27,20 @@ def _storage(contiguous, urlpath, mode="w"):
     return blosc2.Storage(contiguous=contiguous, urlpath=urlpath, mode=mode)
 
 
-def _make_nested_blosc2_objects():
-    ndarray = blosc2.arange(6, dtype=np.int32)
-
-    schunk = blosc2.SChunk(chunksize=16)
-    schunk.append_data(np.arange(4, dtype=np.int32))
-
-    nested_vlarray = blosc2.VLArray()
-    nested_vlarray.extend(["alpha", {"beta": 2}])
-
-    nested_batchstore = blosc2.BatchStore(items_per_block=2)
-    nested_batchstore.extend([[1, 2], ["x", {"y": 3}]])
-
-    estore = blosc2.EmbedStore()
-    estore["/node"] = blosc2.arange(3, dtype=np.int32)
-
-    return ndarray, schunk, nested_vlarray, nested_batchstore, estore
-
-
-def _make_c2array(monkeypatch, path="@public/examples/ds-1d.b2nd", urlbase="https://cat2.cloud/demo/"):
-    def fake_info(path_, urlbase_, params=None, headers=None, model=None, auth_token=None):
-        return {"schunk": {"cparams": dict(blosc2.cparams_dflts)}}
-
-    monkeypatch.setattr(blosc2_c2array, "info", fake_info)
-    return blosc2.C2Array(path, urlbase=urlbase)
-
-
-def _make_persistent_lazyexpr(tmp_path):
-    a = blosc2.asarray(np.arange(5, dtype=np.int64), urlpath=tmp_path / "a.b2nd", mode="w")
-    b = blosc2.asarray(np.arange(5, dtype=np.int64) * 2, urlpath=tmp_path / "b.b2nd", mode="w")
-    expr = blosc2.lazyexpr("a + b", operands={"a": a, "b": b})
-    expected = np.arange(5, dtype=np.int64) * 3
-    return expr, expected
-
-
-def _make_in_memory_lazyexpr():
-    a = blosc2.asarray(np.arange(5, dtype=np.int64))
-    b = blosc2.asarray(np.arange(5, dtype=np.int64) * 2)
-    return blosc2.lazyexpr("a + b", operands={"a": a, "b": b})
-
-
-def _make_persistent_lazyudf(tmp_path):
-    a = blosc2.asarray(np.arange(5, dtype=np.float32), urlpath=tmp_path / "a_udf.b2nd", mode="w")
-    b = blosc2.asarray(np.arange(5, dtype=np.float32) * 2, urlpath=tmp_path / "b_udf.b2nd", mode="w")
-    udf = blosc2.lazyudf(_kernel_add_twice, (a, b), dtype=a.dtype, shape=a.shape)
-    expected = a[:] + b[:] * 2
-    return udf, expected
-
-
-def _make_persistent_python_lazyudf(tmp_path):
-    a = blosc2.asarray(np.arange(5, dtype=np.float32), urlpath=tmp_path / "a_pyudf.b2nd", mode="w")
-    b = blosc2.asarray(np.arange(5, dtype=np.float32) * 2, urlpath=tmp_path / "b_pyudf.b2nd", mode="w")
-    return blosc2.lazyudf(_python_udf_add, (a, b), dtype=a.dtype, shape=a.shape)
-
-
-def _make_persistent_ref(tmp_path):
-    a = blosc2.asarray(np.arange(5, dtype=np.int64), urlpath=tmp_path / "a_ref.b2nd", mode="w")
-    return blosc2.Ref.from_object(a), a[:]
-
-
 @pytest.mark.parametrize(
     ("contiguous", "urlpath"),
     [
         (False, None),
         (True, None),
-        (True, "test_batchstore.b2b"),
-        (False, "test_batchstore_s.b2b"),
+        (True, "test_batcharray.b2b"),
+        (False, "test_batcharray_s.b2b"),
     ],
 )
-def test_batchstore_roundtrip(contiguous, urlpath):
+def test_batcharray_roundtrip(contiguous, urlpath):
     blosc2.remove_urlpath(urlpath)
 
-    barray = blosc2.BatchStore(storage=_storage(contiguous, urlpath))
-    assert barray.meta["batchstore"]["serializer"] == "msgpack"
+    barray = blosc2.BatchArray(storage=_storage(contiguous, urlpath))
+    assert barray.meta["batcharray"]["serializer"] == "msgpack"
 
     for i, batch in enumerate(BATCHES, start=1):
         assert barray.append(batch) == i
@@ -154,7 +82,7 @@ def test_batchstore_roundtrip(contiguous, urlpath):
 
     if urlpath is not None:
         reopened = blosc2.open(urlpath, mode="r")
-        assert isinstance(reopened, blosc2.BatchStore)
+        assert isinstance(reopened, blosc2.BatchArray)
         assert reopened.items_per_block == barray.items_per_block
         assert [batch[:] for batch in reopened] == expected
         with pytest.raises(ValueError):
@@ -181,20 +109,20 @@ def test_batchstore_roundtrip(contiguous, urlpath):
 
         if contiguous:
             reopened_mmap = blosc2.open(urlpath, mode="r", mmap_mode="r")
-            assert isinstance(reopened_mmap, blosc2.BatchStore)
+            assert isinstance(reopened_mmap, blosc2.BatchArray)
             assert [batch[:] for batch in reopened_mmap] == expected
 
     blosc2.remove_urlpath(urlpath)
 
 
-def test_batchstore_arrow_ipc_roundtrip():
+def test_batcharray_arrow_ipc_roundtrip():
     pa = pytest.importorskip("pyarrow")
-    urlpath = "test_batchstore_arrow_ipc.b2b"
+    urlpath = "test_batcharray_arrow_ipc.b2b"
     blosc2.remove_urlpath(urlpath)
 
-    barray = blosc2.BatchStore(storage=_storage(True, urlpath), serializer="arrow")
+    barray = blosc2.BatchArray(storage=_storage(True, urlpath), serializer="arrow")
     assert barray.serializer == "arrow"
-    assert barray.meta["batchstore"]["serializer"] == "arrow"
+    assert barray.meta["batcharray"]["serializer"] == "arrow"
 
     batch1 = pa.array([[1, 2], None, [3]])
     batch2 = pa.array([[4], [5, 6]])
@@ -203,20 +131,20 @@ def test_batchstore_arrow_ipc_roundtrip():
 
     assert barray[0][:] == [[1, 2], None, [3]]
     assert barray[1][:] == [[4], [5, 6]]
-    assert barray.meta["batchstore"]["arrow_schema"] is not None
+    assert barray.meta["batcharray"]["arrow_schema"] is not None
 
     reopened = blosc2.open(urlpath, mode="r")
-    assert isinstance(reopened, blosc2.BatchStore)
+    assert isinstance(reopened, blosc2.BatchArray)
     assert reopened.serializer == "arrow"
-    assert reopened.meta["batchstore"]["serializer"] == "arrow"
+    assert reopened.meta["batcharray"]["serializer"] == "arrow"
     assert reopened[0][:] == [[1, 2], None, [3]]
     assert reopened[1][:] == [[4], [5, 6]]
 
     blosc2.remove_urlpath(urlpath)
 
 
-def test_batchstore_inferred_layout_preserves_user_vlmeta():
-    barray = blosc2.BatchStore()
+def test_batcharray_inferred_layout_preserves_user_vlmeta():
+    barray = blosc2.BatchArray()
     barray.vlmeta["user"] = {"x": 1}
 
     barray.append([1, 2, 3])
@@ -224,10 +152,10 @@ def test_batchstore_inferred_layout_preserves_user_vlmeta():
     assert barray.vlmeta["user"] == {"x": 1}
 
 
-def test_batchstore_arrow_layout_persistence_preserves_user_vlmeta():
+def test_batcharray_arrow_layout_persistence_preserves_user_vlmeta():
     pa = pytest.importorskip("pyarrow")
 
-    barray = blosc2.BatchStore(serializer="arrow")
+    barray = blosc2.BatchArray(serializer="arrow")
     barray.vlmeta["user"] = {"x": 1}
 
     barray.append(pa.array([[1], [2, 3]]))
@@ -235,8 +163,8 @@ def test_batchstore_arrow_layout_persistence_preserves_user_vlmeta():
     assert barray.vlmeta["user"] == {"x": 1}
 
 
-def test_batchstore_from_cframe():
-    barray = blosc2.BatchStore()
+def test_batcharray_from_cframe():
+    barray = blosc2.BatchArray()
     barray.extend(BATCHES)
     barray.insert(1, ["inserted", True, None])
     del barray[3]
@@ -245,244 +173,16 @@ def test_batchstore_from_cframe():
     del expected[3]
 
     restored = blosc2.from_cframe(barray.to_cframe())
-    assert isinstance(restored, blosc2.BatchStore)
+    assert isinstance(restored, blosc2.BatchArray)
     assert [batch[:] for batch in restored] == expected
 
     restored2 = blosc2.from_cframe(barray.to_cframe())
-    assert isinstance(restored2, blosc2.BatchStore)
+    assert isinstance(restored2, blosc2.BatchArray)
     assert [batch[:] for batch in restored2] == expected
 
 
-def test_batchstore_msgpack_supports_blosc2_objects():
-    ndarray, schunk, nested_vlarray, nested_batchstore, estore = _make_nested_blosc2_objects()
-
-    barray = blosc2.BatchStore(items_per_block=2)
-    barray.append([ndarray, schunk, nested_vlarray, nested_batchstore, estore])
-
-    restored = barray[0][:]
-
-    assert isinstance(restored[0], blosc2.NDArray)
-    assert np.array_equal(restored[0][:], ndarray[:])
-
-    assert isinstance(restored[1], blosc2.SChunk)
-    assert restored[1].decompress_chunk(0) == schunk.decompress_chunk(0)
-
-    assert isinstance(restored[2], blosc2.VLArray)
-    assert list(restored[2]) == list(nested_vlarray)
-
-    assert isinstance(restored[3], blosc2.BatchStore)
-    assert [batch[:] for batch in restored[3]] == [batch[:] for batch in nested_batchstore]
-
-    assert isinstance(restored[4], blosc2.EmbedStore)
-    assert list(restored[4].keys()) == ["/node"]
-    assert np.array_equal(restored[4]["/node"][:], estore["/node"][:])
-
-
-def test_msgpack_supports_c2array(monkeypatch):
-    c2array = _make_c2array(monkeypatch)
-
-    payload = msgpack_packb({"remote": c2array})
-    restored = msgpack_unpackb(payload)
-
-    assert isinstance(restored["remote"], blosc2.C2Array)
-    assert restored["remote"].path == c2array.path
-    assert restored["remote"].urlbase == c2array.urlbase
-    assert restored["remote"].auth_token is None
-
-
-def test_msgpack_supports_ref(tmp_path):
-    ref, expected = _make_persistent_ref(tmp_path)
-
-    restored = msgpack_unpackb(msgpack_packb({"ref": ref}))["ref"]
-
-    assert isinstance(restored, blosc2.Ref)
-    assert restored == ref
-    np.testing.assert_array_equal(restored.open()[:], expected)
-
-
-def test_batchstore_msgpack_supports_c2array(monkeypatch):
-    c2array = _make_c2array(monkeypatch)
-
-    barray = blosc2.BatchStore(items_per_block=2)
-    barray.append([c2array])
-
-    restored = barray[0][0]
-
-    assert isinstance(restored, blosc2.C2Array)
-    assert restored.path == c2array.path
-    assert restored.urlbase == c2array.urlbase
-    assert restored.auth_token is None
-
-
-def test_msgpack_supports_lazyexpr(tmp_path):
-    expr, expected = _make_persistent_lazyexpr(tmp_path)
-
-    payload = msgpack_packb({"expr": expr})
-    restored = msgpack_unpackb(payload)["expr"]
-
-    assert isinstance(restored, blosc2.LazyExpr)
-    np.testing.assert_array_equal(restored[:], expected)
-
-
-def test_batchstore_msgpack_supports_lazyexpr(tmp_path):
-    expr, expected = _make_persistent_lazyexpr(tmp_path)
-
-    barray = blosc2.BatchStore(items_per_block=2)
-    barray.append([expr])
-
-    restored = barray[0][0]
-
-    assert isinstance(restored, blosc2.LazyExpr)
-    np.testing.assert_array_equal(restored[:], expected)
-
-
-def test_msgpack_supports_lazyudf_dslkernel(tmp_path):
-    udf, expected = _make_persistent_lazyudf(tmp_path)
-
-    restored = msgpack_unpackb(msgpack_packb({"udf": udf}))["udf"]
-
-    assert isinstance(restored, blosc2.LazyUDF)
-    np.testing.assert_allclose(restored[:], expected)
-
-
-def test_batchstore_msgpack_supports_lazyudf_dslkernel(tmp_path):
-    udf, expected = _make_persistent_lazyudf(tmp_path)
-
-    barray = blosc2.BatchStore(items_per_block=2)
-    barray.append([udf])
-    restored = barray[0][0]
-
-    assert isinstance(restored, blosc2.LazyUDF)
-    np.testing.assert_allclose(restored[:], expected)
-
-
-def test_msgpack_rejects_plain_python_lazyudf(tmp_path):
-    udf = _make_persistent_python_lazyudf(tmp_path)
-
-    with pytest.raises(TypeError, match="DSLKernel"):
-        msgpack_packb({"udf": udf})
-
-
-def test_msgpack_rejects_lazyexpr_with_in_memory_operands():
-    expr = _make_in_memory_lazyexpr()
-
-    with pytest.raises(ValueError, match="stored on disk/network"):
-        msgpack_packb({"expr": expr})
-
-
-def test_batchstore_msgpack_rejects_lazyexpr_with_in_memory_operands():
-    expr = _make_in_memory_lazyexpr()
-
-    barray = blosc2.BatchStore(items_per_block=2)
-    with pytest.raises(ValueError, match="stored on disk/network"):
-        barray.append([expr])
-
-
-@pytest.mark.network
-def test_msgpack_supports_lazyexpr_with_c2array_operand(cat2_context, tmp_path):
-    path = "@public/expr/ds-1-2-linspace-float64-b2-(5,)d.b2nd"
-    a = blosc2.C2Array(path)
-    a_values = np.asarray(a[:])
-    b = blosc2.asarray(a_values * 2, urlpath=tmp_path / "b.b2nd", mode="w")
-    expr = blosc2.lazyexpr("a + b", operands={"a": a, "b": b})
-
-    restored = msgpack_unpackb(msgpack_packb({"expr": expr}))["expr"]
-
-    assert isinstance(restored, blosc2.LazyExpr)
-    np.testing.assert_allclose(restored[:], a_values + b[:])
-
-
-@pytest.mark.network
-def test_batchstore_msgpack_supports_lazyexpr_with_c2array_operand(cat2_context, tmp_path):
-    path = "@public/expr/ds-1-2-linspace-float64-b2-(5,)d.b2nd"
-    a = blosc2.C2Array(path)
-    a_values = np.asarray(a[:])
-    b = blosc2.asarray(a_values * 2, urlpath=tmp_path / "b.b2nd", mode="w")
-    expr = blosc2.lazyexpr("a + b", operands={"a": a, "b": b})
-
-    barray = blosc2.BatchStore(items_per_block=2)
-    barray.append([expr])
-    restored = barray[0][0]
-
-    assert isinstance(restored, blosc2.LazyExpr)
-    np.testing.assert_allclose(restored[:], a_values + b[:])
-
-
-@pytest.mark.parametrize("suffix", [".b2d", ".b2z"])
-def test_msgpack_lazyexpr_with_dictstore_operands(tmp_path, suffix):
-    store_path = tmp_path / f"operands{suffix}"
-    ext_a = tmp_path / "a.b2nd"
-    ext_b = tmp_path / "b.b2nd"
-    expected = np.arange(5, dtype=np.int64) * 3
-
-    a = blosc2.asarray(np.arange(5, dtype=np.int64), urlpath=str(ext_a), mode="w")
-    b = blosc2.asarray(np.arange(5, dtype=np.int64) * 2, urlpath=str(ext_b), mode="w")
-    with blosc2.DictStore(str(store_path), mode="w", threshold=None) as dstore:
-        dstore["/a"] = a
-        dstore["/b"] = b
-
-    with blosc2.DictStore(str(store_path), mode="r") as dstore:
-        expr = blosc2.lazyexpr("a + b", operands={"a": dstore["/a"], "b": dstore["/b"]})
-        restored = msgpack_unpackb(msgpack_packb({"expr": expr}))["expr"]
-
-    assert isinstance(restored, blosc2.LazyExpr)
-    np.testing.assert_array_equal(restored[:], expected)
-
-
-def test_batchstore_msgpack_lazyexpr_with_dictstore_operands(tmp_path):
-    store_path = tmp_path / "operands.b2z"
-    ext_a = tmp_path / "a.b2nd"
-    ext_b = tmp_path / "b.b2nd"
-    expected = np.arange(5, dtype=np.int64) * 3
-
-    a = blosc2.asarray(np.arange(5, dtype=np.int64), urlpath=str(ext_a), mode="w")
-    b = blosc2.asarray(np.arange(5, dtype=np.int64) * 2, urlpath=str(ext_b), mode="w")
-    with blosc2.DictStore(str(store_path), mode="w", threshold=None) as dstore:
-        dstore["/a"] = a
-        dstore["/b"] = b
-
-    with blosc2.DictStore(str(store_path), mode="r") as dstore:
-        expr = blosc2.lazyexpr("a + b", operands={"a": dstore["/a"], "b": dstore["/b"]})
-        barray = blosc2.BatchStore(items_per_block=2)
-        barray.append([expr])
-        restored = barray[0][0]
-
-    assert isinstance(restored, blosc2.LazyExpr)
-    np.testing.assert_array_equal(restored[:], expected)
-
-
-@pytest.mark.network
-def test_msgpack_roundtrip_c2array_network(cat2_context):
-    path = "@public/expr/ds-1-2-linspace-float64-b2-(5,)d.b2nd"
-    original = blosc2.C2Array(path)
-
-    payload = msgpack_packb({"remote": original})
-    restored = msgpack_unpackb(payload)["remote"]
-
-    assert isinstance(restored, blosc2.C2Array)
-    assert restored.path == original.path
-    assert restored.urlbase == original.urlbase
-    np.testing.assert_allclose(restored[:], original[:])
-
-
-@pytest.mark.network
-def test_batchstore_msgpack_roundtrip_c2array_network(cat2_context):
-    path = "@public/expr/ds-1-2-linspace-float64-b2-(5,)d.b2nd"
-    original = blosc2.C2Array(path)
-
-    barray = blosc2.BatchStore(items_per_block=2)
-    barray.append([original])
-
-    restored = barray[0][0]
-
-    assert isinstance(restored, blosc2.C2Array)
-    assert restored.path == original.path
-    assert restored.urlbase == original.urlbase
-    np.testing.assert_allclose(restored[:], original[:])
-
-
-def test_batchstore_info():
-    barray = blosc2.BatchStore()
+def test_batcharray_info():
+    barray = blosc2.BatchArray()
     barray.extend(BATCHES)
 
     assert barray.typesize == 1
@@ -490,7 +190,7 @@ def test_batchstore_info():
     assert barray.urlpath == barray.schunk.urlpath
 
     items = dict(barray.info_items)
-    assert items["type"] == "BatchStore"
+    assert items["type"] == "BatchArray"
     assert items["serializer"] == "msgpack"
     assert items["nbatches"].startswith(f"{len(BATCHES)} (items per batch: mean=")
     assert items["nblocks"].startswith(str(len(BATCHES)))
@@ -505,16 +205,16 @@ def test_batchstore_info():
     text = repr(barray.info)
     assert "type" in text
     assert "serializer" in text
-    assert "BatchStore" in text
+    assert "BatchArray" in text
     assert "items per batch" in text
     assert "items per block" in text
 
 
-def test_batchstore_info_uses_persisted_batch_lengths():
-    barray = blosc2.BatchStore()
+def test_batcharray_info_uses_persisted_batch_lengths():
+    barray = blosc2.BatchArray()
     barray.extend(BATCHES)
 
-    assert barray.vlmeta["_batch_store_metadata"]["batch_lengths"] == [len(batch) for batch in BATCHES]
+    assert barray.vlmeta["_batch_array_metadata"]["batch_lengths"] == [len(batch) for batch in BATCHES]
 
     def fail_decode(*args, **kwargs):
         raise AssertionError(
@@ -532,32 +232,32 @@ def test_batchstore_info_uses_persisted_batch_lengths():
     assert "items per batch: mean=" in items["nbatches"]
 
 
-def test_batchstore_info_reports_exact_block_stats_from_lazy_chunks():
-    barray = blosc2.BatchStore(items_per_block=2)
+def test_batcharray_info_reports_exact_block_stats_from_lazy_chunks():
+    barray = blosc2.BatchArray(items_per_block=2)
     barray.extend([[1, 2, 3, 4, 5], [6, 7], [8]])
 
     items = dict(barray.info_items)
     assert items["nblocks"] == "5 (items per block: mean=1.60, max=2, min=1)"
 
 
-def test_batchstore_pop_keeps_batch_lengths_metadata_in_sync():
-    barray = blosc2.BatchStore(items_per_block=2)
+def test_batcharray_pop_keeps_batch_lengths_metadata_in_sync():
+    barray = blosc2.BatchArray(items_per_block=2)
     barray.extend([[1, 2, 3], [4, 5], [6]])
 
     removed = barray.pop(1)
 
     assert removed == [4, 5]
     assert [batch[:] for batch in barray] == [[1, 2, 3], [6]]
-    assert barray.vlmeta["_batch_store_metadata"]["batch_lengths"] == [3, 1]
+    assert barray.vlmeta["_batch_array_metadata"]["batch_lengths"] == [3, 1]
     items = dict(barray.info_items)
     assert items["nbatches"].startswith("2 (items per batch: mean=2.00")
 
 
-def test_batchstore_clear_keeps_empty_store_vlmeta_readable():
-    urlpath = "test_batchstore_clear_empty_vlmeta.b2b"
+def test_batcharray_clear_keeps_empty_store_vlmeta_readable():
+    urlpath = "test_batcharray_clear_empty_vlmeta.b2b"
     blosc2.remove_urlpath(urlpath)
 
-    barray = blosc2.BatchStore(urlpath=urlpath, mode="w", contiguous=True)
+    barray = blosc2.BatchArray(urlpath=urlpath, mode="w", contiguous=True)
     barray.append([1, 2, 3])
     barray.clear()
 
@@ -569,11 +269,11 @@ def test_batchstore_clear_keeps_empty_store_vlmeta_readable():
     blosc2.remove_urlpath(urlpath)
 
 
-def test_batchstore_delete_last_keeps_empty_store_vlmeta_readable():
-    urlpath = "test_batchstore_delete_last_empty_vlmeta.b2b"
+def test_batcharray_delete_last_keeps_empty_store_vlmeta_readable():
+    urlpath = "test_batcharray_delete_last_empty_vlmeta.b2b"
     blosc2.remove_urlpath(urlpath)
 
-    barray = blosc2.BatchStore(urlpath=urlpath, mode="w", contiguous=True)
+    barray = blosc2.BatchArray(urlpath=urlpath, mode="w", contiguous=True)
     barray.append([1, 2, 3])
     barray.delete(0)
 
@@ -585,26 +285,26 @@ def test_batchstore_delete_last_keeps_empty_store_vlmeta_readable():
     blosc2.remove_urlpath(urlpath)
 
 
-def test_batchstore_zstd_does_not_use_dict_by_default():
-    barray = blosc2.BatchStore()
+def test_batcharray_zstd_does_not_use_dict_by_default():
+    barray = blosc2.BatchArray()
     assert barray.cparams.codec == blosc2.Codec.ZSTD
     assert barray.cparams.use_dict is False
 
 
-def test_batchstore_explicit_items_per_block():
-    barray = blosc2.BatchStore(items_per_block=2)
+def test_batcharray_explicit_items_per_block():
+    barray = blosc2.BatchArray(items_per_block=2)
     assert barray.items_per_block == 2
     barray.append([1, 2, 3])
     barray.append([4])
     assert [batch[:] for batch in barray] == [[1, 2, 3], [4]]
 
 
-def test_batchstore_get_vlblock_and_scalar_access():
-    urlpath = "test_batchstore_vlblock.b2b"
+def test_batcharray_get_vlblock_and_scalar_access():
+    urlpath = "test_batcharray_vlblock.b2b"
     blosc2.remove_urlpath(urlpath)
 
     batch = [0, 1, 2, 3, 4]
-    barray = blosc2.BatchStore(storage=_storage(True, urlpath), items_per_block=2)
+    barray = blosc2.BatchArray(storage=_storage(True, urlpath), items_per_block=2)
     barray.append(batch)
 
     assert barray.items_per_block == 2
@@ -617,7 +317,7 @@ def test_batchstore_get_vlblock_and_scalar_access():
     assert barray[0][4] == 4
 
     reopened = blosc2.open(urlpath, mode="r")
-    assert isinstance(reopened, blosc2.BatchStore)
+    assert isinstance(reopened, blosc2.BatchArray)
     assert reopened.items_per_block == 2
     assert reopened[0][0] == 0
     assert reopened[0][2] == 2
@@ -627,8 +327,8 @@ def test_batchstore_get_vlblock_and_scalar_access():
     blosc2.remove_urlpath(urlpath)
 
 
-def test_batchstore_scalar_reads_cache_vlblocks():
-    barray = blosc2.BatchStore(items_per_block=2)
+def test_batcharray_scalar_reads_cache_vlblocks():
+    barray = blosc2.BatchArray(items_per_block=2)
     barray.append([0, 1, 2, 3, 4])
 
     batch = barray[0]
@@ -651,8 +351,8 @@ def test_batchstore_scalar_reads_cache_vlblocks():
         barray.schunk.get_vlblock = original_get_vlblock
 
 
-def test_batchstore_iter_items():
-    barray = blosc2.BatchStore(items_per_block=2)
+def test_batcharray_iter_items():
+    barray = blosc2.BatchArray(items_per_block=2)
     batches = [[1, 2, 3], [4], [5, 6]]
     barray.extend(batches)
 
@@ -660,44 +360,44 @@ def test_batchstore_iter_items():
     assert list(barray.iter_items()) == [1, 2, 3, 4, 5, 6]
 
 
-def test_batchstore_respects_explicit_use_dict_and_non_zstd():
-    barray = blosc2.BatchStore(cparams={"codec": blosc2.Codec.LZ4, "clevel": 5})
+def test_batcharray_respects_explicit_use_dict_and_non_zstd():
+    barray = blosc2.BatchArray(cparams={"codec": blosc2.Codec.LZ4, "clevel": 5})
     assert barray.cparams.codec == blosc2.Codec.LZ4
     assert barray.cparams.use_dict is False
 
-    barray = blosc2.BatchStore(cparams={"codec": blosc2.Codec.LZ4HC, "clevel": 1, "use_dict": True})
+    barray = blosc2.BatchArray(cparams={"codec": blosc2.Codec.LZ4HC, "clevel": 1, "use_dict": True})
     assert barray.cparams.codec == blosc2.Codec.LZ4HC
     assert barray.cparams.use_dict is True
 
-    barray = blosc2.BatchStore(cparams={"codec": blosc2.Codec.ZSTD, "clevel": 0})
+    barray = blosc2.BatchArray(cparams={"codec": blosc2.Codec.ZSTD, "clevel": 0})
     assert barray.cparams.codec == blosc2.Codec.ZSTD
     assert barray.cparams.use_dict is False
 
-    barray = blosc2.BatchStore(cparams={"codec": blosc2.Codec.ZSTD, "clevel": 5, "use_dict": False})
+    barray = blosc2.BatchArray(cparams={"codec": blosc2.Codec.ZSTD, "clevel": 5, "use_dict": False})
     assert barray.cparams.use_dict is False
 
-    barray = blosc2.BatchStore(cparams=blosc2.CParams(codec=blosc2.Codec.ZSTD, clevel=5, use_dict=False))
+    barray = blosc2.BatchArray(cparams=blosc2.CParams(codec=blosc2.Codec.ZSTD, clevel=5, use_dict=False))
     assert barray.cparams.use_dict is False
 
 
-def test_batchstore_guess_items_per_block_uses_l2_for_clevel_5(monkeypatch):
+def test_batcharray_guess_items_per_block_uses_l2_for_clevel_5(monkeypatch):
     monkeypatch.setitem(blosc2.cpu_info, "l1_data_cache_size", 100)
     monkeypatch.setitem(blosc2.cpu_info, "l2_cache_size", 1000)
-    barray = blosc2.BatchStore(cparams={"clevel": 5})
+    barray = blosc2.BatchArray(cparams={"clevel": 5})
     assert barray._guess_blocksize([30, 30, 30, 30]) == 4
 
 
-def test_batchstore_guess_items_per_block_uses_l2_for_mid_clevel(monkeypatch):
+def test_batcharray_guess_items_per_block_uses_l2_for_mid_clevel(monkeypatch):
     monkeypatch.setitem(blosc2.cpu_info, "l1_data_cache_size", 100)
     monkeypatch.setitem(blosc2.cpu_info, "l2_cache_size", 150)
-    barray = blosc2.BatchStore(cparams={"clevel": 6})
+    barray = blosc2.BatchArray(cparams={"clevel": 6})
     assert barray._guess_blocksize([60, 60, 60, 60]) == 2
 
 
-def test_batchstore_guess_items_per_block_uses_full_batch_for_clevel_9(monkeypatch):
+def test_batcharray_guess_items_per_block_uses_full_batch_for_clevel_9(monkeypatch):
     monkeypatch.setitem(blosc2.cpu_info, "l1_data_cache_size", 1)
     monkeypatch.setitem(blosc2.cpu_info, "l2_cache_size", 1)
-    barray = blosc2.BatchStore(cparams={"clevel": 9})
+    barray = blosc2.BatchArray(cparams={"clevel": 9})
     assert barray._guess_blocksize([100, 100, 100, 100]) == 4
 
 
@@ -738,14 +438,14 @@ def test_vlcompress_small_blocks_roundtrip():
     assert out == payloads
 
 
-def test_batchstore_constructor_kwargs():
-    urlpath = "test_batchstore_kwargs.b2b"
+def test_batcharray_constructor_kwargs():
+    urlpath = "test_batcharray_kwargs.b2b"
     blosc2.remove_urlpath(urlpath)
 
-    barray = blosc2.BatchStore(urlpath=urlpath, mode="w", contiguous=True)
+    barray = blosc2.BatchArray(urlpath=urlpath, mode="w", contiguous=True)
     barray.extend(BATCHES)
 
-    reopened = blosc2.BatchStore(urlpath=urlpath, mode="r", contiguous=True, mmap_mode="r")
+    reopened = blosc2.BatchArray(urlpath=urlpath, mode="r", contiguous=True, mmap_mode="r")
     assert [batch[:] for batch in reopened] == BATCHES
 
     blosc2.remove_urlpath(urlpath)
@@ -756,14 +456,14 @@ def test_batchstore_constructor_kwargs():
     [
         (False, None),
         (True, None),
-        (True, "test_batchstore_list_ops.b2b"),
-        (False, "test_batchstore_list_ops_s.b2b"),
+        (True, "test_batcharray_list_ops.b2b"),
+        (False, "test_batcharray_list_ops_s.b2b"),
     ],
 )
-def test_batchstore_list_like_ops(contiguous, urlpath):
+def test_batcharray_list_like_ops(contiguous, urlpath):
     blosc2.remove_urlpath(urlpath)
 
-    barray = blosc2.BatchStore(storage=_storage(contiguous, urlpath))
+    barray = blosc2.BatchArray(storage=_storage(contiguous, urlpath))
     barray.extend([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
     assert [batch[:] for batch in barray] == [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
     assert barray.pop() == [7, 8, 9]
@@ -789,15 +489,15 @@ def test_batchstore_list_like_ops(contiguous, urlpath):
     [
         (False, None),
         (True, None),
-        (True, "test_batchstore_slices.b2b"),
-        (False, "test_batchstore_slices_s.b2b"),
+        (True, "test_batcharray_slices.b2b"),
+        (False, "test_batcharray_slices_s.b2b"),
     ],
 )
-def test_batchstore_slices(contiguous, urlpath):
+def test_batcharray_slices(contiguous, urlpath):
     blosc2.remove_urlpath(urlpath)
 
     expected = [[i, i + 100, i + 200] for i in range(8)]
-    barray = blosc2.BatchStore(storage=_storage(contiguous, urlpath))
+    barray = blosc2.BatchArray(storage=_storage(contiguous, urlpath))
     barray.extend(expected)
 
     assert [batch[:] for batch in barray[1:6:2]] == expected[1:6:2]
@@ -826,8 +526,8 @@ def test_batchstore_slices(contiguous, urlpath):
     blosc2.remove_urlpath(urlpath)
 
 
-def test_batchstore_slice_errors():
-    barray = blosc2.BatchStore()
+def test_batcharray_slice_errors():
+    barray = blosc2.BatchArray()
     barray.extend([[0], [1], [2], [3]])
 
     with pytest.raises(ValueError, match="extended slice"):
@@ -843,16 +543,16 @@ def test_batchstore_slice_errors():
     [
         (False, None),
         (True, None),
-        (True, "test_batchstore_items.b2b"),
-        (False, "test_batchstore_items_s.b2b"),
+        (True, "test_batcharray_items.b2b"),
+        (False, "test_batcharray_items_s.b2b"),
     ],
 )
-def test_batchstore_items_accessor(contiguous, urlpath):
+def test_batcharray_items_accessor(contiguous, urlpath):
     blosc2.remove_urlpath(urlpath)
 
     batches = [["a", "b"], [10, 11, 12], [{"x": 1}], [None, True]]
     flat = [item for batch in batches for item in batch]
-    barray = blosc2.BatchStore(storage=_storage(contiguous, urlpath), items_per_block=2)
+    barray = blosc2.BatchArray(storage=_storage(contiguous, urlpath), items_per_block=2)
     barray.extend(batches)
 
     assert len(barray.items) == len(flat)
@@ -895,13 +595,13 @@ def test_batchstore_items_accessor(contiguous, urlpath):
     blosc2.remove_urlpath(urlpath)
 
 
-def test_batchstore_copy():
-    urlpath = "test_batchstore_copy.b2b"
-    copy_path = "test_batchstore_copy_out.b2b"
+def test_batcharray_copy():
+    urlpath = "test_batcharray_copy.b2b"
+    copy_path = "test_batcharray_copy_out.b2b"
     blosc2.remove_urlpath(urlpath)
     blosc2.remove_urlpath(copy_path)
 
-    original = blosc2.BatchStore(urlpath=urlpath, mode="w", contiguous=True)
+    original = blosc2.BatchArray(urlpath=urlpath, mode="w", contiguous=True)
     original.extend(BATCHES)
     original.insert(1, ["copy", True, 123])
 
@@ -925,13 +625,13 @@ def test_batchstore_copy():
     blosc2.remove_urlpath(copy_path)
 
 
-def test_batchstore_copy_with_storage_preserves_user_metadata():
-    urlpath = "test_batchstore_copy_storage.b2b"
-    copy_path = "test_batchstore_copy_storage_out.b2b"
+def test_batcharray_copy_with_storage_preserves_user_metadata():
+    urlpath = "test_batcharray_copy_storage.b2b"
+    copy_path = "test_batcharray_copy_storage_out.b2b"
     blosc2.remove_urlpath(urlpath)
     blosc2.remove_urlpath(copy_path)
 
-    original = blosc2.BatchStore(urlpath=urlpath, mode="w", contiguous=True, meta={"user_meta": {"a": 1}})
+    original = blosc2.BatchArray(urlpath=urlpath, mode="w", contiguous=True, meta={"user_meta": {"a": 1}})
     original.vlmeta["user_vlmeta"] = {"b": 2}
     original.extend(BATCHES)
 
@@ -946,7 +646,7 @@ def test_batchstore_copy_with_storage_preserves_user_metadata():
 
 
 @pytest.mark.parametrize(("contiguous", "nthreads"), [(False, 2), (True, 4)])
-def test_batchstore_multithreaded_inner_vl(contiguous, nthreads):
+def test_batcharray_multithreaded_inner_vl(contiguous, nthreads):
     batches = []
     for batch_id in range(24):
         batch = []
@@ -963,7 +663,7 @@ def test_batchstore_multithreaded_inner_vl(contiguous, nthreads):
             )
         batches.append(batch)
 
-    barray = blosc2.BatchStore(
+    barray = blosc2.BatchArray(
         storage=blosc2.Storage(contiguous=contiguous),
         cparams=blosc2.CParams(typesize=1, nthreads=nthreads, codec=blosc2.Codec.ZSTD, clevel=5),
         dparams=blosc2.DParams(nthreads=nthreads),
@@ -974,8 +674,8 @@ def test_batchstore_multithreaded_inner_vl(contiguous, nthreads):
     assert [barray[i][:] for i in range(len(barray))] == batches
 
 
-def test_batchstore_validation_errors():
-    barray = blosc2.BatchStore()
+def test_batcharray_validation_errors():
+    barray = blosc2.BatchArray()
 
     with pytest.raises(TypeError):
         barray.append("value")
@@ -986,7 +686,7 @@ def test_batchstore_validation_errors():
     with pytest.raises(IndexError):
         barray.delete(3)
     with pytest.raises(IndexError):
-        blosc2.BatchStore().pop()
+        blosc2.BatchArray().pop()
     barray.extend([[1, 2, 3]])
     assert barray.append([2, 3]) == 2
     assert [batch[:] for batch in barray] == [[1, 2, 3], [2, 3]]
@@ -994,29 +694,29 @@ def test_batchstore_validation_errors():
         barray.pop(slice(0, 1))
 
 
-def test_batchstore_in_embed_store():
+def test_batcharray_in_embed_store():
     estore = blosc2.EmbedStore()
-    barray = blosc2.BatchStore()
+    barray = blosc2.BatchArray()
     barray.extend(BATCHES)
 
     estore["/batch"] = barray
     restored = estore["/batch"]
-    assert isinstance(restored, blosc2.BatchStore)
+    assert isinstance(restored, blosc2.BatchArray)
     assert [batch[:] for batch in restored] == BATCHES
 
 
-def test_batchstore_in_dict_store():
-    path = "test_batchstore_store.b2z"
+def test_batcharray_in_dict_store():
+    path = "test_batcharray_store.b2z"
     blosc2.remove_urlpath(path)
 
     with blosc2.DictStore(path, mode="w", threshold=1) as dstore:
-        barray = blosc2.BatchStore()
+        barray = blosc2.BatchArray()
         barray.extend(BATCHES)
         dstore["/batch"] = barray
 
     with blosc2.DictStore(path, mode="r") as dstore:
         restored = dstore["/batch"]
-        assert isinstance(restored, blosc2.BatchStore)
+        assert isinstance(restored, blosc2.BatchArray)
         assert [batch[:] for batch in restored] == BATCHES
 
     blosc2.remove_urlpath(path)

--- a/tests/test_tree_store.py
+++ b/tests/test_tree_store.py
@@ -671,42 +671,42 @@ def test_external_vlarray_support():
     os.remove("test_vlarray_external.b2z")
 
 
-def test_external_batchstore_support(tmp_path):
-    store_path = tmp_path / "test_batchstore_external.b2d"
+def test_external_batcharray_support(tmp_path):
+    store_path = tmp_path / "test_batcharray_external.b2d"
 
     with TreeStore(str(store_path), mode="w", threshold=0) as tstore:
-        bstore = blosc2.BatchStore(items_per_block=2)
+        bstore = blosc2.BatchArray(items_per_block=2)
         bstore.extend([[{"id": 1}, {"id": 2}], [{"id": 3}]])
-        tstore["/data/batchstore"] = bstore
+        tstore["/data/batcharray"] = bstore
 
-        batchstore_path = store_path / "data" / "batchstore.b2b"
-        assert batchstore_path.exists()
+        batcharray_path = store_path / "data" / "batcharray.b2b"
+        assert batcharray_path.exists()
 
     with TreeStore(str(store_path), mode="r") as tstore:
-        retrieved = tstore["/data/batchstore"]
-        assert isinstance(retrieved, blosc2.BatchStore)
+        retrieved = tstore["/data/batcharray"]
+        assert isinstance(retrieved, blosc2.BatchArray)
         assert [batch[:] for batch in retrieved] == [[{"id": 1}, {"id": 2}], [{"id": 3}]]
 
 
 @pytest.mark.parametrize("storage_type", ["b2d", "b2z"])
-def test_metadata_discovery_reopens_renamed_batchstore_leaf(storage_type, tmp_path):
-    store_path = tmp_path / f"test_batchstore_renamed.{storage_type}"
+def test_metadata_discovery_reopens_renamed_batcharray_leaf(storage_type, tmp_path):
+    store_path = tmp_path / f"test_batcharray_renamed.{storage_type}"
 
     with TreeStore(str(store_path), mode="w", threshold=0) as tstore:
-        bstore = blosc2.BatchStore(items_per_block=2)
+        bstore = blosc2.BatchArray(items_per_block=2)
         bstore.extend([[{"id": 1}, {"id": 2}], [{"id": 3}]])
-        tstore["/data/batchstore"] = bstore
+        tstore["/data/batcharray"] = bstore
 
-    old_name = "data/batchstore.b2b"
-    new_name = "data/batchstore.odd"
+    old_name = "data/batcharray.b2b"
+    new_name = "data/batcharray.odd"
     _rename_store_member(str(store_path), old_name, new_name)
 
-    with pytest.warns(UserWarning, match=r"batchstore\.odd'.*BatchStore.*expected '\.b2b'"):
+    with pytest.warns(UserWarning, match=r"batcharray\.odd'.*BatchArray.*expected '\.b2b'"):
         tstore = TreeStore(str(store_path), mode="r")
     with tstore:
-        assert tstore.map_tree["/data/batchstore"] == new_name
-        retrieved = tstore["/data/batchstore"]
-        assert isinstance(retrieved, blosc2.BatchStore)
+        assert tstore.map_tree["/data/batcharray"] == new_name
+        retrieved = tstore["/data/batcharray"]
+        assert isinstance(retrieved, blosc2.BatchArray)
         assert [batch[:] for batch in retrieved] == [[{"id": 1}, {"id": 2}], [{"id": 3}]]
 
 

--- a/tests/test_vlarray.py
+++ b/tests/test_vlarray.py
@@ -48,13 +48,13 @@ def _make_nested_blosc2_objects():
     nested_vlarray = blosc2.VLArray()
     nested_vlarray.extend(["alpha", {"beta": 2}])
 
-    nested_batchstore = blosc2.BatchStore(items_per_block=2)
-    nested_batchstore.extend([[1, 2], ["x", {"y": 3}]])
+    nested_batcharray = blosc2.BatchArray(items_per_block=2)
+    nested_batcharray.extend([[1, 2], ["x", {"y": 3}]])
 
     estore = blosc2.EmbedStore()
     estore["/node"] = blosc2.arange(3, dtype=np.int32)
 
-    return ndarray, schunk, nested_vlarray, nested_batchstore, estore
+    return ndarray, schunk, nested_vlarray, nested_batcharray, estore
 
 
 def _make_c2array(monkeypatch, path="@public/examples/ds-1d.b2nd", urlbase="https://cat2.cloud/demo/"):
@@ -190,7 +190,7 @@ def test_vlarray_from_cframe():
 
 
 def test_vlarray_msgpack_supports_blosc2_objects():
-    ndarray, schunk, nested_vlarray, nested_batchstore, estore = _make_nested_blosc2_objects()
+    ndarray, schunk, nested_vlarray, nested_batcharray, estore = _make_nested_blosc2_objects()
 
     vlarray = blosc2.VLArray()
     vlarray.append(
@@ -198,7 +198,7 @@ def test_vlarray_msgpack_supports_blosc2_objects():
             "ndarray": ndarray,
             "schunk": schunk,
             "vlarray": nested_vlarray,
-            "batchstore": nested_batchstore,
+            "batcharray": nested_batcharray,
             "estore": estore,
         }
     )
@@ -214,8 +214,8 @@ def test_vlarray_msgpack_supports_blosc2_objects():
     assert isinstance(restored["vlarray"], blosc2.VLArray)
     assert list(restored["vlarray"]) == list(nested_vlarray)
 
-    assert isinstance(restored["batchstore"], blosc2.BatchStore)
-    assert [batch[:] for batch in restored["batchstore"]] == [batch[:] for batch in nested_batchstore]
+    assert isinstance(restored["batcharray"], blosc2.BatchArray)
+    assert [batch[:] for batch in restored["batcharray"]] == [batch[:] for batch in nested_batcharray]
 
     assert isinstance(restored["estore"], blosc2.EmbedStore)
     assert list(restored["estore"].keys()) == ["/node"]


### PR DESCRIPTION
This adds a new tutorial to the different containers in current Pyton-Blosc2.  Also, `BatchStore` has been renamed to `BatchArray`.