### PR TITLE
Support for fixed-shape N-dimensional CTable columns

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -186,6 +186,21 @@ Reduction operations can be used with any of :ref:`NDArray <NDArray>`, :ref:`C2A
 """
     )
     genbody(f, sorted(reducers))
+    f.write(
+        """
+Grouped reductions
+~~~~~~~~~~~~~~~~~~
+
+The :func:`blosc2.group_reduce` function is a lower-level, array-oriented primitive that groups one-dimensional keys and applies eager reductions to the associated values.
+
+.. autosummary::
+
+    group_reduce
+
+
+.. autofunction:: blosc2.group_reduce
+"""
+    )
 
 hidden = "_ignore_multiple_size"
 

--- a/doc/reference/ctable.rst
+++ b/doc/reference/ctable.rst
@@ -12,9 +12,10 @@ explicitly call :meth:`~blosc2.CTable.to_arrow` or iterate with
 
 .. currentmodule:: blosc2
 
-.. autoclass:: CTable
+.. autoclass:: blosc2.CTable
     :members:
     :member-order: groupwise
+    :special-members: __getitem__, __getattr__
 
     .. rubric:: Special methods
 
@@ -23,6 +24,7 @@ explicitly call :meth:`~blosc2.CTable.to_arrow` or iterate with
         CTable.__len__
         CTable.__iter__
         CTable.__getitem__
+        CTable.__getattr__
         CTable.__repr__
         CTable.__str__
 
@@ -35,21 +37,22 @@ explicitly call :meth:`~blosc2.CTable.to_arrow` or iterate with
        Iterate over live rows in insertion order, yielding namedtuple-like
        row objects with one attribute per column.
 
-    .. automethod:: __getitem__
+    ``__getitem__`` supports type-driven indexing:
 
-       Type-driven indexing:
+    * ``str`` — column name returns a :class:`Column`; any other string
+      is interpreted as a boolean expression and behaves like :meth:`where`.
+    * boolean :class:`~blosc2.LazyExpr` / :class:`~blosc2.NDArray` —
+      filtered row view, same as :meth:`where`, e.g.
+      ``t[t.temperature_f > 70]``.
+    * ``int`` — single row as a namedtuple-like object.
+    * ``slice`` — row-range view.
+    * ``list[int]`` / ``ndarray[int]`` — gathered-row view.
+    * ``ndarray[bool]`` — boolean-mask filtered view.
+    * ``list[str]`` — column-projection view (same as :meth:`select`).
 
-       * ``str`` — column name returns a :class:`Column`; any other string
-         is interpreted as a boolean expression and behaves like
-         :meth:`where`.
-       * boolean :class:`~blosc2.LazyExpr` / :class:`~blosc2.NDArray` —
-         filtered row view, same as :meth:`where`, e.g.
-         ``t[t.temperature_f > 70]``.
-       * ``int`` — single row as a namedtuple-like object.
-       * ``slice`` — row-range view.
-       * ``list[int]`` / ``ndarray[int]`` — gathered-row view.
-       * ``ndarray[bool]`` — boolean-mask filtered view.
-       * ``list[str]`` — column-projection view (same as :meth:`select`).
+    ``__getattr__`` provides convenience attribute-style column access only
+    after normal Python attribute lookup fails; use ``t["name"]`` for columns
+    that conflict with table attributes or methods.
 
     .. automethod:: __repr__
     .. automethod:: __str__

--- a/doc/reference/reduction_functions.rst
+++ b/doc/reference/reduction_functions.rst
@@ -14,7 +14,6 @@ Reduction operations can be used with any of :ref:`NDArray <NDArray>`, :ref:`C2A
     argmax
     argmin
     count_nonzero
-    group_reduce
     cumulative_prod
     cumulative_sum
     max
@@ -32,7 +31,6 @@ Reduction operations can be used with any of :ref:`NDArray <NDArray>`, :ref:`C2A
 .. autofunction:: blosc2.argmax
 .. autofunction:: blosc2.argmin
 .. autofunction:: blosc2.count_nonzero
-.. autofunction:: blosc2.group_reduce
 .. autofunction:: blosc2.cumulative_prod
 .. autofunction:: blosc2.cumulative_sum
 .. autofunction:: blosc2.max

--- a/doc/reference/reduction_functions.rst
+++ b/doc/reference/reduction_functions.rst
@@ -40,3 +40,15 @@ Reduction operations can be used with any of :ref:`NDArray <NDArray>`, :ref:`C2A
 .. autofunction:: blosc2.std
 .. autofunction:: blosc2.sum
 .. autofunction:: blosc2.var
+
+Grouped reductions
+~~~~~~~~~~~~~~~~~~
+
+The :func:`blosc2.group_reduce` function is a lower-level, array-oriented primitive that groups one-dimensional keys and applies eager reductions to the associated values.
+
+.. autosummary::
+
+    group_reduce
+
+
+.. autofunction:: blosc2.group_reduce

--- a/plans/ctable-ndarray-cols-copilot-sonnet.md
+++ b/plans/ctable-ndarray-cols-copilot-sonnet.md
@@ -1,0 +1,647 @@
+# CTable ndarray Column Type
+
+Add support for **fixed-size multi-dimensional columns** to CTable, where each row
+stores an array (1-D, 2-D, …) of uniform dtype instead of a scalar value.
+
+---
+
+## User story
+
+```python
+import numpy as np
+import blosc2 as b2
+from dataclasses import dataclass
+
+
+@dataclass
+class Row:
+    id: int
+    embedding: np.ndarray = b2.field(b2.ndarray(shape=(768,), dtype=b2.float32()))
+    bbox: np.ndarray = b2.field(
+        b2.ndarray(shape=(4,), dtype=b2.float64()),
+        default_factory=lambda: np.full(4, np.nan, dtype=np.float64),
+    )
+
+
+t = b2.CTable(Row)
+t.extend(
+    {"id": np.arange(1000), "embedding": np.random.randn(1000, 768).astype(np.float32)}
+)
+
+# Filter rows where the max element of the embedding exceeds 0.5
+view = t.where(t["embedding"].max() > 0.5)
+
+# L2-norm per row — then filter
+view = t.where(t["embedding"].norm() > 5.0)
+
+# Slice into the inner array — first element of each embedding
+first_elem = t["embedding"][:, 0]  # 1-D NDArray, can be used in t.where()
+
+# Row access returns the full array
+print(t[0].embedding)  # ndarray of shape (768,)
+```
+
+---
+
+## 1. Schema — `NDArraySpec` class
+
+**File:** `src/blosc2/schema.py`
+
+```python
+class NDArraySpec(SchemaSpec):
+    """Fixed-size array column where each row stores a multi-dimensional array.
+
+    Parameters
+    ----------
+    shape: tuple[int, ...]
+        Per-row array shape, e.g. ``(3,)`` for a 3-element vector,
+        ``(4, 4)`` for a 4×4 matrix.  Must be non-empty (scalar columns
+        use ``int32``, ``float64``, etc.).
+    dtype_spec: SchemaSpec
+        The element type, e.g. ``float32()``, ``int32(ge=0)``, ``bool()``.
+    nullable: bool, default False
+        Whether the whole row-array can be ``None``.
+    null_value: array-like, optional
+        Explicit null sentinel pattern.  When omitted, the existing
+        per-dtype sentinel convention is broadcast to ``shape`` (see §1.1).
+    """
+
+    python_type = np.ndarray  # each row value is an ndarray (or None)
+    dtype: np.dtype  # from dtype_spec.dtype
+    dtype_spec: SchemaSpec  # inner spec — constraints, serialization
+    shape: tuple[int, ...]
+    nullable: bool
+    null_value: np.ndarray | None
+```
+
+**Factory function:**
+
+```python
+def ndarray(
+    shape: tuple[int, ...],
+    dtype: SchemaSpec,
+    *,
+    nullable: bool = False,
+    null_value: np.ndarray | list | None = None,
+) -> NDArraySpec: ...
+```
+
+**Dataclass usage:**
+
+```python
+@dataclass
+class Row:
+    v: np.ndarray = b2.field(b2.ndarray(shape=(3,), dtype=b2.float32()))
+    # For nullable:
+    opt: np.ndarray = b2.field(b2.ndarray(shape=(2,), dtype=b2.int32(), nullable=True))
+    # Default with factory:
+    mat: np.ndarray = b2.field(
+        b2.ndarray(shape=(4, 4), dtype=b2.float64()),
+        default_factory=lambda: np.eye(4, dtype=np.float64),
+    )
+```
+
+Users write the annotation as `np.ndarray` (matches `NDArraySpec.python_type`).
+The `default_factory` must produce an ndarray of the right shape + dtype.
+
+**Important**: `np.ndarray` must **not** be added to `_ANNOTATION_TO_SPEC` —
+plain `np.ndarray` annotations without `b2.field(b2.ndarray(...))` are
+unsupported because the shape and dtype cannot be inferred.  A clear error
+message must be raised.
+
+**Naming note**: `b2.ndarray` (spec factory) vs `blosc2.NDArray` (array class)
+differ by case only.  Document clearly: `b2.ndarray(...)` declares a schema
+spec; `blosc2.NDArray` is the compressed array class.
+
+### 1.1 Nullability
+
+Uses the **existing sentinel convention** from scalar columns, broadcast to
+`shape`.  The null sentinel for `ndarray(shape=(3,), dtype=int32())` is
+`[int32.min, int32.min, int32.min]` — the scalar sentinel repeated in every
+element position.
+
+| Inner dtype | Default sentinel | Check |
+|---|---|---|
+| `float32` / `float64` | All-`NaN` | `np.isnan(arr).all(axis=inner)` |
+| `int8` … `int64` | All-`min` (or all-`max` per policy) | `(arr == nv).all(axis=inner)` |
+| `uint8` … `uint64` | All-`max` (or all-`min` per policy) | Same |
+| `bool` | `[255, 255, …]` | Same |
+| `string` / `bytes` | All-`"__BLOSC2_NULL__"` | Same |
+
+`_null_mask_for` adaptation (in `Column`):
+
+```python
+if is_ndarray_spec:
+    inner = tuple(range(1, arr.ndim))  # axes beyond row dim
+    if np.issubdtype(self.dtype, np.floating):
+        return np.isnan(arr).all(axis=inner)
+    return (arr == null_value).all(axis=inner)
+```
+
+`_policy_null_value_for_spec` gets an `NDArraySpec` branch that calls itself
+recursively on the inner spec and broadcasts to `shape`.
+
+### 1.2 Serialization
+
+```python
+# to_metadata_dict → {"kind": "ndarray", "shape": [3], "dtype": {"kind": "float32", ...}, ...}
+# Deserialization via spec_from_metadata_dict, which needs a new "ndarray" branch.
+```
+
+`_KIND_TO_SPEC["ndarray"]` must be added in `schema_compiler.py` (see §2).
+
+### 1.3 `__init__.py` export
+
+Add `ndarray` and `NDArraySpec` to the `from .schema import (...)` block
+in `src/blosc2/__init__.py`.
+
+### 1.4 Chunks / blocks interaction
+
+`compute_chunks_blocks((expected_size, *per_row_shape))` already handles
+multi-dimensional shapes.  For large per-row arrays (e.g. `(224, 224, 3)`)
+users should provide per-column `chunks=` / `blocks=` hints via `b2.field()`.
+
+---
+
+## 2. Schema Compiler
+
+**File:** `src/blosc2/schema_compiler.py`
+
+- `CompiledColumn` gains `per_row_shape: tuple[int, ...]` (empty tuple = scalar).
+- `compile_schema` populates it from `NDArraySpec.shape`.
+- `validate_annotation_matches_spec` accepts `np.ndarray` (and `np.ndarray | None`
+  for nullable) for `NDArraySpec` columns.  **`list[T]` is not accepted** —
+  the annotation must be `np.ndarray` to signal fixed-size storage.
+- `_policy_null_value_for_spec` and `_validate_null_value_for_spec` get
+  `NDArraySpec` branches.
+- `spec_from_metadata_dict` gets an `"ndarray"` branch.
+- `_KIND_TO_SPEC` gets `"ndarray": NDArraySpec` (or a factory callable).
+
+---
+
+## 3. Column NDArray storage shape
+
+Every place the physical NDArray backing a column is created must use
+`(capacity, *per_row_shape)` instead of `(capacity,)`:
+
+| Location | Current | New |
+|---|---|---|
+| `_init_columns` | `shape=(expected_size,)` | `shape=(expected_size, *per_row_shape)` |
+| `_grow` | `resize((c*2,))` | `resize((c*2, *self._raw_col.shape[1:]))` |
+| `add_column` | `shape=(capacity,)` | `shape=(capacity, *per_row_shape)` |
+| `_create_empty_stored_column` | same | same |
+| `materialize_computed_column` | same | same |
+| `_add_physical_column_from_spec` | same | same |
+
+**No changes needed** for `compact()` or `_sort_by_inplace` /
+`_sorted_copy_from_positions`: both use `arr[pos_array]` and
+`arr[start:end] = arr[other_pos]` patterns that work automatically for
+multi-dimensional NDArrays.
+
+---
+
+## 4. Column class
+
+**File:** `src/blosc2/ctable.py`
+
+### 4.1 Metadata properties
+
+```python
+@property
+def shape(self) -> tuple[int, ...]:
+    return (len(self), *self._per_row_shape)
+
+
+@property
+def ndim(self) -> int:
+    return 1 + len(self._per_row_shape)
+
+
+@property
+def size(self) -> int:
+    return len(self) * math.prod(self._per_row_shape)  # math.prod(()) == 1 for scalar
+```
+
+`self._per_row_shape` is resolved from
+`self._table._schema.columns_by_name[name].per_row_shape`.
+
+### 4.2 Per-row aggregation methods
+
+`max`, `min`, `sum`, `mean`, `std`, `var`, `any`, `all`, and **`norm`**
+operate on ndarray columns by reducing **all inner axes** by default,
+returning a **1-D NDArray** (one scalar per row):
+
+```python
+def max(self, axis=None, *, where=None):
+    if self._is_ndarray_column():
+        if axis is None:
+            axis = tuple(range(1, self._raw_col.ndim))
+        result = self._raw_col.max(axis=axis)
+        # ensure result is NDArray for LazyExpr interop (see §9 risk #2)
+        if not isinstance(result, blosc2.NDArray):
+            result = blosc2.asarray(result)
+        return result
+    # existing scalar path (unchanged)
+    ...
+
+
+def norm(self, ord=2, *, where=None):
+    """Per-row L-norm.  Returns a 1-D NDArray."""
+    ...
+```
+
+The returned 1-D NDArray supports comparison operators (`>`, `<`, `==`, …)
+which create a `LazyExpr` usable in `t.where(...)`.
+
+An explicit `axis=` parameter allows partial reductions:
+
+```python
+t["mat"].max(axis=(-1,))  # reduce last dim only, keep others
+t["mat"].sum(axis=None)  # global scalar across all rows+axes (explicit)
+```
+
+For **scalar columns** the current behavior is preserved.  Note that calling
+`t["scalar_col"].max()` already returns a Python scalar today; there is no
+risk of breakage.
+
+**Implementation note:** the ndarray path bypasses `_lazy_aggregate_fastpath`
+entirely and delegates to `self._raw_col`.  The `where=` parameter is not
+supported in the ndarray branch for v1 (null masking is applied downstream in
+`_null_mask_for`).
+
+### 4.3 Element-slice access via `__getitem__`
+
+`Column.__getitem__` accepts **tuple keys** for ndarray columns.  The first
+element is the row selector (existing `int`/`slice`/`list`/`ndarray`/`bool`
+logic), the remaining elements slice into the inner axes:
+
+```text
+t["emb"][:, 0]         → 1-D numpy array (first element per row)
+t["emb"][:, :2]        → 2-D numpy array (first two elements per row)
+t["emb"][:5, [0, 2]]   → 2-D numpy array (rows 0-4, inner positions 0 and 2)
+```
+
+For `(slice(None), *inner)` the inner slice is applied directly to
+`self._raw_col`, which materializes eagerly as a numpy array via
+`NDArray.__getitem__`.  For other row selectors, physical indices are resolved
+first, then inner slicing is applied.
+
+**Note:** The result is a numpy array, not an NDArray.  To use it in
+`t.where(...)` as a predicate, the comparison (`> 0.5`) produces a boolean
+numpy array which `where()` accepts via `blosc2.asarray()`.
+
+### 4.4 Comparison operators — blocked for ndarray
+
+`__gt__`, `__lt__`, `__eq__`, `__ne__`, `__ge__`, `__le__` raise a clear
+`TypeError` for ndarray columns with an actionable message:
+
+```python
+t["emb"] > 0.5
+# → TypeError: Cannot compare ndarray column 'emb' (shape=(768,)) with a
+#   scalar directly.  Use an aggregation: t["emb"].max() > 0.5, or
+#   an element slice: t["emb"][:, 0] > 0.5
+```
+
+### 4.5 `__setitem__`, `append`, `extend`
+
+- **`append`**: `_coerce_row_to_storage` skips `.item()` for ndarray columns.
+  Shape and dtype validation must be added:
+  ```python
+  arr = np.asarray(val, dtype=col.dtype)
+  if arr.shape != col.per_row_shape:
+      raise ValueError(
+          f"Expected shape {col.per_row_shape} for column {col.name!r}, got {arr.shape}"
+      )
+  result[col.name] = arr
+  ```
+- **`extend`**: `np.ascontiguousarray(raw_columns[name], dtype=target_dtype)`
+  preserves inner dimensions.  Explicit shape check: column batch must be
+  `(n_rows, *per_row_shape)`.  A wrong shape gives a clear error early.
+- **`__setitem__`**: assigns arrays at row positions.
+
+### 4.6 Row access `t[i]`
+
+`_physical_row_value` fetches `self._cols[col_name][pos]`, which for ndarray
+columns returns the per-row array (e.g. shape `(768,)`) as a numpy array.
+`_normalize_scalar_value` passes through non-0d arrays unmodified, so
+`t[5].embedding` returns the correct ndarray.
+
+**Fix needed (v1):** the computed-column branch of `_physical_row_value`
+currently does `.ravel()[0]` (assumes scalars).  Since computed ndarray columns
+are **deferred**, this fix is only needed once §D1 lands; mark it with a
+`# TODO ndarray-computed` comment for now.
+
+### 4.7 Display
+
+- `Column.__repr__`: for narrow shapes (`len(per_row_shape) == 1` and
+  `shape[0] <= 8`) show values inline: `[0.1, 0.2, …]`.  For wider arrays
+  show only shape: `ndarray(768,)`.
+- `CTable.__str__` header: show dtype and shape info (e.g. `float32[768]`)
+  rather than individual values to avoid blowing up horizontal space.
+- `_fetch_col_at_positions`: returns 2-D for ndarray columns; display
+  formatter adapts by showing shape.
+
+### 4.8 `_where_expression_operands`
+
+This method currently includes all non-list/non-varlen/non-dictionary columns
+as operands for string lazy expressions.  For ndarray columns it **must skip**
+the column:
+
+```python
+if col is not None and not (
+    self._is_list_column(col)
+    or self._is_varlen_scalar_column(col)
+    or self._is_dictionary_column(col)
+    or self._is_ndarray_column(col)  # ← add this
+):
+    operands[name] = arr
+```
+
+Without this guard, a string expression like `"embedding > 0"` would pass a
+2-D NDArray to `numexpr`, which does not handle multi-dimensional operands
+in the expected row-wise manner.
+
+### 4.9 Iteration
+
+`__iter__` yields namedtuple rows with ndarray column values (full per-row
+array).  Chunk decompression follows the normal NDArray access pattern — the
+same chunk is reused for consecutive positions within it.
+
+---
+
+## 5. Interop
+
+### 5.1 Arrow (`to_arrow` / `from_arrow`)
+
+Arrow's `FixedSizeList` maps naturally for **1-D** shapes.  For **multi-dimensional**
+shapes, the pragmatic approach is a **flat** `FixedSizeList` plus a `blosc2:ndarray_shape`
+field-level metadata entry, rather than nested FixedSizeList (which has
+limited support in the Arrow ecosystem):
+
+```
+ndarray(shape=(768,), dtype=float32())
+    ⇄  pa.list_(pa.float32(), 768)
+       + field metadata {"blosc2:ndarray_shape": "[768]"}
+
+ndarray(shape=(2, 2), dtype=int64())
+    ⇄  pa.list_(pa.int64(), 4)          # list_size = math.prod([2,2])
+       + field metadata {"blosc2:ndarray_shape": "[2, 2]"}
+```
+
+`to_arrow` builds a flat `FixedSizeListArray` (C-contiguous reshape of the
+physical values buffer) and embeds the original shape in field metadata.
+`from_arrow` detects `FixedSizeList` fields with `blosc2:ndarray_shape` and
+constructs `NDArraySpec`.  `FixedSizeList` fields without that metadata key are
+treated as 1-D ndarray columns (shape = `(list_size,)`).
+
+**New required code:** `_pa_type_from_spec` needs an `NDArraySpec` branch;
+`_compiled_columns_from_arrow` needs to handle `FixedSizeList` and reconstruct
+the spec.
+
+Nullability: Arrow's validity bitmap maps to the sentinel pattern — null rows
+are written as the sentinel pattern, and on import, the presence of a null
+bitmap with `nullable=False` raises an import error.
+
+### 5.2 Parquet (`to_parquet` / `from_parquet`)
+
+Modern Parquet (via pyarrow) **does** write Arrow `FixedSizeList` arrays to
+Parquet as a LIST with fixed-size metadata and reads them back correctly.
+This means the Arrow round-trip (§5.1) is also a valid Parquet round-trip:
+write via `to_arrow()` → `to_parquet()`, read via `from_parquet()` →
+`from_arrow()`.
+
+The earlier "flatten to N separate columns" strategy is **not recommended**:
+for a `shape=(768,)` embedding, that would produce 768 Parquet columns,
+which is impractical in all common Parquet tooling.
+
+### 5.3 CSV (`to_csv` / `from_csv`)
+
+- **`to_csv`**: ndarray cells are serialized as space-separated values
+  (e.g. `"0.1 0.2 0.3"`).  Multi-dimensional arrays flatten in C order.
+- **`from_csv`**: cannot infer ndarray columns — users must provide an
+  explicit `row_type`.
+
+### 5.4 DataFrame / NumPy
+
+- **`to_dataframe`**: ndarray columns become DataFrame columns of dtype
+  `object` (each cell is a numpy array).  Note: pandas has no native dtype
+  for fixed-size arrays; `object` is the only option.
+- **`from_dataframe`**: `object`-dtype columns of numpy arrays are **not**
+  auto-detected as ndarray columns.  Users must provide an explicit `row_type`
+  with `NDArraySpec` columns, same as for `from_csv`.  Auto-detection is
+  fragile (requires inspecting the first row, may fail on empty DataFrames).
+- **`__array__`**: the structured numpy array dtype uses `object` for
+  ndarray columns (numpy structured arrays cannot nest fixed-size arrays natively).
+
+---
+
+## 6. Non-supported operations (v1)
+
+These raise a clear `NotImplementedError` or `TypeError` with an actionable
+message:
+
+| Operation | Reason | Alternative |
+|---|---|---|
+| `t["emb"] > 0.5` | Array vs scalar comparison undefined | `t["emb"].max() > 0.5` |
+| `t.sort_by("emb")` | No total order on arrays | Add scalar column `t.add_column("emb_max", t["emb"].max()[:])`, then `t.sort_by("emb_max")` |
+| `t.groupby("emb")` | Grouping by array values undefined | Group by a scalar column |
+| `t.describe()` on ndarray cols | No meaningful scalar stats | Shows `(stats not available for ndarray columns)` — same style as list columns |
+| `t.cov()` / `t.corr()` | Columns must be scalar | Add scalar aggregation columns first |
+| `create_index("emb")` | Index engine requires 1-D arrays | Add scalar aggregation column, then index it |
+| `t["emb"] == t["emb2"]` | Element-wise equality → 2-D result, not a 1-D row mask | `(t["emb"] - t["emb2"]).norm() < eps` once element-wise ops are added; for v1, compare aggregations |
+
+**Guards needed in code:**
+- `_normalise_sort_keys`: add ndarray column check (the function currently
+  allows any column with a dtype — without a guard, `_build_lex_keys` would
+  pass a 2-D array to `np.lexsort`, which silently fails or crashes).
+- `describe`: add ndarray branch showing "stats not available" (otherwise the
+  numeric path tries `col.min()` / `col.max()` and returns arrays instead
+  of scalars, breaking the display logic).
+
+---
+
+## 7. Computed columns + indexing (deferred — requires more infrastructure)
+
+### 7.1 Problem
+
+The natural workflow is:
+
+```python
+t.add_computed_column("emb_max", lambda cols: cols["embedding"].max(axis=-1))
+t.create_index("emb_max")
+t.where(t["emb_max"] > 0.5)  # index hit
+```
+
+But this can't work today because:
+1. `cols["embedding"].max(axis=-1)` **materializes** the result (returns a
+   numpy array or NDArray, not a `LazyExpr`).  `add_computed_column` requires
+   a `LazyExpr` from the callable.
+2. The lazy expression engine (`numexpr`/`lazyexpr`) has no **lazy reduction
+   primitive** — reductions in `LazyExpr.max(axis=...)` eagerly call
+   `compute(_reduce_args=...)` via `reduce_slices`.
+3. Even with a LazyExpr, the query planner (`_find_indexed_columns`) matches
+   operands by object identity — a computed column's operands are the *source*
+   NDArrays, not the computed column's projected 1-D array.
+
+### 7.2 Required infrastructure
+
+1. **Lazy reduction expression** — a `LazyExpr` that carries a reduction
+   descriptor (`op`, `axis`) without immediately calling `compute`.
+
+2. **Computed column from lazy reduction** — the callable form returns
+   the deferred expression (not the materialized result).
+
+3. **Materialize-on-index** — `create_index` on a computed column:
+   materializes it into `_cols`, creates a 1-D index, registers as
+   `_materialized_cols` for auto-fill on future writes.
+
+4. **Staleness and lazy rebuild** — `append` and `extend` mark the index
+   `stale`; `_try_index_where` detects the flag, rebuilds inline, then uses
+   the fresh index.
+
+### 7.2.1 Why `delete` doesn't need stale-marking
+
+When rows are deleted only `_valid_rows` changes; physical positions never
+move.  The caller (`_try_index_where`) always intersects index results with
+`_valid_rows`:
+
+```
+index returns  →  [pos_3, pos_7]
+valid_rows     →  [T, T, F, T, T, T, F, T]
+final result   →  [pos_3]          (pos_7 deleted → excluded)
+```
+
+A stale index can never "return deleted rows".  Staleness only matters when
+**new** rows arrive (`append` / `extend`).
+
+### 7.3 Fallback summary
+
+Until §7.2 is built, users have two practical options:
+
+| Option | API | Always in sync? | Performance |
+|---|---|---|---|
+| **Lazy scan** | `t["emb"].max() > 0.5` | ✅ yes | Chunked eval via `reduce_slices` — good for most workloads |
+| **Manual materialize** | `t.add_column("emb_max", ...)` → `t.create_index("emb_max")` | ❌ user-managed | Index-accelerated |
+
+The lazy scan is the recommended v1 path.
+
+---
+
+## 8. Implementation phases
+
+### Phase 1 — Core (schema, storage, Column basics)
+
+| # | Task | Files | Complexity |
+|---|---|---|---|
+| 1.1 | `NDArraySpec` class + `ndarray()` factory + `to_metadata_dict` / `from_metadata_dict` | `schema.py` | **Low** ~60 lines |
+| 1.2 | `per_row_shape` in `CompiledColumn` / `compile_schema` | `schema_compiler.py` | **Low** ~40 lines |
+| 1.3 | `_KIND_TO_SPEC["ndarray"]` + `spec_from_metadata_dict` branch | `schema_compiler.py` | **Low** ~15 lines |
+| 1.4 | Nullability: `_policy_null_value_for_spec`, `_validate_null_value_for_spec`, `_null_mask_for` | `schema_compiler.py`, `ctable.py` | **Low** ~50 lines |
+| 1.5 | Storage shape: `_init_columns`, `_grow`, `add_column`, etc. | `ctable.py` | **Low** ~30 lines (many 1-liners) |
+| 1.6 | `Column.shape`, `ndim`, `size`, `_per_row_shape` helper | `ctable.py` | **Low** ~25 lines |
+| 1.7 | `__init__.py` export of `ndarray` + `NDArraySpec` | `__init__.py` | **Low** ~3 lines |
+| 1.8 | Tests for phase 1 | `tests/ctable/` | **Medium** ~150 lines |
+
+### Phase 2 — Data path (append, extend, access)
+
+| # | Task | Files | Complexity |
+|---|---|---|---|
+| 2.1 | `_coerce_row_to_storage`: skip `.item()` + shape validation | `ctable.py` | **Low** ~20 lines |
+| 2.2 | `extend`: preserve inner dims + shape validation | `ctable.py` | **Medium** ~70 lines — existing scalar/list/dict/varlen branches, each needs ndarray handling |
+| 2.3 | `__setitem__`: assign arrays at row positions | `ctable.py` | **Low** ~20 lines |
+| 2.4 | Row access `_physical_row_value`: add `# TODO ndarray-computed` guard | `ctable.py` | **Low** ~5 lines |
+| 2.5 | `_where_expression_operands`: skip ndarray columns | `ctable.py` | **Low** ~3 lines |
+| 2.6 | Tests for phase 2 | `tests/ctable/` | **Medium** ~200 lines |
+
+### Phase 3 — Query path (aggregation, slicing, display)
+
+| # | Task | Files | Complexity |
+|---|---|---|---|
+| 3.1 | Per-row aggregation methods (`max`, `min`, `sum`, `mean`, `std`, `var`, `any`, `all`, `norm`) | `ctable.py` | **Medium** ~140 lines — ndarray branch + `blosc2.asarray()` wrap |
+| 3.2 | `__getitem__` tuple-key support for inner-axis slicing | `ctable.py` | **Medium** ~80 lines |
+| 3.3 | Comparison operators: `TypeError` with actionable message | `ctable.py` | **Low** ~15 lines |
+| 3.4 | Display: `__repr__`, `__str__`, `_fetch_col_at_positions` | `ctable.py` | **Low** ~50 lines |
+| 3.5 | Tests for phase 3 | `tests/ctable/` | **Medium** ~200 lines |
+
+### Phase 4 — Interop
+
+| # | Task | Files | Complexity |
+|---|---|---|---|
+| 4.1 | `to_arrow` / `from_arrow` — flat `FixedSizeList` + field metadata; `_pa_type_from_spec`; `_compiled_columns_from_arrow` | `ctable.py` | **Medium-High** ~120 lines |
+| 4.2 | `to_parquet` / `from_parquet` — route through Arrow; verify round-trip | `ctable.py` | **Low** ~20 lines (inherits Arrow support) |
+| 4.3 | `to_csv` / `from_csv` — space-separated serialization | `ctable.py` | **Low** ~40 lines |
+| 4.4 | `to_dataframe` — `object` dtype cells; `from_dataframe` — requires explicit schema | `ctable.py` | **Low** ~30 lines |
+| 4.5 | `__array__` — `object` dtype for ndarray fields | `ctable.py` | **Low** ~10 lines |
+| 4.6 | Tests for phase 4 | `tests/ctable/` | **Medium** ~200 lines |
+
+### Phase 5 — Polish and guards
+
+| # | Task | Files | Complexity |
+|---|---|---|---|
+| 5.1 | `_normalise_sort_keys`: ndarray guard (prevents silent crash in `_build_lex_keys`) | `ctable.py` | **Low** ~8 lines |
+| 5.2 | `describe`: ndarray branch showing "stats not available" | `ctable.py` | **Low** ~10 lines |
+| 5.3 | `cov`, `corr`, `groupby` guards | `ctable.py` | **Low** ~15 lines |
+| 5.4 | `info()` / `.info_items` report per-row shape | `ctable.py` | **Low** ~15 lines |
+| 5.5 | Docs + doctests | `core.py`, `schema.py` | **Medium** ~100 lines |
+| 5.6 | Edge cases: empty tables, all-null columns, `copy`, `rename_column` | `ctable.py` | **Medium** ~80 lines |
+
+### Deferred (not in v1)
+
+| # | Task | Reason |
+|---|---|---|
+| D1 | Computed column from ndarray aggregation | Requires lazy-reduction `LazyExpr` primitive |
+| D2 | `create_index` on computed ndarray aggregation | Depends on D1 + materialize-on-index + stale tracking |
+| D3 | `_physical_row_value` fix for computed ndarray columns | Not needed until D1 lands |
+| D4 | Element-wise ops between ndarray columns (`+`, `-`, `*`) | Nice to have; needs element-wise LazyExpr on 2-D NDArray |
+
+---
+
+## 9. Complexity summary
+
+| Phase | Code lines | Risk |
+|---|---|---|
+| 1 — Core | ~373 | **Very low** — new class + mechanical one-liner changes |
+| 2 — Data path | ~318 | **Medium** — `extend` branches need care; shape validation is new |
+| 3 — Query path | ~485 | **Medium** — aggregation return-type wrapping; tuple-key indexing |
+| 4 — Interop | ~420 | **Medium-High** — Arrow `FixedSizeList` in `_pa_type_from_spec` and `_compiled_columns_from_arrow` is non-trivial |
+| 5 — Polish | ~228 | **Low** — mostly guards and docs |
+| **Total** | **~1,824** | — |
+
+### Highest-risk areas
+
+1. **`extend` ndarray path** (§2.2): the existing scalar branch does
+   `np.ascontiguousarray(raw_columns[name], dtype=target_dtype)` followed by
+   `self._cols[name][start_pos:end_pos] = values[:]`.  For ndarray columns the
+   batch must have shape `(n_rows, *per_row_shape)`.  The main risk is
+   correctly threading this through all dispatch branches (scalar/dict/list/varlen)
+   without duplicating logic.
+
+2. **Aggregation return type** (§3.1): `NDArray.max(axis=inner_axes)` goes
+   through `LazyExpr` → `reduce_slices`, which returns a numpy array when
+   `kwargs` is empty.  The Column method must wrap with
+   `blosc2.asarray(result)` to get an NDArray that supports `__gt__` →
+   `LazyExpr`.  This is a **one-liner fix** but easy to miss.
+
+3. **Arrow interop** (§4.1): `_pa_type_from_spec` and
+   `_compiled_columns_from_arrow` are moderately complex functions.
+   `FixedSizeList` is a minority Arrow type with some rough edges in pyarrow.
+   The flat-FixedSizeList + field-metadata convention needs to be correctly
+   roundtripped through both Arrow and Parquet.
+
+4. **`_where_expression_operands` guard** (§2.5 / §4.8): without this,
+   string-expression queries like `t.where("embedding > 0")` silently pass
+   a 2-D NDArray to numexpr, producing wrong results or a crash rather than
+   a clear error.  Small fix, high consequence if missed.
+
+---
+
+## 10. Open questions
+
+- **`b2.field()` default shorthand**: allow `default=0.0` to mean
+  `default_factory=lambda: np.full(shape, 0.0, dtype=dtype)`?  Deferred —
+  `default_factory` is explicit and unambiguous.
+
+- **Nested ndarray in struct/list specs**: `ListSpec(item=NDArraySpec(...))`
+  or `StructSpec({"a": NDArraySpec(...)})` not in v1 — the `BatchArray` /
+  `ListArray` backends would need their own ndarray sub-path.  Users flatten
+  nested structure into a single ndarray column.

--- a/plans/ctable-ndarray-cols.md
+++ b/plans/ctable-ndarray-cols.md
@@ -1,0 +1,348 @@
+# CTable fixed-shape ndarray columns — follow-up plan
+
+This plan assumes the current core implementation exists:
+
+- `blosc2.ndarray(item_shape, dtype=...)` / `NDArraySpec`
+- physical storage as `(nrows, *item_shape)`
+- append / extend shape validation
+- row access returning per-row NumPy arrays
+- persistence round-trip
+- `np.asarray(table)` using structured subarray dtypes
+
+The remaining work below focuses on making ndarray columns safer, more queryable,
+and easier to analyze from inside a `CTable`.
+
+---
+
+## 1. Immediate safety guards
+
+These should land before advertising ndarray columns broadly.  Without them,
+existing scalar-oriented table operations may accidentally receive 2-D/3-D arrays
+and produce confusing errors.
+
+### 1.1 String `where()` expressions
+
+Skip ndarray columns in string-expression operands, or reject them with a clear
+message.
+
+Example rejected form:
+
+```python
+t.where("embedding > 0")
+```
+
+Suggested error:
+
+```text
+Column 'embedding' is a fixed-shape ndarray column. String expressions only
+support scalar columns. Use an element projection or a row-wise reduction first.
+```
+
+Files likely involved:
+
+- `src/blosc2/ctable.py`, `_where_expression_operands` / string where helpers
+
+### 1.2 Sorting, grouping, indexing
+
+Reject ndarray columns in operations requiring scalar comparable values:
+
+- `sort_by("embedding")`
+- `group_by("embedding")`
+- `create_index("embedding")`
+- scalar-only helpers used by `describe()`, `cov()`, `corr()`
+
+Suggested alternatives in error messages:
+
+```text
+Cannot sort by ndarray column 'embedding' with per-row shape (768,).
+Materialize a scalar feature first, e.g. embedding_norm or embedding_max.
+```
+
+---
+
+## 2. Column metadata API
+
+Add small, cheap introspection helpers to `Column`.
+
+```python
+t.embedding.shape  # (n_live_rows, 768)
+t.embedding.item_shape  # (768,)
+t.embedding.ndim  # 2
+t.embedding.item_ndim  # 1
+t.embedding.size  # n_live_rows * 768
+t.embedding.item_size  # 768
+```
+
+For scalar columns:
+
+```python
+t.price.item_shape == ()
+t.price.item_ndim == 0
+```
+
+These are useful for generic code that handles both scalar and fixed-shape array
+columns.
+
+---
+
+## 3. Element projection / inner-axis slicing
+
+Support tuple indexing on ndarray columns, where the first selector addresses
+rows and remaining selectors address the per-row item axes.
+
+Examples:
+
+```python
+t.embedding[:, 0]  # first coordinate for all live rows
+t.embedding[:10, :4]  # first 4 coordinates for first 10 live rows
+t.image[:, :, :, 0]  # channel 0 for all rows, if item_shape=(H, W, C)
+t.matrix[5, :, :]  # one row's matrix
+```
+
+Return type can initially be NumPy arrays, matching current `Column.__getitem__`
+materialization behavior.  Later, the common full-row-slice case may return a
+Blosc2 `NDArray` view/projection if such support becomes available.
+
+Important behavior:
+
+- tuple indexing is only accepted for `NDArraySpec` columns
+- scalar columns keep current indexing semantics
+- boolean row masks still refer to live logical rows
+
+---
+
+## 4. Direct comparison guard
+
+Block ambiguous comparisons on full ndarray columns:
+
+```python
+t.embedding > 0.5
+```
+
+A full comparison returns an N-D boolean array, not the 1-D row mask required by
+`CTable.where()`.  Raise a clear error.
+
+Suggested message:
+
+```text
+Cannot compare ndarray column 'embedding' directly; the result would not be a
+1-D row mask. Use an element projection like t.embedding[:, 0] > 0.5 or a
+row-wise feature like t.embedding.row_max() > 0.5.
+```
+
+---
+
+## 5. Practical user-facing analysis helpers
+
+This is an extra practical addition beyond the existing plans: provide explicit
+row-wise feature extraction methods on ndarray columns.  These make it easy to
+analyze fixed-shape columns without leaving `CTable` ergonomics.
+
+### 5.1 Row-wise reductions
+
+Add methods that reduce only the inner item axes and return one value per row:
+
+```python
+t.embedding.row_sum()
+t.embedding.row_mean()
+t.embedding.row_min()
+t.embedding.row_max()
+t.embedding.row_std()
+t.embedding.row_var()
+t.embedding.row_any()
+t.embedding.row_all()
+t.embedding.row_norm(ord=2)
+```
+
+For `item_shape=(768,)`, each returns shape `(nrows,)`.
+For `item_shape=(H, W, C)`, each reduces axes `(1, 2, 3)` by default.
+
+Optional `axis=` can reduce selected inner axes:
+
+```python
+t.image.row_mean(axis=(1, 2))  # mean over H,W, keep channel dimension
+```
+
+Naming these `row_*` avoids ambiguity with existing scalar-column `.sum()` /
+`.max()` methods, which currently mean “reduce the whole column to a scalar”.
+
+### 5.2 Materialize features as scalar columns
+
+Add a convenience method for storing derived scalar/vector features:
+
+```python
+t.embedding.add_feature("embedding_norm", op="norm")
+t.embedding.add_feature("embedding_max", op="max")
+t.embedding.add_feature("embedding_0", element=0)
+```
+
+Equivalent manual workflow today would be:
+
+```python
+values = t.embedding.row_norm()[:]
+t.add_column("embedding_norm", blosc2.field(blosc2.float64(), default=0.0))
+t.embedding_norm[:] = values
+```
+
+The helper can:
+
+- choose output dtype
+- validate output shape is 1-D for scalar feature columns
+- optionally create an index immediately:
+
+```python
+t.embedding.add_feature("embedding_norm", op="norm", create_index=True)
+```
+
+This is practical for workflows like similarity screening, image metadata,
+embeddings, and sensor windows.
+
+### 5.3 Quick summary method
+
+Add:
+
+```python
+t.embedding.summary()
+```
+
+Potential output:
+
+```text
+ndarray column 'embedding'
+  rows       : 1,000,000 live / 1,048,576 capacity
+  item_shape : (768,)
+  dtype      : float32
+  storage    : NDArray shape=(1048576, 768), chunks=(..., ...), blocks=(..., ...)
+  cbytes     : ...
+  row stats  : min(row_norm)=..., mean(row_norm)=..., max(row_norm)=...
+```
+
+Keep this opt-in so normal table display stays compact.
+
+---
+
+## 6. Display improvements
+
+Normal table display should not dump whole per-row arrays for wide shapes.
+
+Suggested formatting:
+
+- small 1-D item shapes, e.g. `(3,)`: show `[1.0, 2.0, 3.0]`
+- larger shapes: show `ndarray(shape=(768,), dtype=float32)`
+- multi-dimensional shapes: show `ndarray(shape=(32, 32, 3), dtype=uint8)`
+
+`Column.__repr__` can use the same threshold.
+
+---
+
+## 7. Nullable ndarray columns
+
+Later addition.  Current implementation should either reject nullable ndarray
+specs or document that they are unsupported.
+
+A robust design would use broadcast sentinels:
+
+- float: all-NaN item means null
+- signed int: all min or all max, following null policy
+- unsigned int: all min or all max, following null policy
+- bool: uint8 sentinel pattern
+
+Null mask for a batch:
+
+```python
+inner_axes = tuple(range(1, arr.ndim))
+mask = np.isnan(arr).all(axis=inner_axes)  # float
+mask = (arr == null_value).all(axis=inner_axes)  # non-float
+```
+
+This requires changes in:
+
+- null policy resolution
+- null sentinel validation
+- `Column._null_mask_for`
+- append / extend coercion
+- Arrow import/export null bitmap handling
+
+---
+
+## 8. Arrow / Parquet interop
+
+Map ndarray columns to Arrow `FixedSizeList`.
+
+Recommended representation:
+
+- flatten each row in C order
+- Arrow type: `fixed_size_list(value_type, prod(item_shape))`
+- store original shape in field metadata, e.g.
+  `b"blosc2:ndarray_shape": b"[2, 3]"`
+
+Examples:
+
+```text
+item_shape=(768,), dtype=float32 -> fixed_size_list(float32, 768)
+item_shape=(2, 3), dtype=float64 -> fixed_size_list(float64, 6) + shape metadata
+```
+
+Parquet can inherit this via Arrow.
+
+---
+
+## 9. CSV / DataFrame behavior
+
+CSV:
+
+- require explicit schema for import
+- serialize ndarray cells as flattened values, preferably JSON arrays for
+  readability and shape safety
+
+DataFrame:
+
+- export ndarray columns as object dtype cells containing NumPy arrays
+- do not infer ndarray columns from object dtype on import unless an explicit
+  row schema is provided
+
+---
+
+## 10. Structured NumPy materialization
+
+Current implementation uses NumPy structured subarray dtypes:
+
+```python
+np.asarray(t).dtype["matrix"].shape == (2, 3)
+```
+
+Keep this.  It is more useful than object dtype for `np.asarray(table)` because
+it preserves a compact homogeneous memory representation when all fields are
+fixed-size.
+
+Potential fallback: use object dtype only for columns that cannot be represented
+as structured subarrays.
+
+---
+
+## 11. Tests to add next
+
+- tuple inner slicing
+- direct comparison guard
+- sort/groupby/index guard messages
+- display of small and large item shapes
+- `Column.ndim`, `size`, `item_shape`
+- row-wise feature helpers
+- add-feature helper and optional indexing
+- Arrow/Parquet roundtrip for `(n,)` and `(m, n)` shapes
+- nullable ndarray columns once implemented
+
+---
+
+## Suggested next phase
+
+A good next small PR would be:
+
+1. safety guards for scalar-only operations
+2. `Column.item_shape`, `ndim`, `size`
+3. tuple inner slicing
+4. direct comparison guard
+5. tests for the above
+
+This would make the existing core implementation much safer and substantially
+more ergonomic without taking on nullable columns or Arrow interop yet.

--- a/plans/ctable-ndarray-cols.md
+++ b/plans/ctable-ndarray-cols.md
@@ -55,7 +55,7 @@ Suggested alternatives in error messages:
 
 ```text
 Cannot sort by ndarray column 'embedding' with per-row shape (768,).
-Materialize a scalar feature first, e.g. embedding_norm or embedding_max.
+Materialize a scalar generated column first, e.g. embedding_norm or embedding_max.
 ```
 
 ---
@@ -127,7 +127,7 @@ Suggested message:
 ```text
 Cannot compare ndarray column 'embedding' directly; the result would not be a
 1-D row mask. Use an element projection like t.embedding[:, 0] > 0.5 or a
-row-wise feature like t.embedding.row_max() > 0.5.
+row-wise reduction like t.embedding.row_max() > 0.5.
 ```
 
 ---
@@ -135,7 +135,7 @@ row-wise feature like t.embedding.row_max() > 0.5.
 ## 5. Practical user-facing analysis helpers
 
 This is an extra practical addition beyond the existing plans: provide explicit
-row-wise feature extraction methods on ndarray columns.  These make it easy to
+row-wise reduction methods on ndarray columns.  These make it easy to
 analyze fixed-shape columns without leaving `CTable` ergonomics.
 
 ### 5.1 Row-wise reductions
@@ -166,14 +166,87 @@ t.image.row_mean(axis=(1, 2))  # mean over H,W, keep channel dimension
 Naming these `row_*` avoids ambiguity with existing scalar-column `.sum()` /
 `.max()` methods, which currently mean “reduce the whole column to a scalar”.
 
-### 5.2 Materialize features as scalar columns
+### 5.2 Materialize row-wise reductions as generated columns
 
-Add a convenience method for storing derived scalar/vector features:
+Use `CTable.add_generated_column()` as the canonical API for storing generated
+scalar/vector columns.  This is consistent with the existing
+`add_computed_column()` name while making the storage/maintenance semantics
+explicit.
+
+The first use case is ndarray row-wise reductions:
 
 ```python
-t.embedding.add_feature("embedding_norm", op="norm")
-t.embedding.add_feature("embedding_max", op="max")
-t.embedding.add_feature("embedding_0", element=0)
+t.add_generated_column(
+    "embedding_norm",
+    source_columns=["embedding"],
+    transform={"kind": "ndarray_row_reduction", "op": "norm", "ord": 2},
+    dtype=blosc2.float64(),
+    create_index=True,
+)
+
+t.add_generated_column(
+    "embedding_max",
+    source_columns=["embedding"],
+    transform={"kind": "ndarray_row_reduction", "op": "max"},
+    dtype=blosc2.float32(),
+)
+
+t.add_generated_column(
+    "embedding_0",
+    source_columns=["embedding"],
+    transform={"kind": "ndarray_element", "key": 0},
+    dtype=blosc2.float32(),
+)
+```
+
+The concept is general: a **generated column** is a real stored column
+maintained from one or more source columns.  `add_generated_column()` should
+support two explicit generation modes:
+
+- `expr=` for scalar expressions, mirroring `add_computed_column()`
+- `transform=` for structured transforms such as ndarray row-wise reductions
+
+Exactly one of `expr` or `transform` should be provided.  Do not overload
+`transform=` to also accept expression strings; keeping `expr=` separate makes
+validation and documentation clearer.
+
+Scalar generated-column example:
+
+```python
+t.add_generated_column(
+    "total", expr="price * qty", dtype=blosc2.float64(), create_index=True
+)
+```
+
+Structured transform examples:
+
+```python
+t.add_generated_column(
+    "price_with_tax",
+    source_columns=["price"],
+    transform={"kind": "scalar_unary", "op": "mul", "value": 1.21},
+    dtype=blosc2.float64(),
+)
+```
+
+A generated column differs from a virtual computed column: it is declared from
+source columns and maintained by the table. In this plan, generated columns are
+stored on disk/in memory.  This makes them cheap to query repeatedly and
+directly indexable, at the cost of storage and maintenance.
+
+Example:
+
+```python
+t.add_generated_column(
+    "embedding_norm",
+    source_columns=["embedding"],
+    transform={"kind": "ndarray_row_reduction", "op": "norm", "ord": 2},
+    dtype=blosc2.float64(),
+    create_index=True,
+)
+
+print(t.embedding_norm[:])  # materialized norms, one per row
+view = t.where(t.embedding_norm > 5.0)  # can use the index
 ```
 
 Equivalent manual workflow today would be:
@@ -182,20 +255,111 @@ Equivalent manual workflow today would be:
 values = t.embedding.row_norm()[:]
 t.add_column("embedding_norm", blosc2.field(blosc2.float64(), default=0.0))
 t.embedding_norm[:] = values
+t.create_index("embedding_norm")
 ```
 
-The helper can:
-
-- choose output dtype
-- validate output shape is 1-D for scalar feature columns
-- optionally create an index immediately:
+Suggested signature:
 
 ```python
-t.embedding.add_feature("embedding_norm", op="norm", create_index=True)
+def add_generated_column(
+    self,
+    name: str,
+    *,
+    expr=None,
+    source_columns: list[str] | None = None,
+    transform: dict | None = None,
+    dtype=None,
+    create_index: bool = False,
+) -> None: ...
 ```
 
+Validation rules:
+
+- exactly one of `expr` or `transform` is required
+- `expr` accepts the same expression forms as `add_computed_column()` where practical
+- `source_columns` may be inferred for expression strings / LazyExpr callables when possible
+- `source_columns` is required for structured `transform=` descriptors
+- generated columns are always stored and maintained; virtual columns remain the job of `add_computed_column()`
+
+The helper should:
+
+- choose or validate output dtype
+- validate output shape is 1-D for scalar generated columns
+- write existing rows immediately
+- register generated-column metadata so `append()` / `extend()` can auto-fill new rows
+- mark a created index as stale, or rebuild/update it, when new rows arrive
+- optionally create an index immediately
+
+Suggested metadata shape:
+
+```python
+{
+    "kind": "generated_column",
+    "output": "embedding_norm",
+    "source_columns": ["embedding"],
+    "materialized": True,
+    "maintain_on_append": True,
+    "stale_on_source_update": True,
+    "dtype": "float64",
+    "transform": {
+        "kind": "ndarray_row_reduction",
+        "op": "norm",
+        "ord": 2,
+        "axis": None,
+    },
+    "index": {
+        "create": True,
+        "stale_policy": "mark_stale",
+    },
+}
+```
+
+Expression-generated columns use `expr` metadata instead of `transform`:
+
+```python
+{
+    "kind": "generated_column",
+    "output": "total",
+    "source_columns": ["price", "qty"],
+    "materialized": True,
+    "maintain_on_append": True,
+    "stale_on_source_update": True,
+    "dtype": "float64",
+    "expr": "price * qty",
+}
+```
+
+Expected maintenance behavior:
+
+```python
+t.add_generated_column(
+    "embedding_norm",
+    source_columns=["embedding"],
+    transform={"kind": "ndarray_row_reduction", "op": "norm", "ord": 2},
+    dtype=blosc2.float64(),
+    create_index=True,
+)
+t.append((new_id, new_embedding))
+
+# embedding_norm is automatically appended for the new row too
+assert t.embedding_norm[-1] == np.linalg.norm(new_embedding)
+```
+
+Source-column mutation needs an explicit policy.  For v1, the simplest safe
+policy is to mark dependent generated columns stale when source values are
+assigned through `t.embedding[...] = ...`, and provide refresh methods:
+
+```python
+t.refresh_generated_column("embedding_norm")
+t.refresh_generated_columns(source="embedding")
+```
+
+A later optimization can update only the affected generated rows during
+`Column.__setitem__`, but correctness should come first.
+
 This is practical for workflows like similarity screening, image metadata,
-embeddings, and sensor windows.
+embeddings, sensor windows, and scalar business metrics that benefit from
+materialization and indexing.
 
 ### 5.3 Quick summary method
 
@@ -327,8 +491,10 @@ as structured subarrays.
 - sort/groupby/index guard messages
 - display of small and large item shapes
 - `Column.ndim`, `size`, `item_shape`
-- row-wise feature helpers
-- add-feature helper and optional indexing
+- row-wise reduction helpers
+- `add_generated_column()` with optional indexing
+- generated-column auto-fill on `append()` / `extend()`
+- generated-column staleness / refresh behavior after source-column mutation
 - Arrow/Parquet roundtrip for `(n,)` and `(m, n)` shapes
 - nullable ndarray columns once implemented
 

--- a/plans/ctable-ndarray-cols.md
+++ b/plans/ctable-ndarray-cols.md
@@ -126,105 +126,109 @@ Suggested message:
 
 ```text
 Cannot compare ndarray column 'embedding' directly; the result would not be a
-1-D row mask. Use an element projection like t.embedding[:, 0] > 0.5 or a
-row-wise reduction like t.embedding.row_max() > 0.5.
+1-D row mask. Use an element projection like t.embedding[:, 0] > 0.5 or an
+axis-aware reduction like t.embedding.max(axis=1) > 0.5.
 ```
 
 ---
 
 ## 5. Practical user-facing analysis helpers
 
-This is an extra practical addition beyond the existing plans: provide explicit
-row-wise reduction methods on ndarray columns.  These make it easy to
-analyze fixed-shape columns without leaving `CTable` ergonomics.
+Treat an ndarray column as a logical array with shape `(nrows, *item_shape)`.
+Column reductions should follow NumPy / Blosc2 NDArray axis semantics over that
+logical shape.
 
-### 5.1 Row-wise reductions
+### 5.1 Axis-aware reductions
 
-Add methods that reduce only the inner item axes and return one value per row:
-
-```python
-t.embedding.row_sum()
-t.embedding.row_mean()
-t.embedding.row_min()
-t.embedding.row_max()
-t.embedding.row_std()
-t.embedding.row_var()
-t.embedding.row_any()
-t.embedding.row_all()
-t.embedding.row_norm(ord=2)
-```
-
-For `item_shape=(768,)`, each returns shape `(nrows,)`.
-For `item_shape=(H, W, C)`, each reduces axes `(1, 2, 3)` by default.
-
-Optional `axis=` can reduce selected inner axes:
+For scalar columns, existing behavior remains unchanged:
 
 ```python
-t.image.row_mean(axis=(1, 2))  # mean over H,W, keep channel dimension
+t.price.shape  # (nrows,)
+t.price.sum()  # scalar reduction over rows
 ```
 
-Naming these `row_*` avoids ambiguity with existing scalar-column `.sum()` /
-`.max()` methods, which currently mean “reduce the whole column to a scalar”.
+For ndarray columns:
 
-### 5.2 Materialize row-wise reductions as generated columns
+```python
+t.embedding.shape  # (nrows, dim)
+t.embedding.sum()  # scalar full reduction, same as axis=None
+t.embedding.sum(axis=None)  # scalar full reduction
+t.embedding.sum(axis=0)  # reduce rows -> shape (dim,)
+t.embedding.sum(axis=1)  # reduce embedding coords -> shape (nrows,)
+t.embedding.norm(axis=1)  # row-wise norm -> shape (nrows,)
+```
+
+For image-like columns:
+
+```python
+t.image.shape  # (nrows, H, W, C)
+t.image.mean()  # scalar full reduction
+t.image.mean(axis=0)  # mean image over rows -> shape (H, W, C)
+t.image.mean(axis=(1, 2))  # per-row per-channel mean -> shape (nrows, C)
+t.image.sum(axis=(1, 2, 3))  # per-row total -> shape (nrows,)
+```
+
+This avoids special `row_*` methods and minimizes surprise: the table row is
+always the leading axis (`axis=0`), exactly as if the column were an NDArray of
+shape `(nrows, *item_shape)`.
+
+`CTable.where()` still requires a 1-D row mask.  For example,
+`t.embedding.norm(axis=1) > 5` is valid, whereas
+`t.image.mean(axis=(1, 2)) > 0.5` returns shape `(nrows, C)` and should be
+rejected unless further reduced to `(nrows,)`.
+
+### 5.2 Materialize reductions as generated columns
 
 Use `CTable.add_generated_column()` as the canonical API for storing generated
 scalar/vector columns.  This is consistent with the existing
 `add_computed_column()` name while making the storage/maintenance semantics
 explicit.
 
-The first use case is ndarray row-wise reductions:
+The first use case is ndarray reductions that produce one value per row:
 
 ```python
 t.add_generated_column(
     "embedding_norm",
-    source_columns=["embedding"],
-    transform={"kind": "ndarray_row_reduction", "op": "norm", "ord": 2},
+    transform=blosc2.transform.norm("embedding", axis=1, ord=2),
     dtype=blosc2.float64(),
     create_index=True,
 )
 
 t.add_generated_column(
     "embedding_max",
-    source_columns=["embedding"],
-    transform={"kind": "ndarray_row_reduction", "op": "max"},
+    transform=blosc2.transform.max("embedding", axis=1),
     dtype=blosc2.float32(),
 )
 
 t.add_generated_column(
     "embedding_0",
-    source_columns=["embedding"],
-    transform={"kind": "ndarray_element", "key": 0},
+    transform=blosc2.transform["embedding", 0],
     dtype=blosc2.float32(),
 )
 ```
 
 The concept is general: a **generated column** is a real stored column
 maintained from one or more source columns.  `add_generated_column()` should
-support two explicit generation modes:
+accept a `blosc2.Transform` object built by the `blosc2.transform` singleton
+namespace/factory.
 
-- `expr=` for scalar expressions, mirroring `add_computed_column()`
-- `transform=` for structured transforms such as ndarray row-wise reductions
-
-Exactly one of `expr` or `transform` should be provided.  Do not overload
-`transform=` to also accept expression strings; keeping `expr=` separate makes
-validation and documentation clearer.
-
-Scalar generated-column example:
+Scalar expression transform example:
 
 ```python
 t.add_generated_column(
-    "total", expr="price * qty", dtype=blosc2.float64(), create_index=True
+    "total",
+    transform=blosc2.transform("price * qty"),
+    dtype=blosc2.float64(),
+    create_index=True,
 )
 ```
 
-Structured transform examples:
+Other transform examples:
 
 ```python
 t.add_generated_column(
     "price_with_tax",
-    source_columns=["price"],
-    transform={"kind": "scalar_unary", "op": "mul", "value": 1.21},
+    transform=blosc2.transform("price * 1.21"),
     dtype=blosc2.float64(),
 )
 ```
@@ -239,8 +243,7 @@ Example:
 ```python
 t.add_generated_column(
     "embedding_norm",
-    source_columns=["embedding"],
-    transform={"kind": "ndarray_row_reduction", "op": "norm", "ord": 2},
+    transform=blosc2.transform.norm("embedding", axis=1, ord=2),
     dtype=blosc2.float64(),
     create_index=True,
 )
@@ -252,7 +255,7 @@ view = t.where(t.embedding_norm > 5.0)  # can use the index
 Equivalent manual workflow today would be:
 
 ```python
-values = t.embedding.row_norm()[:]
+values = t.embedding.norm(axis=1)[:]
 t.add_column("embedding_norm", blosc2.field(blosc2.float64(), default=0.0))
 t.embedding_norm[:] = values
 t.create_index("embedding_norm")
@@ -265,9 +268,7 @@ def add_generated_column(
     self,
     name: str,
     *,
-    expr=None,
-    source_columns: list[str] | None = None,
-    transform: dict | None = None,
+    transform: blosc2.Transform,
     dtype=None,
     create_index: bool = False,
 ) -> None: ...
@@ -275,11 +276,34 @@ def add_generated_column(
 
 Validation rules:
 
-- exactly one of `expr` or `transform` is required
-- `expr` accepts the same expression forms as `add_computed_column()` where practical
-- `source_columns` may be inferred for expression strings / LazyExpr callables when possible
-- `source_columns` is required for structured `transform=` descriptors
+- `transform` must be a `blosc2.Transform` instance
+- string expressions are represented as `blosc2.transform("price * qty")`
+- ndarray projections are represented as `blosc2.transform["embedding", 0]`
+- reductions follow logical `(nrows, *item_shape)` axis semantics, e.g. `blosc2.transform.norm("embedding", axis=1)`
+- source columns are taken from `transform.source_columns`
 - generated columns are always stored and maintained; virtual columns remain the job of `add_computed_column()`
+
+`blosc2.transform` API sketch:
+
+```python
+blosc2.transform("price * qty")  # expression transform
+blosc2.transform.norm("embedding", axis=1, ord=2)
+blosc2.transform.max("embedding", axis=1)
+blosc2.transform.mean("image", axis=(1, 2))  # shape (nrows, C)
+blosc2.transform["embedding", 0]  # per-row item projection
+blosc2.transform["image", :, :, 0]  # per-row item projection with slices
+```
+
+It is a callable singleton namespace/factory.  All constructors return a
+`blosc2.Transform` object with at least:
+
+```python
+transform.kind
+transform.source_columns
+transform.to_metadata()
+transform.evaluate_existing(table)
+transform.evaluate_batch(raw_columns)
+```
 
 The helper should:
 
@@ -305,7 +329,7 @@ Suggested metadata shape:
         "kind": "ndarray_row_reduction",
         "op": "norm",
         "ord": 2,
-        "axis": None,
+        "axis": 1,
     },
     "index": {
         "create": True,
@@ -314,7 +338,7 @@ Suggested metadata shape:
 }
 ```
 
-Expression-generated columns use `expr` metadata instead of `transform`:
+Expression-generated columns use expression transform metadata:
 
 ```python
 {
@@ -325,7 +349,10 @@ Expression-generated columns use `expr` metadata instead of `transform`:
     "maintain_on_append": True,
     "stale_on_source_update": True,
     "dtype": "float64",
-    "expr": "price * qty",
+    "transform": {
+        "kind": "expression",
+        "expression": "price * qty",
+    },
 }
 ```
 
@@ -334,8 +361,7 @@ Expected maintenance behavior:
 ```python
 t.add_generated_column(
     "embedding_norm",
-    source_columns=["embedding"],
-    transform={"kind": "ndarray_row_reduction", "op": "norm", "ord": 2},
+    transform=blosc2.transform.norm("embedding", axis=1, ord=2),
     dtype=blosc2.float64(),
     create_index=True,
 )
@@ -378,7 +404,7 @@ ndarray column 'embedding'
   dtype      : float32
   storage    : NDArray shape=(1048576, 768), chunks=(..., ...), blocks=(..., ...)
   cbytes     : ...
-  row stats  : min(row_norm)=..., mean(row_norm)=..., max(row_norm)=...
+  row stats  : min(norm(axis=1))=..., mean(norm(axis=1))=..., max(norm(axis=1))=...
 ```
 
 Keep this opt-in so normal table display stays compact.
@@ -491,7 +517,7 @@ as structured subarrays.
 - sort/groupby/index guard messages
 - display of small and large item shapes
 - `Column.ndim`, `size`, `item_shape`
-- row-wise reduction helpers
+- axis-aware ndarray column reductions
 - `add_generated_column()` with optional indexing
 - generated-column auto-fill on `append()` / `extend()`
 - generated-column staleness / refresh behavior after source-column mutation

--- a/plans/ctable-ndarray-cols.md
+++ b/plans/ctable-ndarray-cols.md
@@ -184,137 +184,164 @@ scalar/vector columns.  This is consistent with the existing
 `add_computed_column()` name while making the storage/maintenance semantics
 explicit.
 
-The first use case is ndarray reductions that produce one value per row:
+Generated columns are real stored columns declared from source columns and
+maintained by the table.  They differ from virtual computed columns, which are
+not stored and are evaluated lazily.  Generated columns are cheap to query
+repeatedly and directly indexable, at the cost of storage and maintenance.
+
+#### Row-oriented ndarray transformers
+
+For ndarray columns, use a column-bound `row_transformer`.  It transforms each
+row value independently and sees only the per-row `item_shape`, not the table's
+leading `nrows` dimension.  Thus, for an embedding with item shape `(dim,)`,
+`axis=0` means the embedding-coordinate axis.
 
 ```python
 t.add_generated_column(
     "embedding_norm",
-    transform=blosc2.transform.norm("embedding", axis=1, ord=2),
+    values=t["embedding"].row_transformer.norm(axis=0, ord=2),
     dtype=blosc2.float64(),
     create_index=True,
 )
 
 t.add_generated_column(
     "embedding_max",
-    transform=blosc2.transform.max("embedding", axis=1),
+    values=t["embedding"].row_transformer.max(axis=0),
     dtype=blosc2.float32(),
 )
 
 t.add_generated_column(
     "embedding_0",
-    transform=blosc2.transform["embedding", 0],
+    values=t["embedding"].row_transformer[0],
     dtype=blosc2.float32(),
 )
 ```
 
-The concept is general: a **generated column** is a real stored column
-maintained from one or more source columns.  `add_generated_column()` should
-accept a `blosc2.Transform` object built by the `blosc2.transform` singleton
-namespace/factory.
+For image-like rows with item shape `(H, W, C)`:
 
-Scalar expression transform example:
+```python
+t.add_generated_column(
+    "image_mean_rgb",
+    values=t["image"].row_transformer.mean(axis=(0, 1)),
+    dtype=blosc2.ndarray((3,), dtype=blosc2.float32()),
+)
+
+t.add_generated_column(
+    "red_channel_mean",
+    values=t["image"].row_transformer[:, :, 0].mean(axis=(0, 1)),
+    dtype=blosc2.float32(),
+)
+```
+
+#### Expression transformers
+
+For scalar expressions, keep the same ergonomic forms as computed columns:
 
 ```python
 t.add_generated_column(
     "total",
-    transform=blosc2.transform("price * qty"),
+    values="price * qty",
     dtype=blosc2.float64(),
     create_index=True,
 )
-```
 
-Other transform examples:
+t.add_generated_column(
+    "big_tip",
+    values=(t.payment.tips > 100),
+    dtype=blosc2.bool(),
+    create_index=True,
+)
 
-```python
 t.add_generated_column(
     "price_with_tax",
-    transform=blosc2.transform("price * 1.21"),
+    values=lambda cols: cols["price"] * 1.21,
     dtype=blosc2.float64(),
 )
 ```
 
-A generated column differs from a virtual computed column: it is declared from
-source columns and maintained by the table. In this plan, generated columns are
-stored on disk/in memory.  This makes them cheap to query repeatedly and
-directly indexable, at the cost of storage and maintenance.
-
-Example:
+Equivalent manual workflow for the embedding norm today would be:
 
 ```python
-t.add_generated_column(
-    "embedding_norm",
-    transform=blosc2.transform.norm("embedding", axis=1, ord=2),
-    dtype=blosc2.float64(),
-    create_index=True,
-)
-
-print(t.embedding_norm[:])  # materialized norms, one per row
-view = t.where(t.embedding_norm > 5.0)  # can use the index
-```
-
-Equivalent manual workflow today would be:
-
-```python
-values = t.embedding.norm(axis=1)[:]
+values = np.linalg.norm(t.embedding[:], axis=1)
 t.add_column("embedding_norm", blosc2.field(blosc2.float64(), default=0.0))
 t.embedding_norm[:] = values
 t.create_index("embedding_norm")
 ```
 
-Suggested signature:
+Suggested signatures:
 
 ```python
 def add_generated_column(
     self,
     name: str,
     *,
-    transform: blosc2.Transform,
+    values: (
+        str
+        | blosc2.LazyExpr
+        | Callable[[dict[str, blosc2.NDArray]], blosc2.LazyExpr]
+        | RowTransformer
+    ),
     dtype=None,
     create_index: bool = False,
 ) -> None: ...
+
+
+def add_computed_column(
+    self,
+    name: str,
+    expr: (
+        str | blosc2.LazyExpr | Callable[[dict[str, blosc2.NDArray]], blosc2.LazyExpr]
+    ),
+    *,
+    dtype=None,
+) -> None: ...
 ```
 
-Validation rules:
+`add_computed_column()` should not accept `RowTransformer` in v1.  A
+`RowTransformer` often represents row-wise ndarray reductions/projections that
+cannot yet be represented as a virtual LazyExpr.  If such support is added later,
+`add_computed_column()` can accept only `RowTransformer` instances that implement
+a lazy lowering path; otherwise it should raise a clear error recommending
+`add_generated_column()`.
 
-- `transform` must be a `blosc2.Transform` instance
-- string expressions are represented as `blosc2.transform("price * qty")`
-- ndarray projections are represented as `blosc2.transform["embedding", 0]`
-- reductions follow logical `(nrows, *item_shape)` axis semantics, e.g. `blosc2.transform.norm("embedding", axis=1)`
-- source columns are taken from `transform.source_columns`
+Validation rules for generated columns:
+
+- string / LazyExpr / callable transformers follow the same dependency rules as computed columns
+- `RowTransformer` is accepted only by `add_generated_column()`
+- source columns are taken from the normalized transformer metadata
 - generated columns are always stored and maintained; virtual columns remain the job of `add_computed_column()`
+- generated columns intended for indexing must produce a 1-D result with length `nrows`
 
-`blosc2.transform` API sketch:
+`RowTransformer` API sketch:
 
 ```python
-blosc2.transform("price * qty")  # expression transform
-blosc2.transform.norm("embedding", axis=1, ord=2)
-blosc2.transform.max("embedding", axis=1)
-blosc2.transform.mean("image", axis=(1, 2))  # shape (nrows, C)
-blosc2.transform["embedding", 0]  # per-row item projection
-blosc2.transform["image", :, :, 0]  # per-row item projection with slices
+t["embedding"].row_transformer.norm(axis=0, ord=2)
+t["embedding"].row_transformer.max(axis=0)
+t["image"].row_transformer.mean(axis=(0, 1))
+t["embedding"].row_transformer[0]
+t["image"].row_transformer[:, :, 0]
 ```
 
-It is a callable singleton namespace/factory.  All constructors return a
-`blosc2.Transform` object with at least:
+A `RowTransformer` object should expose at least:
 
 ```python
-transform.kind
-transform.source_columns
-transform.to_metadata()
-transform.evaluate_existing(table)
-transform.evaluate_batch(raw_columns)
+transformer.kind
+transformer.source_columns
+transformer.to_metadata()
+transformer.evaluate_existing(table)
+transformer.evaluate_batch(raw_columns)
 ```
 
 The helper should:
 
 - choose or validate output dtype
-- validate output shape is 1-D for scalar generated columns
+- validate output shape is compatible with the requested generated column spec
 - write existing rows immediately
 - register generated-column metadata so `append()` / `extend()` can auto-fill new rows
 - mark a created index as stale, or rebuild/update it, when new rows arrive
 - optionally create an index immediately
 
-Suggested metadata shape:
+Suggested row-transformer metadata shape:
 
 ```python
 {
@@ -325,11 +352,12 @@ Suggested metadata shape:
     "maintain_on_append": True,
     "stale_on_source_update": True,
     "dtype": "float64",
-    "transform": {
-        "kind": "ndarray_row_reduction",
+    "transformer": {
+        "kind": "row_reduction",
+        "source": "embedding",
         "op": "norm",
         "ord": 2,
-        "axis": 1,
+        "axis": 0,
     },
     "index": {
         "create": True,
@@ -338,7 +366,7 @@ Suggested metadata shape:
 }
 ```
 
-Expression-generated columns use expression transform metadata:
+Expression-generated columns use expression transformer metadata:
 
 ```python
 {
@@ -349,7 +377,7 @@ Expression-generated columns use expression transform metadata:
     "maintain_on_append": True,
     "stale_on_source_update": True,
     "dtype": "float64",
-    "transform": {
+    "transformer": {
         "kind": "expression",
         "expression": "price * qty",
     },
@@ -361,7 +389,7 @@ Expected maintenance behavior:
 ```python
 t.add_generated_column(
     "embedding_norm",
-    transform=blosc2.transform.norm("embedding", axis=1, ord=2),
+    values=t["embedding"].row_transformer.norm(axis=0, ord=2),
     dtype=blosc2.float64(),
     create_index=True,
 )

--- a/plans/ctable-ndarray-cols.md
+++ b/plans/ctable-ndarray-cols.md
@@ -12,6 +12,42 @@ This plan assumes the current core implementation exists:
 The remaining work below focuses on making ndarray columns safer, more queryable,
 and easier to analyze from inside a `CTable`.
 
+## Implementation status — updated after current session
+
+Implemented in the current working tree:
+
+- Safety guards for string `where()`, direct ndarray-column comparisons, sorting,
+  grouping, indexing, `describe()`, and `cov()`.
+- Column metadata API: `item_shape`, `item_ndim`, `item_size`, logical `shape`,
+  `ndim`, and `size`.
+- Tuple inner-axis slicing on ndarray columns.
+- Axis-aware ndarray reductions: `sum`, `mean`, `min`, `max`, `std`, and `norm`.
+- Compact ndarray display in table display and `Column.__repr__`.
+- `Column.summary()` for ndarray columns.
+- `CTable.add_generated_column(..., values=...)` with:
+  - expression strings, `LazyExpr`, and callables for scalar stored columns,
+  - `RowTransformer` for row-wise ndarray projections/reductions,
+  - scalar and fixed-shape ndarray generated outputs,
+  - optional immediate indexing for scalar generated outputs,
+  - append/extend auto-fill,
+  - transitive staleness marking after source-column mutation,
+  - refresh APIs: `refresh_generated_column()` and `refresh_generated_columns()`,
+  - stale-read protection by default and explicit `Column.read_stale()` escape hatch.
+- `add_computed_column()` rejects `RowTransformer` and documents expression/callable forms.
+- Arrow/Parquet interop for ndarray columns via Arrow `FixedSizeList` plus
+  `blosc2:ndarray_shape` field metadata.
+- Sphinx/API documentation updates for `CTable.__getitem__`, `CTable.__getattr__`,
+  `add_computed_column()`, and `add_generated_column()`.
+- Compatibility fix for `blosc2.ndarray.NDArray` while keeping `blosc2.ndarray(...)`
+  as the CTable ndarray schema constructor.
+- Group-reduce optional-kernel fallback fixes when extension kernels are unavailable.
+
+Still not implemented / later additions:
+
+- CSV/DataFrame ndarray-specific import/export behavior.
+- Lazy virtual row-transformer lowering for computed columns.
+- Incremental partial-row generated-column refresh during `Column.__setitem__`.
+
 ---
 
 ## 1. Immediate safety guards
@@ -21,6 +57,10 @@ existing scalar-oriented table operations may accidentally receive 2-D/3-D array
 and produce confusing errors.
 
 ### 1.1 String `where()` expressions
+
+**Status: implemented.** String expressions reject fixed-shape ndarray columns
+with a clear scalar-only message, and ndarray columns are omitted from string
+expression operands.
 
 Skip ndarray columns in string-expression operands, or reject them with a clear
 message.
@@ -44,6 +84,10 @@ Files likely involved:
 
 ### 1.2 Sorting, grouping, indexing
 
+**Status: implemented.** `sort_by()`, `group_by()`, `create_index()`, and
+scalar-only helpers reject ndarray columns with messages pointing users toward
+scalar generated columns.
+
 Reject ndarray columns in operations requiring scalar comparable values:
 
 - `sort_by("embedding")`
@@ -61,6 +105,9 @@ Materialize a scalar generated column first, e.g. embedding_norm or embedding_ma
 ---
 
 ## 2. Column metadata API
+
+**Status: implemented.** `Column.item_shape`, `item_ndim`, `item_size`, logical
+`shape`, `ndim`, and `size` are available for scalar and ndarray columns.
 
 Add small, cheap introspection helpers to `Column`.
 
@@ -86,6 +133,9 @@ columns.
 ---
 
 ## 3. Element projection / inner-axis slicing
+
+**Status: implemented.** Tuple indexing materializes NumPy arrays and keeps
+boolean row masks tied to live logical rows.
 
 Support tuple indexing on ndarray columns, where the first selector addresses
 rows and remaining selectors address the per-row item axes.
@@ -113,6 +163,9 @@ Important behavior:
 
 ## 4. Direct comparison guard
 
+**Status: implemented.** Direct comparisons on full ndarray columns raise with
+guidance to use element projections or row-wise reductions.
+
 Block ambiguous comparisons on full ndarray columns:
 
 ```python
@@ -139,6 +192,10 @@ Column reductions should follow NumPy / Blosc2 NDArray axis semantics over that
 logical shape.
 
 ### 5.1 Axis-aware reductions
+
+**Status: implemented.** ndarray columns support NumPy-like `axis` semantics for
+`sum`, `mean`, `min`, `max`, `std`, and `norm` over logical shape
+`(nrows, *item_shape)`.
 
 For scalar columns, existing behavior remains unchanged:
 
@@ -178,6 +235,12 @@ shape `(nrows, *item_shape)`.
 rejected unless further reduced to `(nrows,)`.
 
 ### 5.2 Materialize reductions as generated columns
+
+**Status: implemented.** The public keyword is `values=` (not `transformer=`).
+Generated columns are stored, maintained on append/extend, can be scalar or
+fixed-shape ndarray outputs, and stale generated columns raise on normal access.
+Use `Column.read_stale()` only when explicitly inspecting the last stored stale
+values.
 
 Use `CTable.add_generated_column()` as the canonical API for storing generated
 scalar/vector columns.  This is consistent with the existing
@@ -306,11 +369,14 @@ a lazy lowering path; otherwise it should raise a clear error recommending
 
 Validation rules for generated columns:
 
-- string / LazyExpr / callable transformers follow the same dependency rules as computed columns
+- string / LazyExpr / callable `values=` definitions follow the same dependency rules as computed columns
 - `RowTransformer` is accepted only by `add_generated_column()`
 - source columns are taken from the normalized transformer metadata
 - generated columns are always stored and maintained; virtual columns remain the job of `add_computed_column()`
-- generated columns intended for indexing must produce a 1-D result with length `nrows`
+- generated columns intended for indexing must produce a 1-D scalar result with length `nrows`
+- expression generated columns may depend on generated columns because generated columns are stored
+- source-column mutation marks dependent generated columns stale transitively
+- stale generated columns raise on normal access/use; use `read_stale()` to inspect old materialized values explicitly
 
 `RowTransformer` API sketch:
 
@@ -399,23 +465,28 @@ t.append((new_id, new_embedding))
 assert t.embedding_norm[-1] == np.linalg.norm(new_embedding)
 ```
 
-Source-column mutation needs an explicit policy.  For v1, the simplest safe
-policy is to mark dependent generated columns stale when source values are
-assigned through `t.embedding[...] = ...`, and provide refresh methods:
+Source-column mutation policy is implemented for v1: dependent generated
+columns are marked stale transitively when source values are assigned through
+`t.embedding[...] = ...`, and refresh methods are provided:
 
 ```python
 t.refresh_generated_column("embedding_norm")
 t.refresh_generated_columns(source="embedding")
 ```
 
-A later optimization can update only the affected generated rows during
-`Column.__setitem__`, but correctness should come first.
+Normal access to a stale generated column raises and points to the refresh APIs
+and to the explicit `Column.read_stale()` escape hatch.  A later optimization can
+update only the affected generated rows during `Column.__setitem__`, but
+correctness should come first.
 
 This is practical for workflows like similarity screening, image metadata,
 embeddings, sensor windows, and scalar business metrics that benefit from
 materialization and indexing.
 
 ### 5.3 Quick summary method
+
+**Status: implemented.** `Column.summary()` prints and returns a compact ndarray
+column summary.
 
 Add:
 
@@ -441,6 +512,10 @@ Keep this opt-in so normal table display stays compact.
 
 ## 6. Display improvements
 
+**Status: implemented.** Small 1-D items are displayed inline; larger and
+multi-dimensional values are summarized as `ndarray(shape=..., dtype=...)`.
+`Column.__repr__` uses the same compact representation.
+
 Normal table display should not dump whole per-row arrays for wide shapes.
 
 Suggested formatting:
@@ -455,10 +530,12 @@ Suggested formatting:
 
 ## 7. Nullable ndarray columns
 
-Later addition.  Current implementation should either reject nullable ndarray
-specs or document that they are unsupported.
+**Status: implemented.** Nullable ndarray specs use broadcast sentinels: a row is
+null when every scalar element in the fixed-shape item equals the column's null
+sentinel (or is NaN for floating dtypes). Append/extend/assignment accept
+``None`` for nullable ndarray columns, and Arrow FixedSizeList nulls round-trip.
 
-A robust design would use broadcast sentinels:
+The implementation uses broadcast sentinels:
 
 - float: all-NaN item means null
 - signed int: all min or all max, following null policy
@@ -484,6 +561,10 @@ This requires changes in:
 ---
 
 ## 8. Arrow / Parquet interop
+
+**Status: implemented.** ndarray columns export to Arrow `FixedSizeList` with
+flattened row values and `blosc2:ndarray_shape` metadata, and import back to
+`NDArraySpec`. Parquet inherits this through Arrow.
 
 Map ndarray columns to Arrow `FixedSizeList`.
 
@@ -540,29 +621,40 @@ as structured subarrays.
 
 ## 11. Tests to add next
 
-- tuple inner slicing
-- direct comparison guard
-- sort/groupby/index guard messages
-- display of small and large item shapes
-- `Column.ndim`, `size`, `item_shape`
-- axis-aware ndarray column reductions
-- `add_generated_column()` with optional indexing
-- generated-column auto-fill on `append()` / `extend()`
-- generated-column staleness / refresh behavior after source-column mutation
-- Arrow/Parquet roundtrip for `(n,)` and `(m, n)` shapes
-- nullable ndarray columns once implemented
+Implemented in `tests/ctable/test_ctable_ndarray_columns.py` and related CTable
+suites:
+
+- [x] tuple inner slicing
+- [x] direct comparison guard
+- [x] sort/groupby/index guard messages
+- [x] display of small and large item shapes
+- [x] `Column.ndim`, `size`, `item_shape`
+- [x] axis-aware ndarray column reductions
+- [x] `add_generated_column()` with optional indexing
+- [x] generated-column auto-fill on `append()` / `extend()`
+- [x] generated-column staleness / refresh behavior after source-column mutation
+- [x] stale generated column access raises, with `Column.read_stale()` escape hatch
+- [x] transitive generated-column stale marking / refresh
+- [x] Arrow roundtrip for `(n,)` and `(m, n)` shapes
+- [x] nullable ndarray columns once implemented
+- [ ] CSV/DataFrame ndarray-specific behavior once implemented
 
 ---
 
 ## Suggested next phase
 
-A good next small PR would be:
+The originally suggested small PR is complete:
 
-1. safety guards for scalar-only operations
-2. `Column.item_shape`, `ndim`, `size`
-3. tuple inner slicing
-4. direct comparison guard
-5. tests for the above
+1. [x] safety guards for scalar-only operations
+2. [x] `Column.item_shape`, `ndim`, `size`
+3. [x] tuple inner slicing
+4. [x] direct comparison guard
+5. [x] tests for the above
 
-This would make the existing core implementation much safer and substantially
-more ergonomic without taking on nullable columns or Arrow interop yet.
+Suggested next work:
+
+1. CSV/DataFrame ndarray-specific import/export behavior.
+2. Optional incremental generated-column refresh for only affected rows during
+   `Column.__setitem__`.
+3. Optional lazy lowering for row-transformers so selected row-wise ndarray
+   projections/reductions can become virtual computed columns later.

--- a/plans/ctable-ndarray-cols.md
+++ b/plans/ctable-ndarray-cols.md
@@ -637,7 +637,7 @@ suites:
 - [x] transitive generated-column stale marking / refresh
 - [x] Arrow roundtrip for `(n,)` and `(m, n)` shapes
 - [x] nullable ndarray columns once implemented
-- [ ] CSV/DataFrame ndarray-specific behavior once implemented
+- [x] CSV/DataFrame ndarray-specific behavior once implemented
 
 ---
 

--- a/src/blosc2/__init__.py
+++ b/src/blosc2/__init__.py
@@ -627,7 +627,15 @@ Disable the overloaded equal operator.
 # Delayed imports for avoiding overwriting of python builtins.
 # Note: bool, bytes, string shadow builtins in the blosc2 namespace by design —
 # they are schema spec constructors (b2.bool(), b2.bytes(), etc.).
-from .ctable import DEFAULT_NULL_POLICY, Column, CTable, NullPolicy, get_null_policy, null_policy
+from .ctable import (
+    DEFAULT_NULL_POLICY,
+    Column,
+    CTable,
+    NullPolicy,
+    RowTransformer,
+    get_null_policy,
+    null_policy,
+)
 from .groupby import CTableGroupBy, group_reduce
 from .ndarray import (
     abs,
@@ -759,6 +767,12 @@ from .schema import (
     vlstring,
 )
 
+# ``blosc2.ndarray`` is the fixed-shape CTable schema constructor.  Historically
+# some callers also accessed ``blosc2.ndarray.NDArray`` after importing the
+# package, so keep that compatibility attribute on the constructor function.
+ndarray.NDArray = NDArray
+ndarray.NDField = NDField
+
 __all__ = [  # noqa : RUF022
     # Constants
     "EXTENDED_HEADER_LENGTH",
@@ -812,6 +826,7 @@ __all__ = [  # noqa : RUF022
     "C2Array",
     "CParams",
     "CTableGroupBy",
+    "RowTransformer",
     "Batch",
     "BatchArray",
     # Enums

--- a/src/blosc2/__init__.py
+++ b/src/blosc2/__init__.py
@@ -732,6 +732,7 @@ from .ndarray import (
 )
 from .schema import (
     DictionarySpec,
+    NDArraySpec,
     bool,
     bytes,
     complex64,
@@ -745,6 +746,7 @@ from .schema import (
     int32,
     int64,
     list,
+    ndarray,
     object,
     string,
     struct,
@@ -785,6 +787,8 @@ __all__ = [  # noqa : RUF022
     "dictionary",
     "DictionarySpec",
     "field",
+    "ndarray",
+    "NDArraySpec",
     "float32",
     "float64",
     "int8",

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -1715,13 +1715,13 @@ class Column:
         if self.is_ndarray:
             if arr.ndim <= self.item_ndim:
                 arr = arr.reshape((1, *arr.shape))
-            if isinstance(nv, float) and np.isnan(nv):
+            if isinstance(nv, (float, np.floating)) and np.isnan(nv):
                 elem_mask = np.isnan(arr)
             else:
                 elem_mask = arr == nv
             inner_axes = tuple(range(1, elem_mask.ndim))
             return elem_mask.all(axis=inner_axes) if inner_axes else elem_mask.astype(np.bool_)
-        if isinstance(nv, float) and np.isnan(nv):
+        if isinstance(nv, (float, np.floating)) and np.isnan(nv):
             return np.isnan(arr)
         return arr == nv
 

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -957,6 +957,9 @@ class Column:
             if not (0 <= key < n_rows):
                 raise IndexError(f"index {key} is out of bounds for column with size {n_rows}")
             pos_true = _find_physical_index(self._valid_rows, key)
+            if self.is_ndarray:
+                spec = self._table._schema.columns_by_name[self._col_name].spec
+                value = CTable._coerce_ndarray_value(self._col_name, spec, value)
             self._raw_col[int(pos_true)] = value
 
         elif isinstance(key, np.ndarray) and key.dtype == np.bool_:
@@ -973,7 +976,10 @@ class Column:
                 for pos, cell in zip(phys_indices, value, strict=True):
                     self._raw_col[int(pos)] = cell
             else:
-                if isinstance(value, (list, tuple)):
+                if self.is_ndarray:
+                    spec = self._table._schema.columns_by_name[self._col_name].spec
+                    value = CTable._coerce_ndarray_batch(self._col_name, spec, value, len(phys_indices))
+                elif isinstance(value, (list, tuple)):
                     value = np.array(value, dtype=self._raw_col.dtype)
                 self._raw_col[phys_indices] = value
 
@@ -991,7 +997,10 @@ class Column:
                 for pos, cell in zip(phys_indices, value, strict=True):
                     self._raw_col[int(pos)] = cell
             else:
-                if isinstance(value, (list, tuple)):
+                if self.is_ndarray:
+                    spec = self._table._schema.columns_by_name[self._col_name].spec
+                    value = CTable._coerce_ndarray_batch(self._col_name, spec, value, len(phys_indices))
+                elif isinstance(value, (list, tuple)):
                     value = np.array(value, dtype=self._raw_col.dtype)
                 self._raw_col[phys_indices] = value
 
@@ -1700,6 +1709,16 @@ class Column:
         nv = self.null_value
         if nv is None:
             return np.zeros(len(arr), dtype=np.bool_)
+        arr = np.asarray(arr)
+        if self.is_ndarray:
+            if arr.ndim <= self.item_ndim:
+                arr = arr.reshape((1, *arr.shape))
+            if isinstance(nv, float) and np.isnan(nv):
+                elem_mask = np.isnan(arr)
+            else:
+                elem_mask = arr == nv
+            inner_axes = tuple(range(1, elem_mask.ndim))
+            return elem_mask.all(axis=inner_axes) if inner_axes else elem_mask.astype(np.bool_)
         if isinstance(nv, float) and np.isnan(nv):
             return np.isnan(arr)
         return arr == nv
@@ -1905,6 +1924,9 @@ class Column:
 
     def _ndarray_values_for_reduction(self, where=None) -> np.ndarray:
         arr = np.asarray(self[:])
+        null_mask = self._null_mask_for(arr) if self.null_value is not None else None
+        if null_mask is not None and null_mask.any():
+            arr = arr[~null_mask]
         if where is None:
             return arr
         where = self._normalize_sum_where(where)
@@ -1917,9 +1939,14 @@ class Column:
                 raise ValueError(
                     f"Column reduction where= mask length {len(mask)} does not match live rows {len(self)}."
                 )
+            if null_mask is not None and len(null_mask) == len(mask):
+                mask = mask[~null_mask]
             return arr[mask]
         live_pos = np.where(self._valid_rows[:])[0]
-        return arr[mask[live_pos]]
+        row_mask = mask[live_pos]
+        if null_mask is not None and len(null_mask) == len(row_mask):
+            row_mask = row_mask[~null_mask]
+        return arr[row_mask]
 
     def _ndarray_reduce(self, op: str, *, axis=None, dtype=None, where=None, ddof: int = 0):
         arr = self._ndarray_values_for_reduction(where=where)
@@ -2624,6 +2651,46 @@ class CTable(Generic[RowT]):
         return (capacity,)
 
     @staticmethod
+    def _ndarray_null_item(spec: NDArraySpec) -> np.ndarray:
+        null_value = getattr(spec, "null_value", None)
+        if null_value is None:
+            raise TypeError("NDArraySpec is not nullable")
+        return np.full(spec.item_shape, null_value, dtype=spec.dtype)
+
+    @staticmethod
+    def _coerce_ndarray_value(name: str, spec: NDArraySpec, val) -> np.ndarray:
+        if val is None:
+            if getattr(spec, "null_value", None) is None:
+                raise TypeError(f"Column {name!r} is not nullable; received None.")
+            return CTable._ndarray_null_item(spec)
+        arr = np.asarray(val, dtype=spec.dtype)
+        if arr.shape != spec.item_shape:
+            raise ValueError(f"Column {name!r}: expected item shape {spec.item_shape}, got {arr.shape}")
+        return np.ascontiguousarray(arr)
+
+    @staticmethod
+    def _coerce_ndarray_batch(name: str, spec: NDArraySpec, values, nrows: int) -> np.ndarray:
+        if values is None:
+            null_item = CTable._coerce_ndarray_value(name, spec, None)
+            return np.broadcast_to(null_item, (nrows, *spec.item_shape)).copy()
+        if isinstance(values, np.ndarray) and values.dtype != object:
+            arr = np.ascontiguousarray(values, dtype=spec.dtype)
+            if arr.ndim == len(spec.item_shape):
+                arr = arr.reshape((1, *arr.shape))
+            if arr.shape != (nrows, *spec.item_shape):
+                raise ValueError(
+                    f"Column {name!r}: expected batch shape {(nrows, *spec.item_shape)}, got {arr.shape}"
+                )
+            return arr
+        rows = [CTable._coerce_ndarray_value(name, spec, value) for value in values]
+        arr = np.ascontiguousarray(rows, dtype=spec.dtype)
+        if arr.shape != (nrows, *spec.item_shape):
+            raise ValueError(
+                f"Column {name!r}: expected batch shape {(nrows, *spec.item_shape)}, got {arr.shape}"
+            )
+        return arr
+
+    @staticmethod
     def _column_chunks_blocks(col: CompiledColumn, shape: tuple[int, ...]):
         return compute_chunks_blocks(shape, dtype=col.dtype)
 
@@ -2633,6 +2700,19 @@ class CTable(Generic[RowT]):
 
     @staticmethod
     def _policy_null_value_for_spec(spec: SchemaSpec, policy: NullPolicy):
+        if isinstance(spec, NDArraySpec):
+            dtype = spec.dtype
+            if dtype == np.dtype(np.bool_):
+                return policy.bool_value
+            if dtype.kind == "i":
+                info = np.iinfo(dtype)
+                return info.min if policy.signed_int_strategy == "min" else info.max
+            if dtype.kind == "u":
+                info = np.iinfo(dtype)
+                return info.min if policy.unsigned_int_strategy == "min" else info.max
+            if dtype.kind == "f":
+                return policy.float_value
+            return None
         if isinstance(spec, (int8, int16, int32, int64)):
             info = np.iinfo(spec.dtype)
             return info.min if policy.signed_int_strategy == "min" else info.max
@@ -2652,7 +2732,30 @@ class CTable(Generic[RowT]):
         return None
 
     @staticmethod
-    def _validate_null_value_for_spec(name: str, spec: SchemaSpec, null_value) -> None:
+    def _validate_null_value_for_spec(name: str, spec: SchemaSpec, null_value) -> None:  # noqa: C901
+        if isinstance(spec, NDArraySpec):
+            dtype = spec.dtype
+            if dtype == np.dtype(np.bool_):
+                if null_value != 255:
+                    raise ValueError(f"Null sentinel for nullable bool ndarray column {name!r} must be 255")
+                return
+            if dtype.kind in "iu":
+                if isinstance(null_value, (bool, np.bool_)) or not isinstance(null_value, (int, np.integer)):
+                    raise TypeError(f"Null sentinel for ndarray column {name!r} must be an integer")
+                info = np.iinfo(dtype)
+                if not info.min <= int(null_value) <= info.max:
+                    raise ValueError(
+                        f"Null sentinel for ndarray column {name!r}={null_value!r} is outside {dtype} range"
+                    )
+                return
+            if dtype.kind == "f":
+                if not isinstance(null_value, (int, float, np.integer, np.floating)):
+                    raise TypeError(f"Null sentinel for ndarray column {name!r} must be numeric")
+                return
+            raise TypeError(
+                f"Nullable ndarray column {name!r} has unsupported dtype {dtype!r}; "
+                "use bool, integer, unsigned integer, or floating dtype."
+            )
         if isinstance(spec, (int8, int16, int32, int64, uint8, uint16, uint32, uint64, timestamp)):
             if isinstance(null_value, (bool, np.bool_)) or not isinstance(null_value, (int, np.integer)):
                 raise TypeError(f"Null sentinel for column {name!r} must be an integer")
@@ -2689,6 +2792,18 @@ class CTable(Generic[RowT]):
             raise KeyError(f"column_null_values contains unknown columns: {names}")
         for col in schema.columns:
             spec = col.spec
+            if isinstance(spec, NDArraySpec) and getattr(spec, "null_value", None) is not None:
+                cls._validate_null_value_for_spec(col.name, spec, spec.null_value)
+                if spec.dtype == np.dtype(np.bool_):
+                    spec.dtype = np.dtype(np.uint8)
+                    spec.itemsize = spec.dtype.itemsize
+                    spec.kind = spec.dtype.kind
+                    spec.type = spec.dtype.type
+                    spec.str = spec.dtype.str
+                    spec.name = spec.dtype.name
+                col.dtype = getattr(spec, "dtype", None)
+                col.display_width = compute_display_width(spec)
+                continue
             if (
                 isinstance(
                     spec,
@@ -2714,6 +2829,13 @@ class CTable(Generic[RowT]):
                 spec.dtype = np.dtype(f"S{spec.max_length}")
             elif isinstance(spec, b2_bool):
                 spec.dtype = np.dtype(np.uint8)
+            elif isinstance(spec, NDArraySpec) and spec.dtype == np.dtype(np.bool_):
+                spec.dtype = np.dtype(np.uint8)
+                spec.itemsize = spec.dtype.itemsize
+                spec.kind = spec.dtype.kind
+                spec.type = spec.dtype.type
+                spec.str = spec.dtype.str
+                spec.name = spec.dtype.name
             col.dtype = getattr(spec, "dtype", None)
             col.display_width = compute_display_width(spec)
 
@@ -2861,12 +2983,7 @@ class CTable(Generic[RowT]):
                 # Pass str/None through; DictionaryColumn.__setitem__ encodes.
                 result[col.name] = val
             elif self._is_ndarray_column(col):
-                arr = np.asarray(val, dtype=col.dtype)
-                if arr.shape != col.spec.item_shape:
-                    raise ValueError(
-                        f"Column {col.name!r}: expected item shape {col.spec.item_shape}, got {arr.shape}"
-                    )
-                result[col.name] = np.ascontiguousarray(arr)
+                result[col.name] = self._coerce_ndarray_value(col.name, col.spec, val)
             elif isinstance(col.spec, timestamp):
                 if val is None:
                     result[col.name] = col.spec.null_value
@@ -4308,8 +4425,12 @@ class CTable(Generic[RowT]):
                     continue
                 if col.is_ndarray:
                     spec = self._schema.columns_by_name[name].spec
-                    arr = np.asarray(col[start:stop]).reshape((stop - start, -1))
-                    arrays.append(pa.array(arr.tolist(), type=self._pa_type_from_spec(pa, spec)))
+                    values = np.asarray(col[start:stop])
+                    null_mask = col._null_mask_for(values) if col.null_value is not None else None
+                    flat_values = values.reshape((stop - start, -1)).tolist()
+                    if null_mask is not None and null_mask.any():
+                        flat_values = [None if null_mask[i] else v for i, v in enumerate(flat_values)]
+                    arrays.append(pa.array(flat_values, type=self._pa_type_from_spec(pa, spec)))
                     continue
                 arr = np.asarray(col[start:stop])
                 nv = col.null_value
@@ -4429,7 +4550,7 @@ class CTable(Generic[RowT]):
                     f"Arrow fixed-size-list metadata shape {shape} has size {int(np.prod(shape))}, "
                     f"but the Arrow list size is {pa_type.list_size}."
                 )
-            return b2s.ndarray(shape, dtype=value_dtype)
+            return b2s.ndarray(shape, dtype=value_dtype, nullable=nullable, null_value=null_value)
 
         if pa.types.is_dictionary(pa_type):
             vt = pa_type.value_type
@@ -4618,13 +4739,11 @@ class CTable(Generic[RowT]):
             null_value = None
             has_null_value_override = name in column_null_values
             if has_null_value_override and (
-                field_is_list
-                or field_is_ndarray
-                or field_is_struct
-                or field_is_dictionary
-                or field_is_object_fallback
+                field_is_list or field_is_struct or field_is_dictionary or field_is_object_fallback
             ):
-                raise TypeError(f"column_null_values only supports scalar columns; {name!r} is not scalar")
+                raise TypeError(
+                    f"column_null_values only supports scalar columns and ndarray columns; {name!r} is not scalar"
+                )
             if has_null_value_override and field_is_varlen_scalar:
                 raise TypeError(
                     f"column_null_values is not supported for vlstring/vlbytes column {name!r}; "
@@ -4637,20 +4756,19 @@ class CTable(Generic[RowT]):
                 and field.nullable
                 and not (
                     field_is_list
-                    or field_is_ndarray
                     or field_is_struct
                     or field_is_dictionary
                     or field_is_varlen_scalar
                     or field_is_object_fallback
                 )
             ):
-                null_value = cls._auto_null_sentinel(pa, field.type, null_policy=null_policy)
+                arrow_type_for_null = field.type.value_type if field_is_ndarray else field.type
+                null_value = cls._auto_null_sentinel(pa, arrow_type_for_null, null_policy=null_policy)
             if (
                 arrow_col is not None
                 and arrow_col.null_count
                 and not (
                     field_is_list
-                    or field_is_ndarray
                     or field_is_struct
                     or field_is_dictionary
                     or field_is_varlen_scalar
@@ -4674,7 +4792,6 @@ class CTable(Generic[RowT]):
             )
             if null_value is not None and not (
                 field_is_list
-                or field_is_ndarray
                 or field_is_struct
                 or field_is_dictionary
                 or field_is_varlen_scalar
@@ -4912,9 +5029,7 @@ class CTable(Generic[RowT]):
             return np.array([nv if v is None else int(v) for v in arrow_col.to_pylist()], dtype=np.uint8)
         if isinstance(col.spec, NDArraySpec):
             values = arrow_col.to_pylist()
-            if any(v is None for v in values):
-                raise TypeError(f"Nullable ndarray Arrow column {col.name!r} is not supported yet.")
-            arr = np.asarray(values, dtype=col.dtype)
+            arr = CTable._coerce_ndarray_batch(col.name, col.spec, values, len(values))
             return arr.reshape((len(values), *col.spec.item_shape))
         if isinstance(col.spec, timestamp):
             arr = (
@@ -5931,11 +6046,7 @@ class CTable(Generic[RowT]):
             if default is not MISSING:
                 try:
                     if self._is_ndarray_column(compiled_col):
-                        default_val = np.asarray(default, dtype=spec.dtype)
-                        if default_val.shape != spec.item_shape:
-                            raise ValueError(
-                                f"expected item shape {spec.item_shape}, got {default_val.shape}"
-                            )
+                        default_val = self._coerce_ndarray_value(name, spec, default)
                     else:
                         default_val = spec.dtype.type(default)
                 except (ValueError, OverflowError) as exc:
@@ -9020,15 +9131,9 @@ class CTable(Generic[RowT]):
                         )
                     scalar_processed_cols[name] = np.ascontiguousarray(values, dtype=target_dtype)
                 elif self._is_ndarray_column(col_meta):
-                    values = np.ascontiguousarray(raw_columns[name], dtype=target_dtype)
-                    if values.ndim == len(col_meta.spec.item_shape):
-                        values = values.reshape((1, *values.shape))
-                    if values.shape != (new_nrows, *col_meta.spec.item_shape):
-                        raise ValueError(
-                            f"Column {name!r}: expected batch shape "
-                            f"{(new_nrows, *col_meta.spec.item_shape)}, got {values.shape}"
-                        )
-                    scalar_processed_cols[name] = values
+                    scalar_processed_cols[name] = self._coerce_ndarray_batch(
+                        name, col_meta.spec, raw_columns[name], new_nrows
+                    )
                 else:
                     scalar_processed_cols[name] = np.ascontiguousarray(raw_columns[name], dtype=target_dtype)
 

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -5783,8 +5783,8 @@ class CTable(Generic[RowT]):
         """Write all live rows to a CSV file.
 
         Uses Python's stdlib ``csv`` module — no extra dependency required.
-        Each column is materialised once via ``col[:]``; rows
-        are then written one at a time.
+        Fixed-shape ndarray column cells are serialised as JSON arrays for
+        readability and shape safety (e.g. ``"[1.0, 2.0, 3.0]"``).
 
         Parameters
         ----------
@@ -5797,7 +5797,22 @@ class CTable(Generic[RowT]):
         """
         import csv
 
-        arrays = [self[name][:] for name in self.col_names]
+        n = len(self)
+        arrays: list = []
+        for name in self.col_names:
+            col = self[name]
+            if col.is_ndarray:
+                arr = col[:]
+                null_mask = col._null_mask_for(arr)
+                json_strings: list[str] = []
+                for i in range(n):
+                    if null_mask[i]:
+                        json_strings.append("")
+                    else:
+                        json_strings.append(json.dumps(arr[i].tolist()))
+                arrays.append(json_strings)
+            else:
+                arrays.append(col[:])
 
         with open(path, "w", newline="") as f:
             writer = csv.writer(f, delimiter=sep)
@@ -5805,6 +5820,29 @@ class CTable(Generic[RowT]):
                 writer.writerow(self.col_names)
             for row in zip(*arrays, strict=True):
                 writer.writerow(row)
+
+    @staticmethod
+    def _csv_ndarray_col_to_array(raw: list[str], col) -> np.ndarray:
+        """Convert a list of JSON-array CSV strings to a stacked ndarray for an ndarray column."""
+        spec = col.spec
+        null_value = getattr(spec, "null_value", None)
+        item_shape = spec.item_shape
+        dtype = spec.dtype
+
+        rows = []
+        for val in raw:
+            stripped = val.strip()
+            if stripped == "" and null_value is not None:
+                rows.append(np.full(item_shape, null_value, dtype=dtype))
+            else:
+                arr = np.array(json.loads(stripped), dtype=dtype)
+                if arr.shape != item_shape:
+                    raise ValueError(
+                        f"Column {col.name!r}: expected item shape {item_shape}, got {arr.shape}"
+                    )
+                rows.append(arr)
+
+        return np.ascontiguousarray(rows, dtype=dtype)
 
     @staticmethod
     def _csv_col_to_array(raw: list[str], col, nv) -> np.ndarray:
@@ -5930,9 +5968,164 @@ class CTable(Generic[RowT]):
 
         if n > 0:
             for i, col in enumerate(schema.columns):
-                nv = getattr(col.spec, "null_value", None)
-                arr = cls._csv_col_to_array(col_data[i], col, nv)
+                if isinstance(col.spec, NDArraySpec):
+                    arr = cls._csv_ndarray_col_to_array(col_data[i], col)
+                else:
+                    nv = getattr(col.spec, "null_value", None)
+                    arr = cls._csv_col_to_array(col_data[i], col, nv)
                 new_cols[col.name][:n] = arr
+            new_valid[:n] = True
+            obj._n_rows = n
+            obj._last_pos = n
+
+        return obj
+
+    # ------------------------------------------------------------------
+    # Pandas / DataFrame interop
+    # ------------------------------------------------------------------
+
+    def to_pandas(self):
+        """Convert to a `pandas <https://pandas.pydata.org>`_ DataFrame.
+
+        Scalar columns become regular DataFrame columns.  Fixed-shape ndarray
+        columns become ``object``-dtype columns whose cells hold NumPy arrays
+        of per-row shape *item_shape*.
+
+        Returns
+        -------
+        pandas.DataFrame
+
+        Examples
+        --------
+        >>> import blosc2
+        >>> from dataclasses import dataclass
+        >>> import numpy as np
+        >>> @dataclass
+        ... class Row:
+        ...     id: int = blosc2.field(blosc2.int64())
+        ...     embedding: object = blosc2.field(blosc2.ndarray((3,), dtype=blosc2.float32()))
+        >>> t = blosc2.CTable(Row, new_data=[
+        ...     (1, np.array([1, 2, 3], dtype=np.float32)),
+        ...     (2, np.array([4, 5, 6], dtype=np.float32)),
+        ... ])
+        >>> df = t.to_pandas()
+        >>> df["id"].tolist()
+        [1, 2]
+        >>> df["embedding"].dtype
+        dtype('O')
+        >>> np.testing.assert_array_equal(df["embedding"][0], np.array([1, 2, 3], dtype=np.float32))
+        """
+        import pandas as pd
+
+        data = {}
+        n = len(self)
+        for name in self.col_names:
+            col = self[name]
+            if col.is_ndarray:
+                data[name] = [col[i] for i in range(n)]
+            else:
+                data[name] = col[:]
+
+        return pd.DataFrame(data)
+
+    @classmethod
+    def from_pandas(cls, df, row_cls) -> CTable:
+        """Build a :class:`CTable` from a pandas DataFrame.
+
+        Schema comes from *row_cls* (a dataclass) — CTable is always typed.
+        Object-dtype DataFrame columns are **not** automatically inferred as
+        ndarray columns; the *row_cls* must explicitly declare
+        :func:`blosc2.ndarray` fields.
+
+        Parameters
+        ----------
+        df:
+            Source pandas DataFrame.
+        row_cls:
+            A dataclass whose fields define the column names and types.
+
+        Returns
+        -------
+        CTable
+            A new CTable containing all DataFrame rows.
+
+        Raises
+        ------
+        TypeError
+            If *row_cls* is not a dataclass.
+        ValueError
+            If DataFrame columns do not match the *row_cls* schema.
+        """
+        schema = compile_schema(row_cls)
+        cls._resolve_nullable_specs(schema)
+
+        # Validate column names
+        schema_names = [col.name for col in schema.columns]
+        missing = [name for name in schema_names if name not in df.columns]
+        if missing:
+            raise ValueError(f"DataFrame missing columns declared in row_cls: {missing}")
+        extra = [name for name in df.columns if name not in schema_names]
+        if extra:
+            raise ValueError(f"DataFrame has extra columns not in row_cls: {extra}")
+
+        n = len(df)
+        capacity = max(n, 1)
+        default_chunks, default_blocks = compute_chunks_blocks((capacity,))
+        mem_storage = InMemoryTableStorage()
+
+        new_valid = mem_storage.create_valid_rows(
+            shape=(capacity,),
+            chunks=default_chunks,
+            blocks=default_blocks,
+        )
+        new_cols: dict[str, blosc2.NDArray] = {}
+        for col in schema.columns:
+            shape = cls._column_physical_shape(col, capacity)
+            chunks, blocks = cls._column_chunks_blocks(col, shape)
+            new_cols[col.name] = mem_storage.create_column(
+                col.name,
+                dtype=col.dtype,
+                shape=shape,
+                chunks=chunks,
+                blocks=blocks,
+                cparams=None,
+                dparams=None,
+            )
+
+        obj = cls.__new__(cls)
+        obj._row_type = row_cls
+        obj._validate = True
+        obj._table_cparams = None
+        obj._table_dparams = None
+        obj._storage = mem_storage
+        obj._read_only = False
+        obj._schema = schema
+        obj._cols = new_cols
+        obj._col_widths = {col.name: max(len(col.name), col.display_width) for col in schema.columns}
+        obj.col_names = [col.name for col in schema.columns]
+        obj.auto_compact = False
+        obj.base = None
+        obj._computed_cols = {}
+        obj._materialized_cols = {}
+        obj._expr_index_arrays = {}
+        obj._valid_rows = new_valid
+        obj._n_rows = 0
+        obj._last_pos = 0
+
+        if n > 0:
+            for col in schema.columns:
+                series = df[col.name]
+                if isinstance(col.spec, NDArraySpec):
+                    vals = series.values
+                    if vals.dtype != object:
+                        raise ValueError(
+                            f"Column {col.name!r}: expected object dtype in DataFrame "
+                            f"for ndarray column, got {vals.dtype}"
+                        )
+                    batch = cls._coerce_ndarray_batch(col.name, col.spec, vals, n)
+                    new_cols[col.name][:n] = batch
+                else:
+                    new_cols[col.name][:n] = series.to_numpy(dtype=col.dtype)
             new_valid[:n] = True
             obj._n_rows = n
             obj._last_pos = n

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
 from blosc2.schema import (
     DictionarySpec,
     ListSpec,
+    NDArraySpec,
     ObjectSpec,
     SchemaSpec,
     StructSpec,
@@ -567,6 +568,12 @@ class Column:
         return col is not None and isinstance(col.spec, DictionarySpec)
 
     @property
+    def is_ndarray(self) -> bool:
+        """True if this column stores fixed-shape N-D array values per row."""
+        col = self._table._schema.columns_by_name.get(self._col_name)
+        return col is not None and isinstance(col.spec, NDArraySpec)
+
+    @property
     def _valid_rows(self):
         if self._mask is None:
             return self._table._valid_rows
@@ -608,11 +615,12 @@ class Column:
             real_pos = np.where(self._valid_rows[:])[0]
             start, stop, step = key.indices(len(real_pos))
             if start >= stop:
-                return (
-                    []
-                    if (self.is_list or self.is_varlen_scalar or self.is_dictionary)
-                    else np.array([], dtype=self.dtype)
-                )
+                if self.is_list or self.is_varlen_scalar or self.is_dictionary:
+                    return []
+                if self.is_ndarray:
+                    spec = self._table._schema.columns_by_name[self._col_name].spec
+                    return np.empty((0, *spec.item_shape), dtype=self.dtype)
+                return np.array([], dtype=self.dtype)
             selected_pos = real_pos[start:stop:step]  # physical row positions
             if self.is_computed:
                 lo, hi = int(selected_pos.min()), int(selected_pos.max())
@@ -838,8 +846,11 @@ class Column:
         return blosc2.count_nonzero(self._valid_rows)
 
     @property
-    def shape(self) -> tuple[int]:
+    def shape(self) -> tuple[int, ...]:
         """Logical shape of the live column values."""
+        if self.is_ndarray:
+            spec = self._table._schema.columns_by_name[self._col_name].spec
+            return (len(self), *spec.item_shape)
         return (len(self),)
 
     @property
@@ -2215,6 +2226,20 @@ class CTable(Generic[RowT]):
         return isinstance(col.spec, DictionarySpec)
 
     @staticmethod
+    def _is_ndarray_column(col: CompiledColumn) -> bool:
+        return isinstance(col.spec, NDArraySpec)
+
+    @staticmethod
+    def _column_physical_shape(col: CompiledColumn, capacity: int) -> tuple[int, ...]:
+        if CTable._is_ndarray_column(col):
+            return (capacity, *col.spec.item_shape)
+        return (capacity,)
+
+    @staticmethod
+    def _column_chunks_blocks(col: CompiledColumn, shape: tuple[int, ...]):
+        return compute_chunks_blocks(shape, dtype=col.dtype)
+
+    @staticmethod
     def _is_list_spec(spec: SchemaSpec) -> bool:
         return isinstance(spec, ListSpec)
 
@@ -2352,12 +2377,13 @@ class CTable(Generic[RowT]):
             # string columns (e.g. U183642) don't produce multi-GB chunks.
             chunks = col_storage["chunks"]
             blocks = col_storage["blocks"]
+            shape = self._column_physical_shape(col, expected_size)
             if col.config.chunks is None and col.config.blocks is None:
-                chunks, blocks = compute_chunks_blocks((expected_size,), dtype=col.dtype)
+                chunks, blocks = self._column_chunks_blocks(col, shape)
             self._cols[col.name] = storage.create_column(
                 col.name,
                 dtype=col.dtype,
-                shape=(expected_size,),
+                shape=shape,
                 chunks=chunks,
                 blocks=blocks,
                 cparams=col_storage.get("cparams"),
@@ -2446,6 +2472,13 @@ class CTable(Generic[RowT]):
             elif self._is_dictionary_column(col):
                 # Pass str/None through; DictionaryColumn.__setitem__ encodes.
                 result[col.name] = val
+            elif self._is_ndarray_column(col):
+                arr = np.asarray(val, dtype=col.dtype)
+                if arr.shape != col.spec.item_shape:
+                    raise ValueError(
+                        f"Column {col.name!r}: expected item shape {col.spec.item_shape}, got {arr.shape}"
+                    )
+                result[col.name] = np.ascontiguousarray(arr)
             elif isinstance(col.spec, timestamp):
                 if val is None:
                     result[col.name] = col.spec.null_value
@@ -2518,7 +2551,7 @@ class CTable(Generic[RowT]):
             if self._is_dictionary_column(cc):
                 col_arr.resize((c * 2,))
                 continue
-            col_arr.resize((c * 2,))
+            col_arr.resize(self._column_physical_shape(cc, c * 2))
         self._valid_rows.resize((c * 2,))
 
     # ------------------------------------------------------------------
@@ -3044,12 +3077,13 @@ class CTable(Generic[RowT]):
                     raw_codes = np.asarray(src_dc.codes[live_pos], dtype=np.int32)
                     disk_dc.codes[:n_live] = raw_codes
                 continue
-            dtype_chunks, dtype_blocks = compute_chunks_blocks((capacity,), dtype=col.dtype)
+            shape = self._column_physical_shape(col, capacity)
+            dtype_chunks, dtype_blocks = self._column_chunks_blocks(col, shape)
             col_storage = self._resolve_column_storage(col, dtype_chunks, dtype_blocks)
             disk_col = storage.create_column(
                 name,
                 dtype=col.dtype,
-                shape=(capacity,),
+                shape=shape,
                 chunks=col_storage["chunks"],
                 blocks=col_storage["blocks"],
                 cparams=col_storage.get("cparams"),
@@ -3253,11 +3287,12 @@ class CTable(Generic[RowT]):
                     mem_col.codes[:phys_size] = disk_dc.codes[:phys_size]
                 mem_cols[name] = mem_col
                 continue
-            col_chunks, col_blocks = compute_chunks_blocks((capacity,), dtype=col.dtype)
+            shape = cls._column_physical_shape(col, capacity)
+            col_chunks, col_blocks = cls._column_chunks_blocks(col, shape)
             mem_col = mem_storage.create_column(
                 name,
                 dtype=col.dtype,
-                shape=(capacity,),
+                shape=shape,
                 chunks=col_chunks,
                 blocks=col_blocks,
                 cparams=None,
@@ -4260,13 +4295,14 @@ class CTable(Generic[RowT]):
                     col.name, spec=col.spec, cparams=cparams, dparams=dparams
                 )
             else:
+                shape = cls._column_physical_shape(col, capacity)
                 chunks, blocks = default_chunks, default_blocks
                 if col.dtype is not None:
-                    chunks, blocks = compute_chunks_blocks((capacity,), dtype=col.dtype)
+                    chunks, blocks = cls._column_chunks_blocks(col, shape)
                 new_cols[col.name] = storage.create_column(
                     col.name,
                     dtype=col.dtype,
-                    shape=(capacity,),
+                    shape=shape,
                     chunks=chunks,
                     blocks=blocks,
                     cparams=col.config.cparams if col.config.cparams is not None else cparams,
@@ -5285,12 +5321,14 @@ class CTable(Generic[RowT]):
         )
         new_cols: dict[str, blosc2.NDArray] = {}
         for col in schema.columns:
+            shape = cls._column_physical_shape(col, capacity)
+            chunks, blocks = cls._column_chunks_blocks(col, shape)
             new_cols[col.name] = mem_storage.create_column(
                 col.name,
                 dtype=col.dtype,
-                shape=(capacity,),
-                chunks=default_chunks,
-                blocks=default_blocks,
+                shape=shape,
+                chunks=chunks,
+                blocks=blocks,
                 cparams=None,
                 dparams=None,
             )
@@ -5361,7 +5399,7 @@ class CTable(Generic[RowT]):
             raise TypeError(f"add_column() requires a SchemaSpec, got {type(spec)!r}.")
         return spec, default, config
 
-    def add_column(
+    def add_column(  # noqa: C901
         self,
         name: str,
         spec: SchemaSpec | dataclasses.Field,
@@ -5432,7 +5470,14 @@ class CTable(Generic[RowT]):
         else:
             if default is not MISSING:
                 try:
-                    default_val = spec.dtype.type(default)
+                    if self._is_ndarray_column(compiled_col):
+                        default_val = np.asarray(default, dtype=spec.dtype)
+                        if default_val.shape != spec.item_shape:
+                            raise ValueError(
+                                f"expected item shape {spec.item_shape}, got {default_val.shape}"
+                            )
+                    else:
+                        default_val = spec.dtype.type(default)
                 except (ValueError, OverflowError) as exc:
                     raise TypeError(
                         f"Cannot coerce default {default!r} to dtype {spec.dtype!r}: {exc}"
@@ -5441,19 +5486,23 @@ class CTable(Generic[RowT]):
                 default_val = None
 
             capacity = len(self._valid_rows)
-            default_chunks, default_blocks = compute_chunks_blocks((capacity,))
+            shape = self._column_physical_shape(compiled_col, capacity)
+            default_chunks, default_blocks = self._column_chunks_blocks(compiled_col, shape)
             col_storage = self._resolve_column_storage(compiled_col, default_chunks, default_blocks)
             new_col = self._storage.create_column(
                 name,
                 dtype=spec.dtype,
-                shape=(capacity,),
+                shape=shape,
                 chunks=col_storage["chunks"],
                 blocks=col_storage["blocks"],
                 cparams=col_storage.get("cparams"),
                 dparams=col_storage.get("dparams"),
             )
             if len(live_pos) > 0:
-                new_col[live_pos] = default_val
+                if self._is_ndarray_column(compiled_col):
+                    new_col[live_pos] = np.broadcast_to(default_val, (len(live_pos), *spec.item_shape))
+                else:
+                    new_col[live_pos] = default_val
 
         compiled_col.default = default
         self._cols[name] = new_col
@@ -6143,6 +6192,9 @@ class CTable(Generic[RowT]):
                 or self._is_dictionary_column(col_info)
             ):
                 dtype = np.dtype(object)
+            elif self._is_ndarray_column(col_info):
+                fields.append((name, col_info.dtype, col_info.spec.item_shape))
+                continue
             else:
                 dtype = col_info.dtype if col_info.dtype is not None else np.dtype(object)
             fields.append((name, dtype))
@@ -6735,12 +6787,17 @@ class CTable(Generic[RowT]):
                     dparams=col_storage.get("dparams"),
                 )
             else:
+                shape = self._column_physical_shape(col, capacity)
+                chunks = col_storage["chunks"]
+                blocks = col_storage["blocks"]
+                if col.config.chunks is None and col.config.blocks is None:
+                    chunks, blocks = self._column_chunks_blocks(col, shape)
                 new_cols[col.name] = mem_storage.create_column(
                     col.name,
                     dtype=col.dtype,
-                    shape=(capacity,),
-                    chunks=col_storage["chunks"],
-                    blocks=col_storage["blocks"],
+                    shape=shape,
+                    chunks=chunks,
+                    blocks=blocks,
                     cparams=col_storage.get("cparams"),
                     dparams=col_storage.get("dparams"),
                 )
@@ -7740,6 +7797,8 @@ class CTable(Generic[RowT]):
             return spec.display_label()
         if isinstance(spec, ListSpec):
             return spec.display_label()
+        if isinstance(spec, NDArraySpec):
+            return spec.display_label()
         if isinstance(spec, timestamp):
             return (
                 f"timestamp[{spec.unit}]"
@@ -8034,6 +8093,16 @@ class CTable(Generic[RowT]):
                             dtype=target_dtype,
                         )
                     scalar_processed_cols[name] = np.ascontiguousarray(values, dtype=target_dtype)
+                elif self._is_ndarray_column(col_meta):
+                    values = np.ascontiguousarray(raw_columns[name], dtype=target_dtype)
+                    if values.ndim == len(col_meta.spec.item_shape):
+                        values = values.reshape((1, *values.shape))
+                    if values.shape != (new_nrows, *col_meta.spec.item_shape):
+                        raise ValueError(
+                            f"Column {name!r}: expected batch shape "
+                            f"{(new_nrows, *col_meta.spec.item_shape)}, got {values.shape}"
+                        )
+                    scalar_processed_cols[name] = values
                 else:
                     scalar_processed_cols[name] = np.ascontiguousarray(raw_columns[name], dtype=target_dtype)
 

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -15,6 +15,7 @@ import contextlib
 import contextvars
 import copy
 import dataclasses
+import json
 import os
 import pprint
 import re
@@ -528,6 +529,187 @@ def _make_namedtuple_row_type(col_names: tuple[str, ...]):
 # ---------------------------------------------------------------------------
 
 
+class RowTransformer:
+    """Row-wise transformer for fixed-shape ndarray columns.
+
+    A row transformer sees one table row at a time.  For a source column with
+    physical shape ``(nrows, *item_shape)``, axes passed to reductions are axes
+    within ``item_shape`` (so they are shifted by one for batch evaluation).
+    """
+
+    def __init__(
+        self,
+        source: str,
+        *,
+        selection=(),
+        op: str | None = None,
+        axis=None,
+        ord=None,
+    ) -> None:
+        self.source = source
+        self.selection = tuple(selection)
+        self.op = op
+        self.axis = axis
+        self.ord = ord
+        self.kind = "row_transformer"
+        self.source_columns = [source]
+
+    def __getitem__(self, key):
+        if not isinstance(key, tuple):
+            key = (key,)
+        return RowTransformer(
+            self.source,
+            selection=(*self.selection, *key),
+            op=self.op,
+            axis=self.axis,
+            ord=self.ord,
+        )
+
+    def _with_op(self, op: str, *, axis=None, ord=None):
+        return RowTransformer(self.source, selection=self.selection, op=op, axis=axis, ord=ord)
+
+    def sum(self, *, axis=None):
+        return self._with_op("sum", axis=axis)
+
+    def mean(self, *, axis=None):
+        return self._with_op("mean", axis=axis)
+
+    def min(self, *, axis=None):
+        return self._with_op("min", axis=axis)
+
+    def max(self, *, axis=None):
+        return self._with_op("max", axis=axis)
+
+    def norm(self, *, axis=None, ord=None):
+        return self._with_op("norm", axis=axis, ord=ord)
+
+    @staticmethod
+    def _serialize_selector(selector):
+        if isinstance(selector, slice):
+            return {"kind": "slice", "start": selector.start, "stop": selector.stop, "step": selector.step}
+        if selector is Ellipsis:
+            return {"kind": "ellipsis"}
+        if selector is None:
+            return {"kind": "newaxis"}
+        if isinstance(selector, (int, np.integer)):
+            return {"kind": "int", "value": int(selector)}
+        raise TypeError(f"Unsupported row-transformer selector {selector!r}")
+
+    @staticmethod
+    def _deserialize_selector(data):
+        kind = data["kind"]
+        if kind == "slice":
+            return slice(data.get("start"), data.get("stop"), data.get("step"))
+        if kind == "ellipsis":
+            return Ellipsis
+        if kind == "newaxis":
+            return None
+        if kind == "int":
+            return int(data["value"])
+        raise ValueError(f"Unsupported row-transformer selector kind {kind!r}")
+
+    @staticmethod
+    def _serialize_axis(axis):
+        if isinstance(axis, tuple):
+            return list(axis)
+        return axis
+
+    @staticmethod
+    def _deserialize_axis(axis):
+        if isinstance(axis, list):
+            return tuple(axis)
+        return axis
+
+    def to_metadata(self) -> dict:
+        meta = {
+            "kind": "row_transformer",
+            "source": self.source,
+            "selection": [self._serialize_selector(s) for s in self.selection],
+        }
+        if self.op is not None:
+            meta["op"] = self.op
+            meta["axis"] = self._serialize_axis(self.axis)
+            if self.ord is not None:
+                meta["ord"] = self.ord
+        return meta
+
+    @classmethod
+    def from_metadata(cls, meta: dict):
+        return cls(
+            meta["source"],
+            selection=tuple(cls._deserialize_selector(s) for s in meta.get("selection", ())),
+            op=meta.get("op"),
+            axis=cls._deserialize_axis(meta.get("axis")),
+            ord=meta.get("ord"),
+        )
+
+    def _row_axis_to_batch_axis(self, ndim: int, *, none_means_all_item: bool = False):
+        axis = self.axis
+        item_ndim = max(0, ndim - 1)
+        if axis is None:
+            return tuple(range(1, ndim)) if none_means_all_item and item_ndim else None
+
+        def one(ax):
+            ax = int(ax)
+            if ax < 0:
+                ax += item_ndim
+            if not 0 <= ax < item_ndim:
+                raise ValueError(f"axis {ax} is out of bounds for row item with {item_ndim} dimensions")
+            return ax + 1
+
+        if isinstance(axis, tuple):
+            return tuple(one(ax) for ax in axis)
+        return one(axis)
+
+    def _apply_selection(self, arr: np.ndarray) -> np.ndarray:
+        if not self.selection:
+            return arr
+        return arr[(slice(None), *self.selection)]
+
+    def evaluate_batch(self, raw_columns: Mapping[str, Any]) -> np.ndarray:
+        arr = np.asarray(raw_columns[self.source])
+        if arr.ndim == 0:
+            arr = arr.reshape((1,))
+        arr = self._apply_selection(arr)
+        if self.op is None:
+            return np.asarray(arr)
+        axis = self._row_axis_to_batch_axis(arr.ndim, none_means_all_item=True)
+        if self.op == "sum":
+            return np.asarray(np.sum(arr, axis=axis))
+        if self.op == "mean":
+            return np.asarray(np.mean(arr, axis=axis))
+        if self.op == "min":
+            return np.asarray(np.min(arr, axis=axis))
+        if self.op == "max":
+            return np.asarray(np.max(arr, axis=axis))
+        if self.op == "norm":
+            if self.axis is None:
+                return np.asarray(np.linalg.norm(arr.reshape((arr.shape[0], -1)), ord=self.ord, axis=1))
+            return np.asarray(np.linalg.norm(arr, ord=self.ord, axis=axis))
+        raise ValueError(f"Unsupported row-transformer op {self.op!r}")
+
+    def evaluate_row(self, row: Mapping[str, Any]):
+        arr = np.asarray(row[self.source])
+        if self.selection:
+            arr = arr[self.selection]
+        if self.op is None:
+            return arr
+        if self.op == "sum":
+            return np.sum(arr, axis=self.axis)
+        if self.op == "mean":
+            return np.mean(arr, axis=self.axis)
+        if self.op == "min":
+            return np.min(arr, axis=self.axis)
+        if self.op == "max":
+            return np.max(arr, axis=self.axis)
+        if self.op == "norm":
+            return np.linalg.norm(arr, ord=self.ord, axis=self.axis)
+        raise ValueError(f"Unsupported row-transformer op {self.op!r}")
+
+    def evaluate_existing(self, table: CTable) -> np.ndarray:
+        return self.evaluate_batch({self.source: table[self.source][:]})
+
+
 class Column:
     """Column view for a :class:`CTable`, with vectorized operations and reductions."""
 
@@ -600,6 +782,17 @@ class Column:
 
     def _values_from_key(self, key):  # noqa: C901
         """Materialise values for a logical index key."""
+        if isinstance(key, tuple) and self.is_ndarray:
+            if len(key) == 0:
+                raise IndexError("empty tuple index is not valid for Column")
+            row_key, inner_key = key[0], key[1:]
+            values = self._values_from_key(row_key)
+            if not inner_key:
+                return values
+            if isinstance(row_key, (int, np.integer)) and not isinstance(row_key, (bool, np.bool_)):
+                return values[inner_key]
+            return values[(slice(None), *inner_key)]
+
         if isinstance(key, int):
             n_rows = len(self)
             if key < 0:
@@ -774,7 +967,9 @@ class Column:
 
         else:
             raise TypeError(f"Invalid index type: {type(key)}")
-        self._table._root_table._mark_all_indexes_stale()
+        root = self._table._root_table
+        root._mark_generated_columns_stale(self._col_name)
+        root._mark_all_indexes_stale()
 
     def __iter__(self):
         """Iterate over live column values in insertion order, skipping deleted rows."""
@@ -805,6 +1000,13 @@ class Column:
             data_chunk = self._raw_col[chunk_start : chunk_start + actual_size]
             yield from data_chunk[mask_chunk]
 
+    @staticmethod
+    def _format_array_value(value) -> str:
+        arr = np.asarray(value)
+        if arr.ndim == 1 and arr.size <= 6:
+            return np.array2string(arr, separator=", ", max_line_width=10_000)
+        return f"ndarray(shape={arr.shape}, dtype={arr.dtype})"
+
     def __repr__(self) -> str:
         preview_len = self._REPR_PREVIEW_ITEMS + 1
         if self.is_list:
@@ -824,7 +1026,12 @@ class Column:
         if truncated:
             preview_values = preview_values[: self._REPR_PREVIEW_ITEMS]
 
-        if self.dtype is not None and self.dtype.kind in "biufc" and preview_values:
+        if self.is_ndarray and preview_values:
+            preview_items = [self._format_array_value(value) for value in preview_values]
+            if truncated:
+                preview_items.append("...")
+            preview = ", ".join(preview_items)
+        elif self.dtype is not None and self.dtype.kind in "biufc" and preview_values:
             arr = np.asarray(preview_values, dtype=self.dtype)
             preview = np.array2string(arr, separator=", ", max_line_width=10_000)[1:-1]
             if truncated:
@@ -852,6 +1059,42 @@ class Column:
             spec = self._table._schema.columns_by_name[self._col_name].spec
             return (len(self), *spec.item_shape)
         return (len(self),)
+
+    def summary(self) -> str:
+        """Return and print a compact summary for this column.
+
+        For fixed-shape ndarray columns this includes logical shape, storage, and
+        row-norm statistics when numeric.  Scalar columns fall back to ``info``.
+        """
+        if not self.is_ndarray:
+            text = str(self.info)
+            print(text)
+            return text
+        raw = self._raw_col
+        rows = len(self)
+        capacity = raw.shape[0] if hasattr(raw, "shape") else len(self._table._valid_rows)
+        lines = [
+            f"ndarray column {self._col_name!r}",
+            f"  rows       : {rows:,} live / {capacity:,} capacity",
+            f"  item_shape : {self.item_shape}",
+            f"  dtype      : {self.dtype}",
+            f"  storage    : NDArray shape={getattr(raw, 'shape', None)}, chunks={getattr(raw, 'chunks', None)}, blocks={getattr(raw, 'blocks', None)}",
+        ]
+        cbytes = getattr(raw, "cbytes", None)
+        if cbytes is not None:
+            lines.append(f"  cbytes     : {format_nbytes_info(cbytes)}")
+        if rows and self.dtype is not None and self.dtype.kind in "biufc":
+            flat = np.asarray(self[:]).reshape(rows, -1)
+            norms = np.linalg.norm(flat, axis=1)
+            lines.append(
+                "  row stats  : "
+                f"min(norm(axis=1))={norms.min():.6g}, "
+                f"mean(norm(axis=1))={norms.mean():.6g}, "
+                f"max(norm(axis=1))={norms.max():.6g}"
+            )
+        text = "\n".join(lines)
+        print(text)
+        return text
 
     @property
     def info(self) -> _CTableInfoReporter:
@@ -924,14 +1167,38 @@ class Column:
         return items
 
     @property
+    def item_shape(self) -> tuple[int, ...]:
+        """Per-row item shape; ``()`` for scalar columns."""
+        if self.is_ndarray:
+            return tuple(self._table._schema.columns_by_name[self._col_name].spec.item_shape)
+        return ()
+
+    @property
+    def item_ndim(self) -> int:
+        """Number of per-row item dimensions."""
+        return len(self.item_shape)
+
+    @property
+    def item_size(self) -> int:
+        """Number of scalar values stored in each row item."""
+        return int(np.prod(self.item_shape, dtype=np.int64)) if self.item_shape else 1
+
+    @property
     def ndim(self) -> int:
         """Number of logical dimensions."""
-        return 1
+        return 1 + self.item_ndim
 
     @property
     def size(self) -> int:
-        """Number of live values in the column."""
-        return len(self)
+        """Number of live scalar values in the logical column array."""
+        return len(self) * self.item_size
+
+    @property
+    def row_transformer(self) -> RowTransformer:
+        """Build row-wise projections/reductions for generated columns."""
+        if not self.is_ndarray:
+            raise TypeError(f"Column {self._col_name!r} is not a fixed-shape ndarray column.")
+        return RowTransformer(self._col_name)
 
     def _ensure_queryable(self) -> None:
         if self.is_varlen_scalar:
@@ -944,6 +1211,18 @@ class Column:
                 f"Column {self._col_name!r} is a dictionary column; "
                 "use == and isin() for dictionary column comparisons."
             )
+
+    def _raise_ndarray_compare(self) -> None:
+        raise TypeError(
+            f"Cannot compare ndarray column {self._col_name!r} directly; the result would not be a "
+            "1-D row mask. Use an element projection like t.embedding[:, 0] > 0.5 or an "
+            "axis-aware reduction like t.embedding.max(axis=1) > 0.5."
+        )
+
+    def _ensure_comparable(self) -> None:
+        self._ensure_queryable()
+        if self.is_ndarray:
+            self._raise_ndarray_compare()
 
     @staticmethod
     def _unwrap_operand(other):
@@ -976,6 +1255,8 @@ class Column:
 
     def _coerce_timestamp_operand(self, other):
         spec = self._timestamp_spec
+        if isinstance(other, Column) and other.is_ndarray:
+            other._raise_ndarray_compare()
         other = self._unwrap_operand(other)
         if spec is None:
             return other
@@ -1088,17 +1369,17 @@ class Column:
         return ~self._raw_col
 
     def __lt__(self, other):
-        self._ensure_queryable()
+        self._ensure_comparable()
         return self._raw_col < self._coerce_timestamp_operand(other)
 
     def __le__(self, other):
-        self._ensure_queryable()
+        self._ensure_comparable()
         return self._raw_col <= self._coerce_timestamp_operand(other)
 
     def __eq__(self, other):
         if self.is_dictionary:
             return self._dictionary_eq(other)
-        self._ensure_queryable()
+        self._ensure_comparable()
         if self._is_nullable_bool and isinstance(other, (bool, np.bool_)):
             return self._raw_col == int(other)
         return self._raw_col == self._coerce_timestamp_operand(other)
@@ -1109,7 +1390,7 @@ class Column:
             if isinstance(result, np.ndarray):
                 return ~result
             return ~np.asarray(result, dtype=bool)
-        self._ensure_queryable()
+        self._ensure_comparable()
         if self._is_nullable_bool and isinstance(other, (bool, np.bool_)):
             return self._raw_col == int(not other)
         return self._raw_col != self._coerce_timestamp_operand(other)
@@ -1188,11 +1469,11 @@ class Column:
         return mask
 
     def __gt__(self, other):
-        self._ensure_queryable()
+        self._ensure_comparable()
         return self._raw_col > self._coerce_timestamp_operand(other)
 
     def __ge__(self, other):
-        self._ensure_queryable()
+        self._ensure_comparable()
         return self._raw_col >= self._coerce_timestamp_operand(other)
 
     @property
@@ -1347,7 +1628,9 @@ class Column:
             live_pos = np.where(self._valid_rows[:])[0]
             for pos, cell in zip(live_pos, values, strict=True):
                 self._raw_col[int(pos)] = cell
-            self._table._root_table._mark_all_indexes_stale()
+            root = self._table._root_table
+            root._mark_generated_columns_stale(self._col_name)
+            root._mark_all_indexes_stale()
             return
         n_live = len(self)
         arr = np.asarray(data)
@@ -1359,7 +1642,9 @@ class Column:
             raise TypeError(f"Cannot coerce data to column dtype {self.dtype!r}: {exc}") from exc
         live_pos = np.where(self._valid_rows[:])[0]
         self._raw_col[live_pos] = arr
-        self._table._root_table._mark_all_indexes_stale()
+        root = self._table._root_table
+        root._mark_generated_columns_stale(self._col_name)
+        root._mark_all_indexes_stale()
 
     # ------------------------------------------------------------------
     # Null sentinel support
@@ -1584,7 +1869,39 @@ class Column:
         except Exception:
             return NotImplemented
 
-    def sum(self, dtype=None, *, where=None, jit=None, jit_backend=None):
+    def _ndarray_values_for_reduction(self, where=None) -> np.ndarray:
+        arr = np.asarray(self[:])
+        if where is None:
+            return arr
+        where = self._normalize_sum_where(where)
+        mask = where.compute() if isinstance(where, blosc2.LazyExpr) else where[:]
+        mask = np.asarray(mask, dtype=bool)
+        if mask.ndim != 1:
+            raise ValueError("Column reduction where= must be a 1-D row mask.")
+        if len(mask) != len(self._table._valid_rows):
+            if len(mask) != len(self):
+                raise ValueError(
+                    f"Column reduction where= mask length {len(mask)} does not match live rows {len(self)}."
+                )
+            return arr[mask]
+        live_pos = np.where(self._valid_rows[:])[0]
+        return arr[mask[live_pos]]
+
+    def _ndarray_reduce(self, op: str, *, axis=None, dtype=None, where=None, ddof: int = 0):
+        arr = self._ndarray_values_for_reduction(where=where)
+        if op == "sum":
+            return np.sum(arr, axis=axis, dtype=dtype)
+        if op == "mean":
+            return np.mean(arr, axis=axis, dtype=dtype)
+        if op == "min":
+            return np.min(arr, axis=axis)
+        if op == "max":
+            return np.max(arr, axis=axis)
+        if op == "std":
+            return np.std(arr, axis=axis, ddof=ddof, dtype=dtype)
+        raise ValueError(f"Unsupported ndarray reduction {op!r}")
+
+    def sum(self, dtype=None, axis=None, *, where=None, jit=None, jit_backend=None):
         """Sum of all live, non-null values.
 
         Returns zero for an empty column or filtered view.
@@ -1625,6 +1942,11 @@ class Column:
             # t.col2 is not its configured null sentinel.
             total = t.col2.sum(where=t.col1 < 300)
         """
+        if self.is_ndarray:
+            self._require_kind("biufc", "sum")
+            return self._ndarray_reduce("sum", axis=axis, dtype=dtype, where=where)
+        if axis not in (None, 0):
+            return np.sum(self[:], axis=axis, dtype=dtype)
         self._require_kind("biufc", "sum")
         where = self._normalize_sum_where(where)
         # Use a wide accumulator to reduce overflow risk
@@ -1696,7 +2018,7 @@ class Column:
             return NotImplemented
         return NotImplemented
 
-    def min(self, *, where=None):
+    def min(self, axis=None, *, where=None):
         """Minimum live, non-null value.
 
         Supported dtypes: bool, int, uint, float, string, bytes.
@@ -1704,6 +2026,11 @@ class Column:
         Null sentinel values are skipped. When *where* is provided, only rows
         matching the boolean predicate are included.
         """
+        if self.is_ndarray:
+            self._require_kind("biuf", "min")
+            return self._ndarray_reduce("min", axis=axis, where=where)
+        if axis not in (None, 0):
+            return np.min(self[:], axis=axis)
         self._require_kind("biufUS", "min")
         where = self._normalize_sum_where(where)
         if where is None:
@@ -1725,7 +2052,7 @@ class Column:
             raise ValueError("min() called on a column where all values are null.")
         return result
 
-    def max(self, *, where=None):
+    def max(self, axis=None, *, where=None):
         """Maximum live, non-null value.
 
         Supported dtypes: bool, int, uint, float, string, bytes.
@@ -1733,6 +2060,11 @@ class Column:
         Null sentinel values are skipped. When *where* is provided, only rows
         matching the boolean predicate are included.
         """
+        if self.is_ndarray:
+            self._require_kind("biuf", "max")
+            return self._ndarray_reduce("max", axis=axis, where=where)
+        if axis not in (None, 0):
+            return np.max(self[:], axis=axis)
         self._require_kind("biufUS", "max")
         where = self._normalize_sum_where(where)
         if where is None:
@@ -1752,7 +2084,7 @@ class Column:
             raise ValueError("max() called on a column where all values are null.")
         return result
 
-    def mean(self, *, where=None) -> float:
+    def mean(self, axis=None, *, where=None):
         """Arithmetic mean of all live, non-null values.
 
         Supported dtypes: bool, int, uint, float.
@@ -1760,6 +2092,11 @@ class Column:
         matching the boolean predicate are included.
         Always returns a Python float.
         """
+        if self.is_ndarray:
+            self._require_kind("biuf", "mean")
+            return self._ndarray_reduce("mean", axis=axis, where=where)
+        if axis not in (None, 0):
+            return np.mean(self[:], axis=axis)
         self._require_kind("biuf", "mean")
         where = self._normalize_sum_where(where)
         if where is None and len(self) == 0:
@@ -1780,7 +2117,7 @@ class Column:
             return float("nan")
         return float(total / count)
 
-    def std(self, ddof: int = 0, *, where=None) -> float:
+    def std(self, ddof: int = 0, axis=None, *, where=None):
         """Standard deviation of all live, non-null values (single-pass, Welford's algorithm).
 
         Parameters
@@ -1796,6 +2133,11 @@ class Column:
         Null sentinel values are skipped.
         Always returns a Python float.
         """
+        if self.is_ndarray:
+            self._require_kind("biuf", "std")
+            return self._ndarray_reduce("std", axis=axis, where=where, ddof=ddof)
+        if axis not in (None, 0):
+            return np.std(self[:], axis=axis, ddof=ddof)
         self._require_kind("biuf", "std")
         where = self._normalize_sum_where(where)
         if where is None and len(self) == 0:
@@ -1833,6 +2175,18 @@ class Column:
         if divisor <= 0:
             return float("nan")
         return float(np.sqrt(M2_total / divisor))
+
+    def norm(self, ord=None, axis=None, *, where=None):
+        """Vector/matrix norm of a fixed-shape ndarray column.
+
+        The column is treated as a logical array of shape ``(nrows, *item_shape)``.
+        For example, ``axis=1`` computes one norm per row for a 1-D item shape.
+        """
+        if not self.is_ndarray:
+            raise TypeError(f"Column.norm() is only supported for ndarray columns, got {self._col_name!r}.")
+        self._require_kind("biuf", "norm")
+        arr = self._ndarray_values_for_reduction(where=where)
+        return np.linalg.norm(arr, ord=ord, axis=axis)
 
     def any(self) -> bool:
         """Return True if at least one live, non-null value is True.
@@ -2633,6 +2987,11 @@ class CTable(Generic[RowT]):
             s = str(value).replace("T", " ")
             if s.endswith(".000"):
                 s = s[:-4]
+        elif isinstance(value, np.ndarray):
+            if value.ndim == 1 and value.size <= 6:
+                s = np.array2string(value, separator=", ", max_line_width=10_000)
+            else:
+                s = f"ndarray(shape={value.shape}, dtype={value.dtype})"
         else:
             s = str(value)
         if len(s) > width:
@@ -3588,7 +3947,13 @@ class CTable(Generic[RowT]):
             nc = col.null_count()
             n_nonnull = n - nc
 
-            if isinstance(spec.spec, ListSpec) if spec is not None else False:
+            if isinstance(spec.spec, NDArraySpec) if spec is not None else False:
+                lines.append(f"    count      : {n:,}")
+                lines.append(f"    item_shape : {spec.spec.item_shape}")
+                lines.append(
+                    "    (scalar stats not available for ndarray columns; use column reductions with axis=)"
+                )
+            elif isinstance(spec.spec, ListSpec) if spec is not None else False:
                 lines.append(f"    count : {n:,}")
                 lines.append("    (stats not available for list columns)")
             elif dtype.kind in "biufc" and dtype.kind != "c":
@@ -3662,6 +4027,12 @@ class CTable(Generic[RowT]):
             If the table has fewer than 2 live rows (covariance undefined).
         """
         for name in self.col_names:
+            col_info = self._schema.columns_by_name.get(name)
+            if col_info is not None and self._is_ndarray_column(col_info):
+                raise TypeError(
+                    f"Column {name!r} is a fixed-shape ndarray column and is not supported by cov(). "
+                    "Materialize scalar generated columns first."
+                )
             dtype = self._col_dtype(name)
             if dtype is None or not (
                 np.issubdtype(dtype, np.integer) or np.issubdtype(dtype, np.floating) or dtype == np.bool_
@@ -3782,6 +4153,8 @@ class CTable(Generic[RowT]):
             return pa.large_binary()
         if isinstance(spec, ListSpec):
             return pa.list_(CTable._pa_type_from_spec(pa, spec.item_spec))
+        if isinstance(spec, NDArraySpec):
+            return pa.list_(pa.from_numpy_dtype(spec.dtype), list_size=int(np.prod(spec.item_shape)))
         if isinstance(spec, timestamp):
             return pa.timestamp(spec.unit, tz=spec.timezone)
         if isinstance(spec, StructSpec):
@@ -3828,14 +4201,17 @@ class CTable(Generic[RowT]):
         fields = []
         for name, arrow_name in zip(names, arrow_names, strict=True):
             cc = self._schema.columns_by_name.get(name)
+            metadata = None
             if cc is not None:
                 pa_type = self._pa_type_from_spec(pa, cc.spec)
+                if isinstance(cc.spec, NDArraySpec):
+                    metadata = {b"blosc2:ndarray_shape": json.dumps(list(cc.spec.item_shape)).encode()}
             else:
                 pa_type = pa.from_numpy_dtype(np.asarray(self[name][:0]).dtype)
-            fields.append(pa.field(arrow_name, pa_type))
+            fields.append(pa.field(arrow_name, pa_type, metadata=metadata))
         return pa.schema(fields)
 
-    def iter_arrow_batches(
+    def iter_arrow_batches(  # noqa: C901
         self,
         *,
         columns: list[str] | None = None,
@@ -3895,6 +4271,11 @@ class CTable(Generic[RowT]):
                         arrays.append(
                             pa.DictionaryArray.from_arrays(pa_indices, pa_dict, ordered=spec.ordered)
                         )
+                    continue
+                if col.is_ndarray:
+                    spec = self._schema.columns_by_name[name].spec
+                    arr = np.asarray(col[start:stop]).reshape((stop - start, -1))
+                    arrays.append(pa.array(arr.tolist(), type=self._pa_type_from_spec(pa, spec)))
                     continue
                 arr = np.asarray(col[start:stop])
                 nv = col.null_value
@@ -3971,7 +4352,10 @@ class CTable(Generic[RowT]):
         if pa.types.is_timestamp(pa_type):
             return False
         return not (
-            pa.types.is_list(pa_type) or pa.types.is_large_list(pa_type) or pa.types.is_struct(pa_type)
+            pa.types.is_list(pa_type)
+            or pa.types.is_large_list(pa_type)
+            or pa.types.is_fixed_size_list(pa_type)
+            or pa.types.is_struct(pa_type)
         )
 
     @staticmethod
@@ -3980,6 +4364,7 @@ class CTable(Generic[RowT]):
         pa_type,
         arrow_col=None,
         *,
+        field_metadata=None,
         string_max_length=None,
         null_value=None,
         nullable=False,
@@ -3988,6 +4373,30 @@ class CTable(Generic[RowT]):
         import blosc2.schema as b2s
 
         # Handle Arrow dictionary types (dict-encoded strings)
+        if pa.types.is_fixed_size_list(pa_type):
+            shape = None
+            if field_metadata:
+                encoded = field_metadata.get(b"blosc2:ndarray_shape") or field_metadata.get(
+                    "blosc2:ndarray_shape"
+                )
+                if encoded is not None:
+                    if isinstance(encoded, bytes):
+                        encoded = encoded.decode()
+                    shape = tuple(int(x) for x in json.loads(encoded))
+            if shape is None:
+                shape = (int(pa_type.list_size),)
+            value_type = pa_type.value_type
+            value_spec = CTable._arrow_type_to_spec(pa, value_type, object_fallback=object_fallback)
+            value_dtype = getattr(value_spec, "dtype", None)
+            if value_dtype is None:
+                raise TypeError(f"FixedSizeList values must have a fixed NumPy dtype, got {value_type!r}")
+            if int(np.prod(shape)) != int(pa_type.list_size):
+                raise ValueError(
+                    f"Arrow fixed-size-list metadata shape {shape} has size {int(np.prod(shape))}, "
+                    f"but the Arrow list size is {pa_type.list_size}."
+                )
+            return b2s.ndarray(shape, dtype=value_dtype)
+
         if pa.types.is_dictionary(pa_type):
             vt = pa_type.value_type
             if vt in (pa.string(), pa.large_string(), pa.utf8(), pa.large_utf8()):
@@ -4149,7 +4558,10 @@ class CTable(Generic[RowT]):
             name = field.name
             _validate_column_name(name)
             arrow_col = table_for_inference.column(name) if table_for_inference is not None else None
-            field_is_list = pa.types.is_list(field.type) or pa.types.is_large_list(field.type)
+            field_is_ndarray = pa.types.is_fixed_size_list(field.type)
+            field_is_list = (
+                pa.types.is_list(field.type) or pa.types.is_large_list(field.type)
+            ) and not field_is_ndarray
             field_is_struct = pa.types.is_struct(field.type)
             field_is_dictionary = pa.types.is_dictionary(field.type)
             column_string_max_length = cls._string_max_length_for_column(string_max_length, name)
@@ -4172,7 +4584,11 @@ class CTable(Generic[RowT]):
             null_value = None
             has_null_value_override = name in column_null_values
             if has_null_value_override and (
-                field_is_list or field_is_struct or field_is_dictionary or field_is_object_fallback
+                field_is_list
+                or field_is_ndarray
+                or field_is_struct
+                or field_is_dictionary
+                or field_is_object_fallback
             ):
                 raise TypeError(f"column_null_values only supports scalar columns; {name!r} is not scalar")
             if has_null_value_override and field_is_varlen_scalar:
@@ -4187,6 +4603,7 @@ class CTable(Generic[RowT]):
                 and field.nullable
                 and not (
                     field_is_list
+                    or field_is_ndarray
                     or field_is_struct
                     or field_is_dictionary
                     or field_is_varlen_scalar
@@ -4199,6 +4616,7 @@ class CTable(Generic[RowT]):
                 and arrow_col.null_count
                 and not (
                     field_is_list
+                    or field_is_ndarray
                     or field_is_struct
                     or field_is_dictionary
                     or field_is_varlen_scalar
@@ -4214,6 +4632,7 @@ class CTable(Generic[RowT]):
                 pa,
                 field.type,
                 arrow_col,
+                field_metadata=field.metadata,
                 string_max_length=column_string_max_length,
                 null_value=null_value,
                 nullable=field.nullable,
@@ -4221,6 +4640,7 @@ class CTable(Generic[RowT]):
             )
             if null_value is not None and not (
                 field_is_list
+                or field_is_ndarray
                 or field_is_struct
                 or field_is_dictionary
                 or field_is_varlen_scalar
@@ -4456,6 +4876,12 @@ class CTable(Generic[RowT]):
         nv = getattr(col.spec, "null_value", None)
         if col.spec.to_metadata_dict().get("kind") == "bool" and col.dtype == np.dtype(np.uint8):
             return np.array([nv if v is None else int(v) for v in arrow_col.to_pylist()], dtype=np.uint8)
+        if isinstance(col.spec, NDArraySpec):
+            values = arrow_col.to_pylist()
+            if any(v is None for v in values):
+                raise TypeError(f"Nullable ndarray Arrow column {col.name!r} is not supported yet.")
+            arr = np.asarray(values, dtype=col.dtype)
+            return arr.reshape((len(values), *col.spec.item_shape))
         if isinstance(col.spec, timestamp):
             arr = (
                 arrow_col.to_numpy(zero_copy_only=False)
@@ -5540,11 +5966,16 @@ class CTable(Generic[RowT]):
             raise ValueError("Cannot drop the last column.")
         # Guard: refuse if any computed column depends on this column
         dependents = [cc_name for cc_name, cc in self._computed_cols.items() if name in cc["col_deps"]]
+        dependents.extend(
+            mat_name
+            for mat_name, meta in self._materialized_cols.items()
+            if name in meta.get("col_deps", ())
+        )
         if dependents:
             raise ValueError(
-                f"Cannot drop column {name!r}: it is used by computed column(s) "
+                f"Cannot drop column {name!r}: it is used by computed/generated column(s) "
                 + ", ".join(repr(d) for d in dependents)
-                + ". Drop those computed columns first."
+                + ". Drop those columns first."
             )
 
         catalog = self._storage.load_index_catalog()
@@ -5746,16 +6177,21 @@ class CTable(Generic[RowT]):
                 for name, cc in self._computed_cols.items()
             ]
         if self._materialized_cols:
-            d["materialized_columns"] = [
-                {
+            materialized = []
+            for name, meta in self._materialized_cols.items():
+                entry = {
                     "name": name,
-                    "computed_column": meta["computed_column"],
-                    "expression": meta["expression"],
+                    "computed_column": meta.get("computed_column"),
+                    "expression": meta.get("expression"),
                     "col_deps": meta["col_deps"],
                     "dtype": str(meta["dtype"]),
+                    "transformer_kind": meta.get("transformer_kind", "expression"),
+                    "stale": bool(meta.get("stale", False)),
                 }
-                for name, meta in self._materialized_cols.items()
-            ]
+                if "transformer" in meta:
+                    entry["transformer"] = meta["transformer"]
+                materialized.append(entry)
+            d["materialized_columns"] = materialized
         return d
 
     def _load_computed_cols_from_schema(self, schema_dict: dict) -> None:
@@ -5783,12 +6219,17 @@ class CTable(Generic[RowT]):
     def _load_materialized_cols_from_schema(self, schema_dict: dict) -> None:
         """Reconstruct ``_materialized_cols`` from persisted metadata."""
         for meta in schema_dict.get("materialized_columns", []):
-            self._materialized_cols[meta["name"]] = {
-                "computed_column": meta["computed_column"],
-                "expression": meta["expression"],
+            loaded = {
+                "computed_column": meta.get("computed_column"),
+                "expression": meta.get("expression"),
                 "col_deps": list(meta["col_deps"]),
                 "dtype": np.dtype(meta["dtype"]),
+                "transformer_kind": meta.get("transformer_kind", "expression"),
+                "stale": bool(meta.get("stale", False)),
             }
+            if "transformer" in meta:
+                loaded["transformer"] = dict(meta["transformer"])
+            self._materialized_cols[meta["name"]] = loaded
 
     def _require_computed_column(self, name: str) -> dict:
         """Return metadata for computed column *name* or raise ``KeyError``."""
@@ -5810,9 +6251,13 @@ class CTable(Generic[RowT]):
                 raise ValueError(
                     f"Cannot auto-fill materialized column {name!r}: missing dependency columns {missing!r}."
                 )
-            operands = {f"o{i}": np.asarray([row[dep]]) for i, dep in enumerate(meta["col_deps"])}
-            values = blosc2.lazyexpr(meta["expression"], operands)[:]
-            row[name] = np.asarray(values, dtype=meta["dtype"])[0]
+            if meta.get("transformer_kind") == "row_transformer":
+                transformer = RowTransformer.from_metadata(meta["transformer"])
+                row[name] = np.asarray(transformer.evaluate_row(row), dtype=meta["dtype"])
+            else:
+                operands = {f"o{i}": np.asarray([row[dep]]) for i, dep in enumerate(meta["col_deps"])}
+                values = blosc2.lazyexpr(meta["expression"], operands)[:]
+                row[name] = np.asarray(values, dtype=meta["dtype"])[0]
         return row
 
     def _validate_no_default_columns_present(self, row: dict[str, Any]) -> None:
@@ -5850,11 +6295,15 @@ class CTable(Generic[RowT]):
                 raise ValueError(
                     f"Cannot auto-fill materialized column {name!r}: missing dependency columns {missing!r}."
                 )
-            operands = {
-                f"o{i}": blosc2.asarray(raw_columns[dep], dtype=self._cols[dep].dtype)
-                for i, dep in enumerate(meta["col_deps"])
-            }
-            values = blosc2.lazyexpr(meta["expression"], operands)[:]
+            if meta.get("transformer_kind") == "row_transformer":
+                transformer = RowTransformer.from_metadata(meta["transformer"])
+                values = transformer.evaluate_batch(raw_columns)
+            else:
+                operands = {
+                    f"o{i}": blosc2.asarray(raw_columns[dep], dtype=self._cols[dep].dtype)
+                    for i, dep in enumerate(meta["col_deps"])
+                }
+                values = blosc2.lazyexpr(meta["expression"], operands)[:]
             values = np.asarray(values, dtype=meta["dtype"])
             if len(values) != row_count:
                 raise ValueError(
@@ -5862,6 +6311,20 @@ class CTable(Generic[RowT]):
                 )
             raw_columns[name] = values
         return raw_columns
+
+    @staticmethod
+    def _coerce_generated_spec(dtype_or_spec, sample: np.ndarray | None = None) -> SchemaSpec:
+        """Resolve a generated-column dtype/spec, inferring ndarray shape when needed."""
+        if isinstance(dtype_or_spec, SchemaSpec):
+            return dtype_or_spec
+        if dtype_or_spec is None:
+            if sample is None:
+                raise TypeError("dtype is required when a generated column has no rows to infer from.")
+            arr = np.asarray(sample)
+            if arr.ndim <= 1:
+                return CTable._schema_spec_from_dtype(arr.dtype)
+            return NDArraySpec(item_shape=arr.shape[1:], dtype=arr.dtype)
+        return CTable._schema_spec_from_dtype(np.dtype(dtype_or_spec))
 
     @staticmethod
     def _schema_spec_from_dtype(dtype: np.dtype) -> SchemaSpec:
@@ -5880,26 +6343,23 @@ class CTable(Generic[RowT]):
     def _create_empty_stored_column(
         self,
         name: str,
-        dtype: np.dtype,
+        dtype: np.dtype | None,
         *,
+        spec: SchemaSpec | None = None,
         cparams: dict | None = None,
     ) -> None:
         """Create an empty stored column aligned with the table's physical row space."""
-        spec = self._schema_spec_from_dtype(dtype)
-        default = np.array(0, dtype=dtype).item() if dtype.kind not in {"U", "S"} else dtype.type()
+        if spec is None:
+            if dtype is None:
+                raise TypeError("dtype or spec is required")
+            spec = self._schema_spec_from_dtype(dtype)
+        dtype = np.dtype(spec.dtype)
+        if isinstance(spec, NDArraySpec):
+            default = np.zeros(spec.item_shape, dtype=dtype)
+        else:
+            default = np.array(0, dtype=dtype).item() if dtype.kind not in {"U", "S"} else dtype.type()
 
         capacity = len(self._valid_rows)
-        default_chunks, default_blocks = compute_chunks_blocks((capacity,))
-        new_col = self._storage.create_column(
-            name,
-            dtype=dtype,
-            shape=(capacity,),
-            chunks=default_chunks,
-            blocks=default_blocks,
-            cparams=cparams,
-            dparams=None,
-        )
-
         compiled_col = CompiledColumn(
             name=name,
             py_type=spec.python_type,
@@ -5908,6 +6368,17 @@ class CTable(Generic[RowT]):
             default=default,
             config=ColumnConfig(cparams=cparams, dparams=None, chunks=None, blocks=None),
             display_width=compute_display_width(spec),
+        )
+        shape = self._column_physical_shape(compiled_col, capacity)
+        default_chunks, default_blocks = self._column_chunks_blocks(compiled_col, shape)
+        new_col = self._storage.create_column(
+            name,
+            dtype=dtype,
+            shape=shape,
+            chunks=default_chunks,
+            blocks=default_blocks,
+            cparams=cparams,
+            dparams=None,
         )
         self._cols[name] = new_col
         self.col_names.append(name)
@@ -6018,6 +6489,193 @@ class CTable(Generic[RowT]):
                 self.drop_column(target_name)
             raise
 
+    def _normalize_expression_transformer(self, expr) -> tuple[blosc2.LazyExpr, list[str]]:
+        if isinstance(expr, RowTransformer):
+            raise TypeError(
+                "RowTransformer instances cannot be used for computed columns; use add_generated_column()."
+            )
+        if isinstance(expr, blosc2.LazyExpr):
+            lazy = expr
+        elif callable(expr):
+            lazy = expr(self._cols)
+        elif isinstance(expr, str):
+            self._guard_scalar_expression(expr)
+            operands = self._where_expression_operands()
+            expr, operands = self._rewrite_nested_expression(expr, operands)
+            lazy = blosc2.lazyexpr(expr, operands)
+        else:
+            raise TypeError(
+                f"expr must be a callable or an expression string (or LazyExpr), got {type(expr).__name__!r}."
+            )
+        if not isinstance(lazy, blosc2.LazyExpr):
+            raise TypeError(f"expr must return a blosc2.LazyExpr, got {type(lazy).__name__!r}.")
+
+        owned_ids = {id(arr): cname for cname, arr in self._cols.items()}
+        col_deps = []
+        for key in sorted(lazy.operands.keys()):
+            arr = lazy.operands[key]
+            cname = owned_ids.get(id(arr))
+            if cname is None:
+                raise ValueError(
+                    f"Operand {key!r} in the expression does not reference a stored column of this table."
+                )
+            col_info = self._schema.columns_by_name.get(cname)
+            if col_info is not None and self._is_ndarray_column(col_info):
+                raise TypeError(
+                    f"Column {cname!r} is a fixed-shape ndarray column. Expression transformers only "
+                    "support scalar columns; use a RowTransformer for ndarray row reductions/projections."
+                )
+            col_deps.append(cname)
+        return lazy, col_deps
+
+    def _evaluate_expression_materialized_batch(
+        self, meta: dict, raw_columns: Mapping[str, Any]
+    ) -> np.ndarray:
+        operands = {
+            f"o{i}": blosc2.asarray(raw_columns[dep], dtype=self._cols[dep].dtype)
+            for i, dep in enumerate(meta["col_deps"])
+        }
+        values = blosc2.lazyexpr(meta["expression"], operands)[:]
+        return np.asarray(values, dtype=meta["dtype"])
+
+    def _mark_generated_columns_stale(self, source: str) -> None:
+        changed = False
+        for meta in self._materialized_cols.values():
+            if source in meta.get("col_deps", ()):
+                meta["stale"] = True
+                changed = True
+        if changed and isinstance(self._storage, FileTableStorage):
+            self._storage.save_schema(self._schema_dict_with_computed())
+
+    def refresh_generated_column(self, name: str) -> None:
+        """Recompute a stored generated/materialized column from its source columns."""
+        if self._read_only:
+            raise ValueError("Table is read-only (opened with mode='r').")
+        if name not in self._materialized_cols:
+            raise KeyError(f"{name!r} is not a generated/materialized column.")
+        meta = self._materialized_cols[name]
+        live_pos = np.where(self._valid_rows[:])[0]
+        if meta.get("transformer_kind") == "row_transformer":
+            transformer = RowTransformer.from_metadata(meta["transformer"])
+            values = np.asarray(transformer.evaluate_existing(self), dtype=meta["dtype"])
+        else:
+            raw_columns = {dep: self[dep][:] for dep in meta["col_deps"]}
+            values = self._evaluate_expression_materialized_batch(meta, raw_columns)
+        if len(values) != len(live_pos):
+            raise ValueError(
+                f"Generated column {name!r} produced {len(values)} values, expected {len(live_pos)}."
+            )
+        self._cols[name][live_pos] = values
+        meta["stale"] = False
+        self._mark_all_indexes_stale()
+        if isinstance(self._storage, FileTableStorage):
+            self._storage.save_schema(self._schema_dict_with_computed())
+
+    def refresh_generated_columns(self, *, source: str | None = None) -> None:
+        """Refresh all generated columns, optionally only those depending on *source*."""
+        for name, meta in list(self._materialized_cols.items()):
+            if source is None or source in meta.get("col_deps", ()):
+                self.refresh_generated_column(name)
+
+    def add_generated_column(  # noqa: C901
+        self,
+        name: str,
+        *,
+        values,
+        dtype=None,
+        create_index: bool = False,
+    ) -> None:
+        """Add a stored generated column maintained on append/extend.
+
+        ``values`` may be an expression string, a :class:`blosc2.LazyExpr`, a
+        callable returning a lazy expression, or a :class:`RowTransformer`.
+        """
+        if self.base is not None:
+            raise ValueError("Cannot add a generated column to a view.")
+        if self._read_only:
+            raise ValueError("Table is read-only (opened with mode='r').")
+        _validate_column_name(name)
+        if name in self._cols:
+            raise ValueError(f"A stored column named {name!r} already exists.")
+        if name in self._computed_cols:
+            raise ValueError(f"A computed column named {name!r} already exists.")
+
+        live_pos = np.where(self._valid_rows[:])[0]
+        if isinstance(values, RowTransformer):
+            transformer = values
+            for dep in transformer.source_columns:
+                if dep not in self._cols:
+                    raise KeyError(f"No source column named {dep!r}.")
+                col_info = self._schema.columns_by_name[dep]
+                if not self._is_ndarray_column(col_info):
+                    raise TypeError(f"RowTransformer source {dep!r} is not an ndarray column.")
+            generated_values = (
+                transformer.evaluate_existing(self)
+                if len(live_pos)
+                else transformer.evaluate_batch(
+                    {
+                        transformer.source: np.zeros(
+                            (1, *self._schema.columns_by_name[transformer.source].spec.item_shape),
+                            dtype=self._cols[transformer.source].dtype,
+                        )
+                    }
+                )[:0]
+            )
+            spec = self._coerce_generated_spec(dtype, generated_values)
+            metadata = {
+                "computed_column": None,
+                "expression": None,
+                "col_deps": list(transformer.source_columns),
+                "dtype": np.dtype(spec.dtype),
+                "transformer_kind": "row_transformer",
+                "transformer": transformer.to_metadata(),
+                "stale": False,
+            }
+        else:
+            lazy, col_deps = self._normalize_expression_transformer(values)
+            generated_values = np.asarray(lazy[:])
+            if generated_values.ndim != 1:
+                raise TypeError("Expression generated columns must produce a 1-D scalar result.")
+            generated_values = (
+                generated_values[live_pos]
+                if len(generated_values) == len(self._valid_rows)
+                else generated_values
+            )
+            spec = self._coerce_generated_spec(dtype, generated_values)
+            metadata = {
+                "computed_column": None,
+                "expression": lazy.expression,
+                "col_deps": col_deps,
+                "dtype": np.dtype(spec.dtype),
+                "transformer_kind": "expression",
+                "stale": False,
+            }
+        if create_index and isinstance(spec, NDArraySpec):
+            raise ValueError("Generated columns intended for indexing must be 1-D scalar columns.")
+        generated_values = np.asarray(generated_values, dtype=spec.dtype)
+        if len(generated_values) != len(live_pos):
+            raise ValueError(
+                f"Generated column {name!r} produced {len(generated_values)} values, expected {len(live_pos)}."
+            )
+        if isinstance(spec, NDArraySpec) and generated_values.shape != (len(live_pos), *spec.item_shape):
+            raise ValueError(
+                f"Generated column {name!r} expected shape {(len(live_pos), *spec.item_shape)}, got {generated_values.shape}."
+            )
+
+        self._create_empty_stored_column(name, np.dtype(spec.dtype), spec=spec)
+        self._materialized_cols[name] = metadata
+        try:
+            if len(live_pos):
+                self._cols[name][live_pos] = generated_values
+            if create_index:
+                self.create_index(name)
+        except Exception:
+            with contextlib.suppress(Exception):
+                self.drop_column(name)
+            raise
+        if isinstance(self._storage, FileTableStorage):
+            self._storage.save_schema(self._schema_dict_with_computed())
+
     def add_computed_column(
         self,
         name: str,
@@ -6064,31 +6722,7 @@ class CTable(Generic[RowT]):
         if name in self._computed_cols:
             raise ValueError(f"A computed column named {name!r} already exists.")
 
-        # Build the LazyExpr
-        if callable(expr):
-            lazy = expr(self._cols)
-        elif isinstance(expr, str):
-            lazy = blosc2.lazyexpr(expr, self._cols)
-        else:
-            raise TypeError(f"expr must be a callable or an expression string, got {type(expr).__name__!r}.")
-        if not isinstance(lazy, blosc2.LazyExpr):
-            raise TypeError(f"expr must return a blosc2.LazyExpr, got {type(lazy).__name__!r}.")
-
-        # Verify all operands are stored columns of *this* table and record their names
-        owned_ids = {id(arr): cname for cname, arr in self._cols.items()}
-        sorted_keys = sorted(lazy.operands.keys())  # ["o0", "o1", ...]
-        col_deps = []
-        for key in sorted_keys:
-            arr = lazy.operands[key]
-            cname = owned_ids.get(id(arr))
-            if cname is None:
-                raise ValueError(
-                    f"Operand {key!r} in the expression does not reference a stored "
-                    f"column of this table.  Only stored columns may be used as "
-                    f"dependencies (for v1 computed columns cannot depend on each other)."
-                )
-            col_deps.append(cname)
-
+        lazy, col_deps = self._normalize_expression_transformer(expr)
         result_dtype = np.dtype(dtype) if dtype is not None else lazy.dtype
 
         self._computed_cols[name] = {
@@ -6404,6 +7038,12 @@ class CTable(Generic[RowT]):
         for name in cols:
             if name not in self._cols and name not in self._computed_cols:
                 raise KeyError(f"No column named {name!r}. Available: {self.col_names}")
+            col_info = self._schema.columns_by_name.get(name)
+            if col_info is not None and self._is_ndarray_column(col_info):
+                raise TypeError(
+                    f"Cannot sort by ndarray column {name!r} with per-row shape {col_info.spec.item_shape}. "
+                    "Materialize a scalar generated column first, e.g. embedding_norm or embedding_max."
+                )
             dtype = self._col_dtype(name)
             if dtype is None:
                 cc = self._schema.columns_by_name.get(name)
@@ -7388,6 +8028,12 @@ class CTable(Generic[RowT]):
             )
 
         col_arr = self._cols[col_name]
+        if isinstance(self._schema.columns_by_name[col_name].spec, NDArraySpec):
+            spec = self._schema.columns_by_name[col_name].spec
+            raise ValueError(
+                f"Cannot create an index on ndarray column {col_name!r} with per-row shape {spec.item_shape}. "
+                "Materialize a scalar generated column first, e.g. embedding_norm or embedding_max."
+            )
         if isinstance(self._schema.columns_by_name[col_name].spec, ListSpec):
             raise ValueError(f"Cannot create an index on list column {col_name!r} in V1.")
         if isinstance(
@@ -8146,6 +8792,7 @@ class CTable(Generic[RowT]):
                 self._is_list_column(col)
                 or self._is_varlen_scalar_column(col)
                 or self._is_dictionary_column(col)
+                or self._is_ndarray_column(col)
             ):
                 operands[name] = arr
         operands.update({name: cc["lazy"] for name, cc in self._computed_cols.items()})
@@ -8177,15 +8824,25 @@ class CTable(Generic[RowT]):
                 new_operands[alias] = new_operands.pop(name)
         return rewritten, new_operands
 
-    def _guard_varlen_scalar_expression(self, expr: str) -> None:
+    @staticmethod
+    def _expression_references_name(expr: str, name: str) -> bool:
+        return re.search(rf"(?<![\w.]){re.escape(name)}(?![\w.])", expr) is not None
+
+    def _guard_scalar_expression(self, expr: str) -> None:
         for col in self._schema.columns:
-            if self._is_varlen_scalar_column(col) and re.search(
-                rf"(?<!\w){re.escape(col.name)}(?!\w)", expr
-            ):
+            if self._is_ndarray_column(col) and self._expression_references_name(expr, col.name):
+                raise TypeError(
+                    f"Column {col.name!r} is a fixed-shape ndarray column. String expressions only "
+                    "support scalar columns. Use an element projection or a row-wise reduction first."
+                )
+            if self._is_varlen_scalar_column(col) and self._expression_references_name(expr, col.name):
                 raise NotImplementedError(
                     f"Column {col.name!r} is a variable-length scalar column (vlstring/vlbytes/struct/object); "
                     "lazy expressions are not supported yet."
                 )
+
+    def _guard_varlen_scalar_expression(self, expr: str) -> None:
+        self._guard_scalar_expression(expr)
 
     def where(
         self,
@@ -8307,10 +8964,20 @@ class CTable(Generic[RowT]):
                 return result if columns is None else result.select(list(columns))
 
         filter = expr_result.compute() if isinstance(expr_result, blosc2.LazyExpr) else expr_result
+        if getattr(filter, "ndim", 1) != 1:
+            raise ValueError(
+                "CTable.where() requires a 1-D row mask. Reduce ndarray-column predicates to one "
+                "boolean per row before filtering."
+            )
 
         target_len = len(self._valid_rows)
 
-        if len(filter) > target_len:
+        if len(filter) == self.nrows and len(filter) != target_len:
+            physical = blosc2.zeros(target_len, dtype=np.bool_)
+            live_pos = np.where(self._valid_rows[:])[0]
+            physical[live_pos] = filter[:]
+            filter = physical
+        elif len(filter) > target_len:
             filter = filter[:target_len]
         elif len(filter) < target_len:
             padding = blosc2.zeros(target_len, dtype=np.bool_)

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -6115,11 +6115,10 @@ class CTable(Generic[RowT]):
         import pandas as pd
 
         data = {}
-        n = len(self)
         for name in self.col_names:
             col = self[name]
             if col.is_ndarray:
-                data[name] = [col[i] for i in range(n)]
+                data[name] = list(col)
             else:
                 data[name] = col[:]
 

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -20,7 +20,7 @@ import os
 import pprint
 import re
 import shutil
-from collections import namedtuple
+from collections import deque, namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import MISSING, dataclass
 from dataclasses import field as dataclass_field
@@ -6996,9 +6996,9 @@ class CTable(Generic[RowT]):
     def _generated_dependency_closure(self, source: str) -> set[str]:
         """Return generated columns transitively depending on *source*."""
         affected: set[str] = set()
-        queue = [source]
+        queue = deque([source])
         while queue:
-            current = queue.pop(0)
+            current = queue.popleft()
             for name, meta in self._materialized_cols.items():
                 if name in affected:
                     continue

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -7083,7 +7083,10 @@ class CTable(Generic[RowT]):
           :meth:`where`.  Dotted names (e.g. ``"trip.begin.lon"``) select
           nested leaf columns directly; a struct-prefix name
           (e.g. ``"trip.begin"``) that matches multiple descendant leaves returns
-          a :class:`_StructPathColumn` view.
+          a :class:`_StructPathColumn` view.  This item-access form is the
+          canonical way to access columns and works for every column name,
+          including names that are not valid Python identifiers or that collide
+          with existing :class:`CTable` attributes or methods.
         - boolean :class:`blosc2.LazyExpr` or :class:`blosc2.NDArray`: return the
           same filtered view as :meth:`where`, e.g. ``t[t.temperature_f > 70]``.
         - ``int``: return one live row as a namedtuple-like object.
@@ -7116,6 +7119,14 @@ class CTable(Generic[RowT]):
 
             lons = t["trip.begin.lon"]   # Column for the nested leaf
             lons = t.trip.begin.lon      # equivalent attribute-chain form
+
+        Attribute access is only a convenience fallback.  If a column name is
+        not a valid identifier, or if it conflicts with an existing table
+        attribute or method such as ``nrows``, ``where`` or ``sort_by``, use item
+        access instead::
+
+            col = t["where"]             # column named "where"
+            method = t.where             # CTable.where method
         """
         if isinstance(key, str):
             physical = self._logical_to_physical_name(key)
@@ -7141,6 +7152,14 @@ class CTable(Generic[RowT]):
         return None
 
     def __getattr__(self, s: str):
+        """Convenience fallback for attribute-style column access.
+
+        This is called only after normal Python attribute lookup fails.  Thus
+        ``t.name`` can return a column only for non-conflicting identifier-like
+        column names.  For columns whose names conflict with existing CTable
+        attributes/methods, or are not valid identifiers, use the canonical item
+        access form ``t["name"]``.
+        """
         physical = self._logical_to_physical_name(s)
         if physical in self._cols or physical in self._computed_cols:
             return Column(self, physical)

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -733,6 +733,34 @@ class Column:
         return self._col_name in self._table._computed_cols
 
     @property
+    def is_generated(self) -> bool:
+        """True if this column is a stored generated/materialized column."""
+        return self._col_name in self._table._root_table._materialized_cols
+
+    @property
+    def is_stale(self) -> bool:
+        """True if this generated column needs to be refreshed before use."""
+        meta = self._table._root_table._materialized_cols.get(self._col_name)
+        return bool(meta and meta.get("stale", False))
+
+    def _ensure_not_stale(self) -> None:
+        if self.is_stale:
+            raise ValueError(
+                f"Generated column {self._col_name!r} is stale because one or more source columns were "
+                f"modified. Call refresh_generated_column({self._col_name!r}) before reading it, or use "
+                f"t[{self._col_name!r}].read_stale() to explicitly read the last stored stale values."
+            )
+
+    def read_stale(self, key=slice(None)):
+        """Read stored values even when this generated column is marked stale.
+
+        This is an explicit escape hatch for inspecting the last materialized
+        values.  Normal reads raise for stale generated columns so outdated
+        values are not used accidentally.
+        """
+        return self._values_from_key(key, check_stale=False)
+
+    @property
     def is_list(self) -> bool:
         col = self._table._schema.columns_by_name.get(self._col_name)
         return col is not None and isinstance(col.spec, ListSpec)
@@ -780,13 +808,15 @@ class Column:
         """
         return self._values_from_key(key)
 
-    def _values_from_key(self, key):  # noqa: C901
+    def _values_from_key(self, key, *, check_stale: bool = True):  # noqa: C901
         """Materialise values for a logical index key."""
+        if check_stale:
+            self._ensure_not_stale()
         if isinstance(key, tuple) and self.is_ndarray:
             if len(key) == 0:
                 raise IndexError("empty tuple index is not valid for Column")
             row_key, inner_key = key[0], key[1:]
-            values = self._values_from_key(row_key)
+            values = self._values_from_key(row_key, check_stale=False)
             if not inner_key:
                 return values
             if isinstance(row_key, (int, np.integer)) and not isinstance(row_key, (bool, np.bool_)):
@@ -973,6 +1003,7 @@ class Column:
 
     def __iter__(self):
         """Iterate over live column values in insertion order, skipping deleted rows."""
+        self._ensure_not_stale()
         if self.is_computed:
             yield from self._iter_chunks_computed(size=None)
             return
@@ -1201,6 +1232,7 @@ class Column:
         return RowTransformer(self._col_name)
 
     def _ensure_queryable(self) -> None:
+        self._ensure_not_stale()
         if self.is_varlen_scalar:
             raise NotImplementedError(
                 f"Column {self._col_name!r} is a vlstring/vlbytes column; "
@@ -1504,6 +1536,7 @@ class Column:
         >>> for chunk in t["score"].iter_chunks(size=100_000):
         ...     process(chunk)
         """
+        self._ensure_not_stale()
         if self.is_computed:
             yield from self._iter_chunks_computed(size=size)
             return
@@ -1762,6 +1795,7 @@ class Column:
 
     def _require_kind(self, kinds: str, op: str) -> None:
         """Raise TypeError if this column's dtype is not in *kinds*."""
+        self._ensure_not_stale()
         if self.dtype.kind not in kinds:
             _kind_names = {
                 "b": "bool",
@@ -6119,6 +6153,15 @@ class CTable(Generic[RowT]):
         """
         return dict(self._computed_cols)  # shallow copy so callers can't mutate
 
+    def _ensure_generated_column_not_stale(self, name: str) -> None:
+        meta = self._root_table._materialized_cols.get(name)
+        if meta is not None and meta.get("stale", False):
+            raise ValueError(
+                f"Generated column {name!r} is stale because one or more source columns were modified. "
+                f"Call refresh_generated_column({name!r}) before using it, or use t[{name!r}].read_stale() "
+                "to explicitly read the last stored stale values."
+            )
+
     def _col_dtype(self, name: str) -> np.dtype | None:
         """Return the dtype for *name*, routing through computed cols."""
         cc = self._computed_cols.get(name)
@@ -6152,6 +6195,7 @@ class CTable(Generic[RowT]):
                 [np.asarray(cc["lazy"][int(p)]).ravel()[0] for p in positions],
                 dtype=cc["dtype"],
             )
+        self._ensure_generated_column_not_stale(name)
         col = self._cols[name]
         spec = self._schema.columns_by_name[name].spec
         if self._is_list_spec(spec) or isinstance(
@@ -6519,6 +6563,7 @@ class CTable(Generic[RowT]):
                 raise ValueError(
                     f"Operand {key!r} in the expression does not reference a stored column of this table."
                 )
+            self._ensure_generated_column_not_stale(cname)
             col_info = self._schema.columns_by_name.get(cname)
             if col_info is not None and self._is_ndarray_column(col_info):
                 raise TypeError(
@@ -6538,10 +6583,26 @@ class CTable(Generic[RowT]):
         values = blosc2.lazyexpr(meta["expression"], operands)[:]
         return np.asarray(values, dtype=meta["dtype"])
 
+    def _generated_dependency_closure(self, source: str) -> set[str]:
+        """Return generated columns transitively depending on *source*."""
+        affected: set[str] = set()
+        queue = [source]
+        while queue:
+            current = queue.pop(0)
+            for name, meta in self._materialized_cols.items():
+                if name in affected:
+                    continue
+                if current in meta.get("col_deps", ()):
+                    affected.add(name)
+                    queue.append(name)
+        return affected
+
     def _mark_generated_columns_stale(self, source: str) -> None:
+        affected = self._generated_dependency_closure(source)
         changed = False
-        for meta in self._materialized_cols.values():
-            if source in meta.get("col_deps", ()):
+        for name in affected:
+            meta = self._materialized_cols[name]
+            if not meta.get("stale", False):
                 meta["stale"] = True
                 changed = True
         if changed and isinstance(self._storage, FileTableStorage):
@@ -6573,8 +6634,9 @@ class CTable(Generic[RowT]):
 
     def refresh_generated_columns(self, *, source: str | None = None) -> None:
         """Refresh all generated columns, optionally only those depending on *source*."""
-        for name, meta in list(self._materialized_cols.items()):
-            if source is None or source in meta.get("col_deps", ()):
+        affected = None if source is None else self._generated_dependency_closure(source)
+        for name in list(self._materialized_cols):
+            if affected is None or name in affected:
                 self.refresh_generated_column(name)
 
     def add_generated_column(  # noqa: C901
@@ -7254,6 +7316,7 @@ class CTable(Generic[RowT]):
         for name in cols:
             if name not in self._cols and name not in self._computed_cols:
                 raise KeyError(f"No column named {name!r}. Available: {self.col_names}")
+            self._ensure_generated_column_not_stale(name)
             col_info = self._schema.columns_by_name.get(name)
             if col_info is not None and self._is_ndarray_column(col_info):
                 raise TypeError(
@@ -8237,6 +8300,7 @@ class CTable(Generic[RowT]):
             )
         if col_name not in self._cols:
             raise KeyError(f"No column named {col_name!r}. Available: {self.col_names}")
+        self._ensure_generated_column_not_stale(col_name)
         if col_name in catalog:
             raise ValueError(
                 f"Index already exists for column {col_name!r}. "
@@ -9045,6 +9109,13 @@ class CTable(Generic[RowT]):
         return re.search(rf"(?<![\w.]){re.escape(name)}(?![\w.])", expr) is not None
 
     def _guard_scalar_expression(self, expr: str) -> None:
+        for name, meta in self._root_table._materialized_cols.items():
+            if meta.get("stale", False) and self._expression_references_name(expr, name):
+                raise ValueError(
+                    f"Generated column {name!r} is stale because one or more source columns were modified. "
+                    f"Call refresh_generated_column({name!r}) before using it in expressions, or use "
+                    f"t[{name!r}].read_stale() to explicitly read the last stored stale values."
+                )
         for col in self._schema.columns:
             if self._is_ndarray_column(col) and self._expression_references_name(expr, col.name):
                 raise TypeError(

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -5939,15 +5939,20 @@ class CTable(Generic[RowT]):
         rows = []
         for val in raw:
             stripped = val.strip()
-            if stripped == "" and null_value is not None:
-                rows.append(np.full(item_shape, null_value, dtype=dtype))
-            else:
+            if stripped == "":
+                if null_value is not None:
+                    rows.append(np.full(item_shape, null_value, dtype=dtype))
+                    continue
+                raise ValueError(f"Column {col.name!r}: non-nullable column got empty cell")
+
+            try:
                 arr = np.array(json.loads(stripped), dtype=dtype)
-                if arr.shape != item_shape:
-                    raise ValueError(
-                        f"Column {col.name!r}: expected item shape {item_shape}, got {arr.shape}"
-                    )
-                rows.append(arr)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Column {col.name!r}: invalid JSON array cell {val!r}") from exc
+
+            if arr.shape != item_shape:
+                raise ValueError(f"Column {col.name!r}: expected item shape {item_shape}, got {arr.shape}")
+            rows.append(arr)
 
         return np.ascontiguousarray(rows, dtype=dtype)
 

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -4524,10 +4524,20 @@ class CTable(Generic[RowT]):
                     spec = self._schema.columns_by_name[name].spec
                     values = np.asarray(col[start:stop])
                     null_mask = col._null_mask_for(values) if col.null_value is not None else None
-                    flat_values = values.reshape((stop - start, -1)).tolist()
-                    if null_mask is not None and null_mask.any():
-                        flat_values = [None if null_mask[i] else v for i, v in enumerate(flat_values)]
-                    arrays.append(pa.array(flat_values, type=self._pa_type_from_spec(pa, spec)))
+                    pa_type = self._pa_type_from_spec(pa, spec)
+                    flat_values = np.ascontiguousarray(values.reshape(-1))
+                    pa_values = pa.array(flat_values, type=pa_type.value_type)
+                    arrays.append(
+                        pa.FixedSizeListArray.from_arrays(
+                            pa_values,
+                            type=pa_type,
+                            mask=(
+                                pa.array(null_mask, type=pa.bool_())
+                                if null_mask is not None and null_mask.any()
+                                else None
+                            ),
+                        )
+                    )
                     continue
                 arr = np.asarray(col[start:stop])
                 nv = col.null_value

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -1157,16 +1157,25 @@ class Column:
         table = self._table
         col_meta = table._schema.columns_by_name.get(self._col_name)
         spec = col_meta.spec if col_meta is not None else None
-        physical_len = len(raw) if hasattr(raw, "__len__") else None
+        chunks = getattr(raw, "chunks", None)
+        blocks = getattr(raw, "blocks", None)
         items: list[tuple[str, object]] = [
             ("type", self.__class__.__name__),
             ("name", self._col_name),
-            ("logical_length", len(self)),
-            ("physical_length", physical_len),
-            ("dtype", table._dtype_info_label(self.dtype, spec)),
-            ("computed", self.is_computed),
-            ("nullable", self.null_value is not None or getattr(spec, "nullable", False)),
+            ("nrows", len(self)),
+            ("shape", self.shape),
         ]
+        if chunks is not None:
+            items.append(("chunks", chunks))
+        if blocks is not None:
+            items.append(("blocks", blocks))
+        items.extend(
+            [
+                ("dtype", table._dtype_info_label(self.dtype, spec)),
+                ("computed", self.is_computed),
+                ("nullable", self.null_value is not None or getattr(spec, "nullable", False)),
+            ]
+        )
 
         if self.is_list:
             items.append(("storage", "list"))
@@ -1177,13 +1186,6 @@ class Column:
             items.append(("dictionary_size", len(raw.dictionary)))
         else:
             items.append(("storage", "ndarray" if isinstance(raw, blosc2.NDArray) else type(raw).__name__))
-
-        chunks = getattr(raw, "chunks", None)
-        blocks = getattr(raw, "blocks", None)
-        if chunks is not None:
-            items.append(("chunks", chunks))
-        if blocks is not None:
-            items.append(("blocks", blocks))
 
         nbytes = getattr(raw, "nbytes", None)
         cbytes = getattr(raw, "cbytes", None)

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -2380,6 +2380,101 @@ class _NestedColumnNamespace:
         self._table = table
         self._prefix = prefix
 
+    def _descendant_col_names(self) -> list[str]:
+        prefix_parts = split_field_path(self._prefix)
+        return [
+            name
+            for name in self._table.col_names
+            if (parts := split_field_path(name))[: len(prefix_parts)] == prefix_parts
+            and len(parts) > len(prefix_parts)
+        ]
+
+    def _relative_col_name(self, name: str) -> str:
+        prefix_parts = split_field_path(self._prefix)
+        return join_field_path(split_field_path(name)[len(prefix_parts) :])
+
+    @property
+    def col_names(self) -> list[str]:
+        """Descendant leaf column names relative to this nested prefix."""
+        return [self._relative_col_name(name) for name in self._descendant_col_names()]
+
+    @property
+    def nrows(self) -> int:
+        """Number of logical rows in this nested namespace."""
+        return self._table.nrows
+
+    @property
+    def ncols(self) -> int:
+        """Number of descendant leaf columns in this nested namespace."""
+        return len(self._descendant_col_names())
+
+    @property
+    def nbytes(self) -> int:
+        """Uncompressed size in bytes for stored descendant columns."""
+        return sum(
+            getattr(self._table._cols[name], "nbytes", 0)
+            for name in self._descendant_col_names()
+            if name in self._table._cols
+        )
+
+    @property
+    def cbytes(self) -> int:
+        """Compressed size in bytes for stored descendant columns."""
+        return sum(
+            getattr(self._table._cols[name], "cbytes", 0)
+            for name in self._descendant_col_names()
+            if name in self._table._cols
+        )
+
+    @property
+    def cratio(self) -> float:
+        """Compression ratio for stored descendant columns."""
+        if self.cbytes == 0:
+            return float("inf")
+        return self.nbytes / self.cbytes
+
+    @property
+    def info_items(self) -> list[tuple[str, object]]:
+        """Structured summary items used by :attr:`info`."""
+        table = self._table
+        storage_type = "persistent" if isinstance(table._storage, FileTableStorage) else "in-memory"
+        schema_summary = {}
+        for name in self._descendant_col_names():
+            rel_name = self._relative_col_name(name)
+            if name in table._computed_cols:
+                cc = table._computed_cols[name]
+                schema_summary[rel_name] = _InfoLiteral(
+                    f"{cc['dtype']} (computed: {table._readable_computed_expr(cc)})"
+                )
+            else:
+                col_meta = table._schema.columns_by_name.get(name)
+                schema_summary[rel_name] = _InfoLiteral(
+                    table._dtype_info_label(
+                        getattr(table._cols[name], "dtype", None), col_meta.spec if col_meta else None
+                    )
+                )
+
+        return [
+            ("type", self.__class__.__name__),
+            ("storage", storage_type),
+            ("nrows", self.nrows),
+            ("nbytes", format_nbytes_info(self.nbytes)),
+            ("cbytes", format_nbytes_info(self.cbytes)),
+            ("cratio", f"{self.cratio:.1f}x"),
+            ("schema", schema_summary),
+        ]
+
+    @property
+    def info(self) -> _CTableInfoReporter:
+        """Get information about this nested column namespace.
+
+        Examples
+        --------
+        >>> print(t.trip.info)
+        >>> t.trip.info()
+        """
+        return _CTableInfoReporter(self)
+
     def __getattr__(self, name: str):
         path = join_field_path((*split_field_path(self._prefix), name))
         if path in self._table._cols or path in self._table._computed_cols:

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -21,7 +21,7 @@ import pprint
 import re
 import shutil
 from collections import namedtuple
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import MISSING, dataclass
 from dataclasses import field as dataclass_field
 from textwrap import TextWrapper
@@ -6581,14 +6581,132 @@ class CTable(Generic[RowT]):
         self,
         name: str,
         *,
-        values,
+        values: str | blosc2.LazyExpr | Callable[[dict[str, Any]], blosc2.LazyExpr] | RowTransformer,
         dtype=None,
         create_index: bool = False,
     ) -> None:
-        """Add a stored generated column maintained on append/extend.
+        """Add a stored generated column maintained by the table.
 
-        ``values`` may be an expression string, a :class:`blosc2.LazyExpr`, a
-        callable returning a lazy expression, or a :class:`RowTransformer`.
+        A generated column is physical storage, not a virtual expression.  The
+        initial values are computed for all current live rows, and later
+        ``append()`` / ``extend()`` calls automatically compute values for newly
+        inserted rows when source columns are provided.  If a source column is
+        modified in-place, dependent generated columns are marked stale; call
+        :meth:`refresh_generated_column` or :meth:`refresh_generated_columns` to
+        recompute them.
+
+        Supported signatures are::
+
+            add_generated_column(name, *, values="price * qty", dtype=..., create_index=False)
+            add_generated_column(name, *, values=lazy_expr, dtype=..., create_index=False)
+            add_generated_column(name, *, values=lambda cols: cols["price"] * 1.21, dtype=...)
+            add_generated_column(name, *, values=t.embedding.row_transformer.norm(axis=0), dtype=...)
+            add_generated_column(name, *, values=t.image.row_transformer.mean(axis=(0, 1)),
+                                 dtype=blosc2.ndarray((3,), dtype=...))
+
+        Parameters
+        ----------
+        name:
+            Name of the generated column to create.  It must be a valid column
+            name and must not collide with an existing stored or computed
+            column.
+        values:
+            Definition used to compute the generated values.  Accepted forms:
+
+            * ``str``: scalar expression over stored scalar columns, e.g.
+              ``"price * qty"``.  The expression must produce one scalar value
+              per row.
+            * :class:`blosc2.LazyExpr`: scalar lazy expression over stored
+              columns of this table.  It must produce a 1-D scalar stream.
+            * callable: called as ``values(self._cols)`` and must return a
+              :class:`blosc2.LazyExpr` over stored columns of this table.
+            * :class:`RowTransformer`: row-wise projection/reduction bound to a
+              fixed-shape ndarray column, e.g.
+              ``t.embedding.row_transformer.norm(axis=0)`` or
+              ``t.image.row_transformer.mean(axis=(0, 1))``.  Row transformers
+              may produce either one scalar per row or one fixed-shape ndarray
+              item per row.
+
+            Expression forms currently cannot depend on computed columns and
+            cannot directly consume fixed-shape ndarray columns; use a
+            row-transformer for ndarray row projections/reductions.
+        dtype:
+            Output schema or dtype.  Scalar outputs may pass a NumPy dtype or a
+            Blosc2 scalar spec such as ``blosc2.float64()``.  Fixed-shape
+            ndarray outputs must pass an ndarray spec such as
+            ``blosc2.ndarray((3,), dtype=blosc2.float32())`` unless the table has
+            existing rows from which the output shape can be inferred.  When
+            omitted, dtype and fixed-shape output shape are inferred from the
+            current generated values; this is not possible for an empty table.
+        create_index:
+            If ``True``, create an index on the generated column immediately.
+            Only scalar generated columns can be indexed; fixed-shape ndarray
+            generated columns raise :class:`ValueError` when indexing is
+            requested.
+
+        Examples
+        --------
+        Create and index a scalar generated column from a string expression::
+
+            t.add_generated_column(
+                "total",
+                values="price * qty",
+                dtype=blosc2.float64(),
+                create_index=True,
+            )
+
+        Use a callable when normal Python composition is more convenient::
+
+            t.add_generated_column(
+                "price_with_tax",
+                values=lambda cols: cols["price"] * 1.21,
+                dtype=blosc2.float64(),
+            )
+
+        Generate a scalar from each fixed-shape ndarray row.  For row
+        transformers, axes refer to the per-row item shape, so ``axis=0`` is the
+        embedding-coordinate axis for ``item_shape=(dim,)``::
+
+            t.add_generated_column(
+                "embedding_norm",
+                values=t.embedding.row_transformer.norm(axis=0, ord=2),
+                dtype=blosc2.float64(),
+                create_index=True,
+            )
+
+        Generate a fixed-shape ndarray value per row.  Here an image column has
+        ``item_shape=(height, width, 3)`` and the generated column stores one RGB
+        vector per row::
+
+            t.add_generated_column(
+                "image_mean_rgb",
+                values=t.image.row_transformer.mean(axis=(0, 1)),
+                dtype=blosc2.ndarray((3,), dtype=blosc2.float32()),
+            )
+
+        Generated columns are maintained on append/extend::
+
+            t.append((new_id, new_embedding, new_image))
+            assert t.embedding_norm[-1] == np.linalg.norm(new_embedding)
+
+        If source values are changed in place, refresh dependent generated
+        columns before relying on them::
+
+            t.embedding[0] = new_embedding
+            t.refresh_generated_column("embedding_norm")
+
+        Raises
+        ------
+        ValueError
+            If called on a view or read-only table, if *name* already exists,
+            if generated output length/shape is incompatible with the table, or
+            if ``create_index=True`` is requested for an ndarray generated
+            column.
+        TypeError
+            If *values* has an unsupported form, references unsupported source
+            columns, or cannot be coerced to *dtype*.
+        KeyError
+            If a :class:`RowTransformer` references a missing source column.
         """
         if self.base is not None:
             raise ValueError("Cannot add a generated column to a view.")
@@ -6679,38 +6797,117 @@ class CTable(Generic[RowT]):
     def add_computed_column(
         self,
         name: str,
-        expr,
+        expr: str | blosc2.LazyExpr | Callable[[dict[str, Any]], blosc2.LazyExpr],
         *,
         dtype: np.dtype | None = None,
     ) -> None:
-        """Add a read-only virtual column whose values are computed from other columns.
+        """Add a read-only virtual column computed from stored columns.
 
-        The column stores no data — it is evaluated on-the-fly when read.
-        It participates in display, filtering, sorting, export (to_arrow / to_csv),
-        and aggregates, but cannot be written to, indexed, or included in
-        ``append`` / ``extend`` inputs.
+        A computed column has no physical storage.  It is backed by a
+        :class:`blosc2.LazyExpr` and is evaluated when values are read, filtered,
+        displayed, exported, or aggregated.  Because it is virtual, it is
+        read-only, cannot be indexed directly, and is not supplied in
+        ``append()`` / ``extend()`` inputs.  To store and optionally index a
+        computed result, use :meth:`add_generated_column` or materialize an
+        existing computed column with :meth:`materialize_computed_column`.
+
+        Supported signatures are::
+
+            add_computed_column(name, "price * qty", dtype=None)
+            add_computed_column(name, lazy_expr, dtype=None)
+            add_computed_column(name, lambda cols: cols["price"] * cols["qty"], dtype=None)
 
         Parameters
         ----------
         name:
-            Column name.  Must not collide with any existing stored or computed
-            column and must satisfy the usual naming rules.
+            Name of the virtual computed column.  It must be a valid column name
+            and must not collide with an existing stored or computed column.
         expr:
-            Either a **callable** ``(cols: dict[str, NDArray]) -> LazyExpr``
-            or an **expression string** (e.g. ``"price * qty"``) where column
-            names are referenced directly and resolved from stored columns.
+            Definition of the virtual column.  Accepted forms:
+
+            * ``str``: scalar expression over stored scalar columns, e.g.
+              ``"price * qty"``.
+            * :class:`blosc2.LazyExpr`: lazy expression over stored columns of
+              this table.
+            * callable: called as ``expr(self._cols)`` and must return a
+              :class:`blosc2.LazyExpr` over stored columns of this table.
+
+            Expressions must depend only on stored columns of this table;
+            computed columns cannot depend on other computed columns in this
+            version.  Fixed-shape ndarray columns are not accepted in computed
+            column expressions yet.  For row-wise ndarray projections or
+            reductions, use :meth:`add_generated_column` with
+            ``values=t.ndarray_col.row_transformer...``.
         dtype:
-            Override the inferred result dtype.  When omitted the dtype is
-            taken from the :class:`blosc2.LazyExpr`.
+            Optional dtype override for the computed values.  When omitted, the
+            dtype is inferred from the resulting :class:`blosc2.LazyExpr`.
+            This changes the dtype reported by the CTable column wrapper; it
+            does not create physical storage.
+
+        Examples
+        --------
+        Add a computed column from a string expression and use it like a normal
+        read-only column::
+
+            t.add_computed_column("total", "price * qty")
+            assert t.total[:].shape == (t.nrows,)
+
+        Add a computed column from a callable.  The callable receives the table's
+        stored column mapping::
+
+            t.add_computed_column(
+                "price_with_tax",
+                lambda cols: cols["price"] * 1.21,
+                dtype=np.float64,
+            )
+
+        Callable expressions can use normal Python logic while still returning a
+        lazy expression::
+
+            def total_expr(cols):
+                base = cols["price"] * cols["qty"]
+                return base * 1.21 if include_tax else base
+
+            t.add_computed_column("total", total_expr)
+
+        They are also convenient for reusable, parameterized helpers::
+
+            def ratio(num, den):
+                return lambda cols: cols[num] / cols[den]
+
+            t.add_computed_column("margin", ratio("profit", "revenue"))
+
+        Computed columns participate in filters and aggregates::
+
+            expensive = t.where(t.total > 100)
+            total_revenue = t.total.sum()
+
+        Computed columns are virtual and read-only.  Materialize one when a
+        stored snapshot or an indexable column is needed::
+
+            t.materialize_computed_column("total", new_name="total_stored")
+            t.create_index("total_stored")
+
+        For maintained stored results, prefer generated columns::
+
+            t.add_generated_column(
+                "total_stored",
+                values="price * qty",
+                dtype=blosc2.float64(),
+                create_index=True,
+            )
 
         Raises
         ------
         ValueError
-            If called on a view, the table is read-only, *name* already
-            exists, or an operand is not a stored column of this table.
+            If called on a view or read-only table, if *name* already exists,
+            or if an expression operand does not reference a stored column of
+            this table.
         TypeError
-            If *expr* is not a callable or string, or does not return a
-            :class:`blosc2.LazyExpr`.
+            If *expr* has an unsupported form, does not produce a
+            :class:`blosc2.LazyExpr`, references unsupported source columns, or
+            if a :class:`RowTransformer` is passed.  Row transformers are only
+            accepted by :meth:`add_generated_column`.
         """
         if self.base is not None:
             raise ValueError("Cannot add a computed column to a view.")

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -6135,7 +6135,7 @@ class CTable(Generic[RowT]):
         return pd.DataFrame(data)
 
     @classmethod
-    def from_pandas(cls, df, row_cls) -> CTable:
+    def from_pandas(cls, df, row_cls) -> CTable:  # noqa: C901
         """Build a :class:`CTable` from a pandas DataFrame.
 
         Schema comes from *row_cls* (a dataclass) — CTable is always typed.
@@ -6184,8 +6184,35 @@ class CTable(Generic[RowT]):
             chunks=default_chunks,
             blocks=default_blocks,
         )
-        new_cols: dict[str, blosc2.NDArray] = {}
+        new_cols: dict[str, Any] = {}
         for col in schema.columns:
+            if cls._is_list_column(col):
+                new_cols[col.name] = mem_storage.create_list_column(
+                    col.name,
+                    spec=col.spec,
+                    cparams=None,
+                    dparams=None,
+                )
+                continue
+            if cls._is_varlen_scalar_column(col):
+                new_cols[col.name] = mem_storage.create_varlen_scalar_column(
+                    col.name,
+                    spec=col.spec,
+                    cparams=None,
+                    dparams=None,
+                )
+                continue
+            if cls._is_dictionary_column(col):
+                dict_col = mem_storage.create_dictionary_column(
+                    col.name,
+                    spec=col.spec,
+                    cparams=None,
+                    dparams=None,
+                )
+                if len(dict_col.codes) < capacity:
+                    dict_col.resize((capacity,))
+                new_cols[col.name] = dict_col
+                continue
             shape = cls._column_physical_shape(col, capacity)
             chunks, blocks = cls._column_chunks_blocks(col, shape)
             new_cols[col.name] = mem_storage.create_column(
@@ -6219,22 +6246,36 @@ class CTable(Generic[RowT]):
         obj._last_pos = 0
 
         if n > 0:
+
+            def normalize_pandas_missing(value):
+                if value is None:
+                    return None
+                if isinstance(value, float) and np.isnan(value):
+                    return None
+                # pandas.NA cannot be compared/coerced reliably; detect it by type name
+                # without importing pandas here.
+                if type(value).__name__ == "NAType":
+                    return None
+                return value
+
+            raw_columns = {}
             for col in schema.columns:
                 series = df[col.name]
-                if isinstance(col.spec, NDArraySpec):
-                    vals = series.values
-                    if vals.dtype != object:
-                        raise ValueError(
-                            f"Column {col.name!r}: expected object dtype in DataFrame "
-                            f"for ndarray column, got {vals.dtype}"
-                        )
-                    batch = cls._coerce_ndarray_batch(col.name, col.spec, vals, n)
-                    new_cols[col.name][:n] = batch
+                if isinstance(col.spec, NDArraySpec) and series.values.dtype != object:
+                    raise ValueError(
+                        f"Column {col.name!r}: expected object dtype in DataFrame "
+                        f"for ndarray column, got {series.values.dtype}"
+                    )
+                if (
+                    cls._is_list_column(col)
+                    or cls._is_varlen_scalar_column(col)
+                    or cls._is_dictionary_column(col)
+                    or isinstance(col.spec, NDArraySpec)
+                ):
+                    raw_columns[col.name] = [normalize_pandas_missing(value) for value in series.tolist()]
                 else:
-                    new_cols[col.name][:n] = series.to_numpy(dtype=col.dtype)
-            new_valid[:n] = True
-            obj._n_rows = n
-            obj._last_pos = n
+                    raw_columns[col.name] = series.to_numpy(dtype=col.dtype)
+            obj.extend(raw_columns, validate=True)
 
         return obj
 

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -1498,9 +1498,10 @@ def _null_output_value(spec: SchemaSpec):
 def group_reduce(keys, values=None, op: AggName = "size", *, sort: bool = False, dropna: bool = True):
     """Group *keys* and reduce *values* with *op*.
 
-    This is a lower-level, NumPy-style grouped reduction primitive.  It exposes
-    Blosc2's optimized group-reduce kernels for plain array-like inputs without
-    requiring a :class:`blosc2.CTable`.
+    This is a lower-level, array-oriented grouped reduction primitive.  It exposes
+    Blosc2's optimized group-reduce kernels for one-dimensional array-like inputs,
+    including NumPy arrays and :class:`blosc2.NDArray`, without requiring a
+    :class:`blosc2.CTable`.
 
     Parameters
     ----------

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -1748,7 +1748,7 @@ def _group_reduce_numpy(  # noqa: C901
 
     order = list(acc)
     if sort:
-        order.sort(key=lambda k: _sortable_key_part(display[k]))
+        order.sort(key=lambda k: _group_reduce_sort_key(display[k]))
     groups = np.asarray([display[k] for k in order], dtype=keys.dtype)
     result = []
     for k in order:
@@ -1766,6 +1766,15 @@ def _group_reduce_numpy(  # noqa: C901
         elif op == "max":
             result.append(max_value if count else _null_value_for(values))
     return groups, np.asarray(result, dtype=_result_dtype(values, op))
+
+
+def _group_reduce_sort_key(value: Any) -> tuple[int, Any]:
+    """Sort group_reduce keys with None first and NaN groups last."""
+    if value is None:
+        return (0, "")
+    if isinstance(value, float) and math.isnan(value):
+        return (2, "")
+    return (1, value)
 
 
 def _maybe_sort(groups: np.ndarray, result: np.ndarray, sort: bool):

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -1008,7 +1008,7 @@ class CTableGroupBy:
                 if spec.input_col is not None:
                     dtype = np.dtype(self.table._schema.columns_by_name[spec.input_col].spec.dtype)
                     out_dtype = np.float64 if dtype.kind == "f" else np.int64
-                states[spec.output_col] = np.zeros(0, dtype=out_dtype)
+                states[spec.output_col] = (np.zeros(0, dtype=out_dtype), np.zeros(0, dtype=np.int64))
             elif spec.op == "mean":
                 states[spec.output_col] = (np.zeros(0, dtype=np.float64), np.zeros(0, dtype=np.int64))
             elif spec.op in {"min", "max"}:
@@ -1027,9 +1027,9 @@ class CTableGroupBy:
             present = np.pad(present, (0, size - old), constant_values=False)
             for spec in specs:
                 state = states[spec.output_col]
-                if spec.op in {"size", "count", "sum"}:
+                if spec.op in {"size", "count"}:
                     states[spec.output_col] = np.pad(state, (0, size - old), constant_values=0)
-                elif spec.op == "mean":
+                elif spec.op in {"sum", "mean"}:
                     sums, counts = state
                     states[spec.output_col] = (
                         np.pad(sums, (0, size - old), constant_values=0),
@@ -1087,13 +1087,16 @@ class CTableGroupBy:
                         keys, weights=non_null.astype(np.int64), minlength=len(present)
                     ).astype(np.int64)
                 elif spec.op == "sum":
-                    state = states[spec.output_col]
+                    sums, counts = states[spec.output_col]
                     if values.dtype.kind in "biu":
-                        np.add.at(state, keys[non_null], values[non_null].astype(np.int64, copy=False))
+                        np.add.at(sums, keys[non_null], values[non_null].astype(np.int64, copy=False))
                     else:
-                        state += np.bincount(
+                        sums += np.bincount(
                             keys, weights=np.where(non_null, values, 0), minlength=len(present)
-                        ).astype(state.dtype, copy=False)
+                        ).astype(sums.dtype, copy=False)
+                    counts += np.bincount(
+                        keys, weights=non_null.astype(np.int64), minlength=len(present)
+                    ).astype(np.int64)
                 elif spec.op == "mean":
                     sums, counts = states[spec.output_col]
                     sums += np.bincount(keys, weights=np.where(non_null, values, 0), minlength=len(present))
@@ -1119,6 +1122,13 @@ class CTableGroupBy:
                     sums, counts = state
                     row[spec.output_col] = (
                         math.nan if counts[code] == 0 else float(sums[code]) / int(counts[code])
+                    )
+                elif spec.op == "sum":
+                    sums, counts = state
+                    row[spec.output_col] = (
+                        _python_scalar(sums[code])
+                        if counts[code] > 0
+                        else _null_output_value(self._result_spec_for_agg(spec))
                     )
                 elif spec.op in {"min", "max"}:
                     values_state, has_state = state

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -89,6 +89,7 @@ class CTableGroupBy:
                 raise NotImplementedError("group_by() over computed columns is not supported yet")
             if name not in table._cols:
                 raise KeyError(f"No column named {name!r}. Available: {table.col_names}")
+            table._ensure_generated_column_not_stale(name)
             col_info = table._schema.columns_by_name[name]
             if isinstance(col_info.spec, NDArraySpec):
                 raise TypeError(
@@ -201,6 +202,7 @@ class CTableGroupBy:
             raise NotImplementedError("group_by() aggregations over computed columns are not supported yet")
         if name not in self.table._cols:
             raise KeyError(f"No column named {name!r}. Available: {self.table.col_names}")
+        self.table._ensure_generated_column_not_stale(name)
         col_info = self.table._schema.columns_by_name[name]
         if self.table._is_list_column(col_info) or self.table._is_varlen_scalar_column(col_info):
             raise TypeError(f"Cannot aggregate variable-length/list column {name!r} in Phase 1")

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -1747,7 +1747,7 @@ def _group_reduce_numpy(  # noqa: C901
 
     order = list(acc)
     if sort:
-        order.sort(key=lambda k: (1, "") if k is _NAN_KEY else (0, display[k]))
+        order.sort(key=lambda k: _sortable_key_part(display[k]))
     groups = np.asarray([display[k] for k in order], dtype=keys.dtype)
     result = []
     for k in order:

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
 
-from blosc2.schema import DictionarySpec, SchemaSpec, float64, int64
+from blosc2.schema import DictionarySpec, NDArraySpec, SchemaSpec, float64, int64
 from blosc2.schema import bool as b2_bool
 from blosc2.schema import field as b2_field
 
@@ -90,6 +90,11 @@ class CTableGroupBy:
             if name not in table._cols:
                 raise KeyError(f"No column named {name!r}. Available: {table.col_names}")
             col_info = table._schema.columns_by_name[name]
+            if isinstance(col_info.spec, NDArraySpec):
+                raise TypeError(
+                    f"Cannot group by ndarray column {name!r} with per-row shape {col_info.spec.item_shape}. "
+                    "Materialize a scalar generated column first, e.g. embedding_norm or embedding_max."
+                )
             if table._is_list_column(col_info) or table._is_varlen_scalar_column(col_info):
                 raise TypeError(f"Cannot group by variable-length/list column {name!r} in Phase 1")
 
@@ -199,6 +204,11 @@ class CTableGroupBy:
         col_info = self.table._schema.columns_by_name[name]
         if self.table._is_list_column(col_info) or self.table._is_varlen_scalar_column(col_info):
             raise TypeError(f"Cannot aggregate variable-length/list column {name!r} in Phase 1")
+        if isinstance(col_info.spec, NDArraySpec):
+            raise TypeError(
+                f"Cannot aggregate ndarray column {name!r} with per-row shape {col_info.spec.item_shape}. "
+                "Materialize a scalar generated column first."
+            )
         if self.table._is_dictionary_column(col_info):
             raise TypeError(f"Cannot aggregate dictionary column {name!r} in Phase 1")
 
@@ -1579,8 +1589,11 @@ def _try_dense_integer(keys: np.ndarray, values: np.ndarray | None, op: str, *, 
     keys_present = np.zeros(max_key + 1, dtype=bool)
 
     if op == "size":
+        kernel = getattr(groupby_ext, "groupby_dense_int_size_checked", None)
+        if kernel is None:
+            return None
         counts = np.zeros(max_key + 1, dtype=np.int64)
-        groupby_ext.groupby_dense_int_size_checked(keys, valid, counts, keys_present, False, 0)
+        kernel(keys, valid, counts, keys_present, False, 0)
         groups = np.nonzero(keys_present)[0].astype(key_dtype if key_dtype.kind != "b" else np.bool_)
         result = counts[np.nonzero(keys_present)[0]]
         return _maybe_sort(groups, result, sort)
@@ -1588,11 +1601,12 @@ def _try_dense_integer(keys: np.ndarray, values: np.ndarray | None, op: str, *, 
     assert values is not None
     value_dtype = np.dtype(values.dtype)
     if op == "count":
+        kernel = getattr(groupby_ext, "groupby_dense_int_count_checked", None)
+        if kernel is None:
+            return None
         counts = np.zeros(max_key + 1, dtype=np.int64)
         values_valid = _values_valid(values)
-        groupby_ext.groupby_dense_int_count_checked(
-            keys, valid, np.ascontiguousarray(values_valid), counts, keys_present, False, 0
-        )
+        kernel(keys, valid, np.ascontiguousarray(values_valid), counts, keys_present, False, 0)
         codes = np.nonzero(keys_present)[0]
         return _maybe_sort(
             codes.astype(key_dtype if key_dtype.kind != "b" else np.bool_), counts[codes], sort
@@ -1602,20 +1616,22 @@ def _try_dense_integer(keys: np.ndarray, values: np.ndarray | None, op: str, *, 
         vals = np.ascontiguousarray(values.astype(np.float64, copy=False))
         skip_nan = value_dtype.kind == "f"
         if op == "sum":
+            kernel = getattr(groupby_ext, "groupby_dense_int_f64_sum_checked", None)
+            if kernel is None:
+                return None
             sums = np.zeros(max_key + 1, dtype=np.float64)
             present = np.zeros(max_key + 1, dtype=bool)
-            groupby_ext.groupby_dense_int_f64_sum_checked(
-                keys, vals, valid, sums, present, keys_present, False, 0, skip_nan
-            )
+            kernel(keys, vals, valid, sums, present, keys_present, False, 0, skip_nan)
             codes = np.nonzero(keys_present)[0]
             result = sums[codes]
             result[~present[codes]] = np.nan
         elif op == "mean":
+            kernel = getattr(groupby_ext, "groupby_dense_int_f64_mean_checked", None)
+            if kernel is None:
+                return None
             sums = np.zeros(max_key + 1, dtype=np.float64)
             counts = np.zeros(max_key + 1, dtype=np.int64)
-            groupby_ext.groupby_dense_int_f64_mean_checked(
-                keys, vals, valid, sums, counts, keys_present, False, 0, skip_nan
-            )
+            kernel(keys, vals, valid, sums, counts, keys_present, False, 0, skip_nan)
             codes = np.nonzero(keys_present)[0]
             result = np.full(len(codes), np.nan, dtype=np.float64)
             ok = counts[codes] > 0
@@ -1623,7 +1639,9 @@ def _try_dense_integer(keys: np.ndarray, values: np.ndarray | None, op: str, *, 
         elif op in {"min", "max"}:
             state = np.zeros(max_key + 1, dtype=np.float64)
             has_value = np.zeros(max_key + 1, dtype=bool)
-            kernel = getattr(groupby_ext, f"groupby_dense_int_f64_{op}_checked")
+            kernel = getattr(groupby_ext, f"groupby_dense_int_f64_{op}_checked", None)
+            if kernel is None:
+                return None
             kernel(keys, vals, valid, state, has_value, keys_present, False, 0, skip_nan)
             codes = np.nonzero(keys_present)[0]
             result = state[codes]
@@ -1667,7 +1685,10 @@ def _try_float_hash(keys: np.ndarray, values: np.ndarray | None, op: str, *, sor
         values_valid = np.ascontiguousarray(_values_valid(values))
         has_values = True
 
-    groups, row_counts, value_counts, sums, mins, maxs, has_value = groupby_ext.groupby_hash_f64_f64(
+    kernel = getattr(groupby_ext, "groupby_hash_f64_f64", None)
+    if kernel is None:
+        return None
+    groups, row_counts, value_counts, sums, mins, maxs, has_value = kernel(
         keys_f64, values_f64, valid, values_valid, has_values, dropna
     )
     groups = groups.astype(key_dtype, copy=False)

--- a/src/blosc2/groupby_ext.pyx
+++ b/src/blosc2/groupby_ext.pyx
@@ -591,6 +591,10 @@ def groupby_dense_int_f64_min_checked(
     bint skip_value_nan=False,
 ):
     """Checked dense integer-key float64 min kernel."""
+    if keys.shape[0] != values.shape[0] or keys.shape[0] != valid.shape[0]:
+        raise ValueError("keys, values and valid must have the same length")
+    if mins.shape[0] != has_value.shape[0] or mins.shape[0] != keys_present.shape[0]:
+        raise ValueError("state arrays must have the same length")
     cdef Py_ssize_t n = keys.shape[0]
     cdef Py_ssize_t nstates = mins.shape[0]
     cdef Py_ssize_t i
@@ -628,6 +632,10 @@ def groupby_dense_int_f64_max_checked(
     bint skip_value_nan=False,
 ):
     """Checked dense integer-key float64 max kernel."""
+    if keys.shape[0] != values.shape[0] or keys.shape[0] != valid.shape[0]:
+        raise ValueError("keys, values and valid must have the same length")
+    if maxs.shape[0] != has_value.shape[0] or maxs.shape[0] != keys_present.shape[0]:
+        raise ValueError("state arrays must have the same length")
     cdef Py_ssize_t n = keys.shape[0]
     cdef Py_ssize_t nstates = maxs.shape[0]
     cdef Py_ssize_t i
@@ -664,6 +672,10 @@ def groupby_dense_int_i64_min_checked(
     int64_t key_null=0,
 ):
     """Checked dense integer-key int64 min kernel."""
+    if keys.shape[0] != values.shape[0] or keys.shape[0] != valid.shape[0]:
+        raise ValueError("keys, values and valid must have the same length")
+    if mins.shape[0] != has_value.shape[0] or mins.shape[0] != keys_present.shape[0]:
+        raise ValueError("state arrays must have the same length")
     cdef Py_ssize_t n = keys.shape[0]
     cdef Py_ssize_t nstates = mins.shape[0]
     cdef Py_ssize_t i
@@ -698,6 +710,10 @@ def groupby_dense_int_i64_max_checked(
     int64_t key_null=0,
 ):
     """Checked dense integer-key int64 max kernel."""
+    if keys.shape[0] != values.shape[0] or keys.shape[0] != valid.shape[0]:
+        raise ValueError("keys, values and valid must have the same length")
+    if maxs.shape[0] != has_value.shape[0] or maxs.shape[0] != keys_present.shape[0]:
+        raise ValueError("state arrays must have the same length")
     cdef Py_ssize_t n = keys.shape[0]
     cdef Py_ssize_t nstates = maxs.shape[0]
     cdef Py_ssize_t i

--- a/src/blosc2/indexing_ext.pyx
+++ b/src/blosc2/indexing_ext.pyx
@@ -834,6 +834,10 @@ def intra_chunk_merge_sorted_slices(
 ):
     cdef np.dtype dtype = left_values.dtype
     cdef np.dtype pos_dtype = np.dtype(position_dtype)
+    if left_values.ndim != 1 or right_values.ndim != 1 or left_positions.ndim != 1 or right_positions.ndim != 1:
+        raise ValueError("values and positions must be 1-D arrays")
+    if left_values.shape[0] != left_positions.shape[0] or right_values.shape[0] != right_positions.shape[0]:
+        raise ValueError("values and positions must have matching lengths")
     if dtype != right_values.dtype:
         raise TypeError("left_values and right_values must have the same dtype")
     if dtype == np.dtype(np.float32):
@@ -1701,6 +1705,8 @@ cdef inline tuple _search_boundary_bounds_uint64_impl(
 
 def index_search_bounds(np.ndarray values, object lower, bint lower_inclusive, object upper, bint upper_inclusive):
     cdef np.dtype dtype = values.dtype
+    if values.ndim != 1:
+        raise ValueError("values must be a 1-D array")
     if dtype == np.dtype(np.float32):
         return _search_bounds_float32_impl(values, lower, lower_inclusive, upper, upper_inclusive)
     if dtype == np.dtype(np.float64):
@@ -1733,6 +1739,10 @@ def index_search_boundary_bounds(
     bint upper_inclusive,
 ):
     cdef np.dtype dtype = starts.dtype
+    if starts.ndim != 1 or ends.ndim != 1:
+        raise ValueError("starts and ends must be 1-D arrays")
+    if starts.shape[0] != ends.shape[0]:
+        raise ValueError("starts and ends must have the same length")
     if dtype != ends.dtype:
         raise TypeError("starts and ends must have the same dtype")
     if dtype == np.dtype(np.float32):
@@ -2290,6 +2300,20 @@ def index_collect_reduced_chunk_nav_positions(
     bint upper_inclusive,
 ):
     cdef np.dtype dtype = span_values.dtype
+    cdef Py_ssize_t idx
+    cdef int64_t chunk_id
+    if span_values.ndim != 1 or local_positions.ndim != 1:
+        raise ValueError("span_values and local_positions must be 1-D arrays")
+    if chunk_len <= 0:
+        raise ValueError("chunk_len must be positive")
+    if nav_segment_len <= 0:
+        raise ValueError("nav_segment_len must be positive")
+    if nsegments_per_chunk <= 0:
+        raise ValueError("nsegments_per_chunk must be positive")
+    for idx in range(candidate_chunk_ids.shape[0]):
+        chunk_id = candidate_chunk_ids[idx]
+        if chunk_id < 0 or chunk_id + 1 >= offsets.shape[0]:
+            raise ValueError("candidate_chunk_ids contains an out-of-bounds chunk id")
     if dtype == np.dtype(np.float32):
         return _collect_chunk_positions_float32(
             offsets, candidate_chunk_ids, values_sidecar, positions_sidecar, l2_sidecar, l2_row,

--- a/src/blosc2/schema.py
+++ b/src/blosc2/schema.py
@@ -709,7 +709,7 @@ class NDArraySpec(SchemaSpec):
 
     python_type = _builtin_object
 
-    def __init__(self, item_shape, dtype=np.float64):
+    def __init__(self, item_shape, dtype=np.float64, *, nullable: bool = False, null_value=None):
         if isinstance(item_shape, int):
             item_shape = (item_shape,)
         item_shape = tuple(int(s) for s in item_shape)
@@ -719,6 +719,9 @@ class NDArraySpec(SchemaSpec):
             raise ValueError("All NDArraySpec item_shape dimensions must be positive.")
         self.item_shape = item_shape
         self.dtype = np.dtype(dtype)
+        self.nullable = nullable or null_value is not None
+        if null_value is not None:
+            self.null_value = null_value
         self.itemsize = self.dtype.itemsize
         self.kind = self.dtype.kind
         self.type = self.dtype.type
@@ -729,19 +732,24 @@ class NDArraySpec(SchemaSpec):
         return {}
 
     def to_metadata_dict(self) -> dict[str, Any]:
-        return {
+        d = {
             "kind": "ndarray",
             "item_shape": _builtin_list(self.item_shape),
             "dtype_str": self.dtype.str,
         }
+        if self.nullable:
+            d["nullable"] = True
+        if hasattr(self, "null_value"):
+            d["null_value"] = self.null_value
+        return d
 
     def display_label(self) -> str:
         return f"ndarray{_builtin_list(self.item_shape)}[{self.dtype}]"
 
 
-def ndarray(item_shape, dtype=np.float64) -> NDArraySpec:
+def ndarray(item_shape, dtype=np.float64, *, nullable: bool = False, null_value=None) -> NDArraySpec:
     """Build a fixed-shape N-D array descriptor for CTable columns."""
-    return NDArraySpec(item_shape=item_shape, dtype=dtype)
+    return NDArraySpec(item_shape=item_shape, dtype=dtype, nullable=nullable, null_value=null_value)
 
 
 def vlstring(

--- a/src/blosc2/schema.py
+++ b/src/blosc2/schema.py
@@ -694,6 +694,56 @@ class VLBytesSpec(SchemaSpec):
         return d
 
 
+# ---------------------------------------------------------------------------
+# Fixed-shape N-D array spec
+# ---------------------------------------------------------------------------
+
+
+class NDArraySpec(SchemaSpec):
+    """Fixed-shape N-D array column for CTable.
+
+    Each row stores a NumPy-compatible array with shape ``item_shape`` and
+    element dtype ``dtype``.  Physically, CTable stores the column as a Blosc2
+    NDArray with shape ``(nrows, *item_shape)``.
+    """
+
+    python_type = _builtin_object
+
+    def __init__(self, item_shape, dtype=np.float64):
+        if isinstance(item_shape, int):
+            item_shape = (item_shape,)
+        item_shape = tuple(int(s) for s in item_shape)
+        if not item_shape:
+            raise ValueError("NDArraySpec item_shape must have at least one dimension.")
+        if any(s <= 0 for s in item_shape):
+            raise ValueError("All NDArraySpec item_shape dimensions must be positive.")
+        self.item_shape = item_shape
+        self.dtype = np.dtype(dtype)
+        self.itemsize = self.dtype.itemsize
+        self.kind = self.dtype.kind
+        self.type = self.dtype.type
+        self.str = self.dtype.str
+        self.name = self.dtype.name
+
+    def to_pydantic_kwargs(self) -> dict[str, Any]:
+        return {}
+
+    def to_metadata_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "ndarray",
+            "item_shape": _builtin_list(self.item_shape),
+            "dtype_str": self.dtype.str,
+        }
+
+    def display_label(self) -> str:
+        return f"ndarray{_builtin_list(self.item_shape)}[{self.dtype}]"
+
+
+def ndarray(item_shape, dtype=np.float64) -> NDArraySpec:
+    """Build a fixed-shape N-D array descriptor for CTable columns."""
+    return NDArraySpec(item_shape=item_shape, dtype=dtype)
+
+
 def vlstring(
     *,
     nullable: bool = False,

--- a/src/blosc2/schema.py
+++ b/src/blosc2/schema.py
@@ -26,6 +26,13 @@ _builtin_list = list
 _builtin_object = object
 
 
+def _normalize_scalar_value(value):
+    """Convert NumPy scalar sentinels to plain Python scalars."""
+    if isinstance(value, np.generic):
+        return value.item()
+    return value
+
+
 # ---------------------------------------------------------------------------
 # Base spec class
 # ---------------------------------------------------------------------------
@@ -90,7 +97,7 @@ class _NumericSpec(SchemaSpec):
         self.le = le
         self.lt = lt
         self.nullable = nullable or null_value is not None
-        self.null_value = null_value
+        self.null_value = _normalize_scalar_value(null_value)
 
     def to_pydantic_kwargs(self) -> dict[str, Any]:
         # null_value is not a Pydantic constraint — exclude it from Pydantic kwargs.
@@ -249,7 +256,7 @@ class timestamp(SchemaSpec):
         self.unit = unit
         self.timezone = timezone
         self.nullable = nullable or null_value is not None
-        self.null_value = null_value
+        self.null_value = _normalize_scalar_value(null_value)
 
     def to_pydantic_kwargs(self) -> dict[str, Any]:
         return {}
@@ -279,7 +286,7 @@ class bool(SchemaSpec):
         if null_value is not None and null_value != 255:
             raise ValueError("Nullable bool null_value must be 255")
         self.nullable = nullable or null_value is not None
-        self.null_value = null_value
+        self.null_value = _normalize_scalar_value(null_value)
         self.dtype = np.dtype(np.uint8) if self.nullable else np.dtype(np.bool_)
 
     def to_pydantic_kwargs(self) -> dict[str, Any]:
@@ -327,7 +334,7 @@ class string(SchemaSpec):
         self.max_length = max_length if max_length is not None else self._DEFAULT_MAX_LENGTH
         self.pattern = pattern
         self.nullable = nullable or null_value is not None
-        self.null_value = null_value
+        self.null_value = _normalize_scalar_value(null_value)
         self.dtype = np.dtype(f"U{self.max_length}")
 
     def to_pydantic_kwargs(self) -> dict[str, Any]:
@@ -373,7 +380,7 @@ class bytes(SchemaSpec):
         self.min_length = min_length
         self.max_length = max_length if max_length is not None else self._DEFAULT_MAX_LENGTH
         self.nullable = nullable or null_value is not None
-        self.null_value = null_value
+        self.null_value = _normalize_scalar_value(null_value)
         self.dtype = np.dtype(f"S{self.max_length}")
 
     def to_pydantic_kwargs(self) -> dict[str, Any]:
@@ -721,7 +728,7 @@ class NDArraySpec(SchemaSpec):
         self.dtype = np.dtype(dtype)
         self.nullable = nullable or null_value is not None
         if null_value is not None:
-            self.null_value = null_value
+            self.null_value = _normalize_scalar_value(null_value)
         self.itemsize = self.dtype.itemsize
         self.kind = self.dtype.kind
         self.type = self.dtype.type

--- a/src/blosc2/schema_compiler.py
+++ b/src/blosc2/schema_compiler.py
@@ -24,6 +24,7 @@ from blosc2.schema import (
     BLOSC2_FIELD_METADATA_KEY,
     DictionarySpec,
     ListSpec,
+    NDArraySpec,
     ObjectSpec,
     SchemaSpec,
     StructSpec,
@@ -79,6 +80,8 @@ _KIND_TO_SPEC: dict[str, type[SchemaSpec]] = {
     "timestamp": timestamp,
     # dictionary
     "dictionary": DictionarySpec,
+    # fixed-shape N-D arrays
+    "ndarray": NDArraySpec,
 }
 
 # ---------------------------------------------------------------------------
@@ -109,6 +112,8 @@ def compute_display_width(spec: SchemaSpec) -> int:
         return 32
     if isinstance(spec, (VLStringSpec, VLBytesSpec, ObjectSpec)):
         return 40
+    if isinstance(spec, NDArraySpec):
+        return max(20, len(spec.display_label()) + 4)
     if isinstance(spec, (ListSpec, StructSpec)):
         return max(40, len(spec.display_label()) + 4)
     if isinstance(spec, timestamp):
@@ -212,6 +217,14 @@ def infer_spec_from_annotation(annotation: Any) -> SchemaSpec:
 
 def validate_annotation_matches_spec(name: str, annotation: Any, spec: SchemaSpec) -> None:
     """Raise :exc:`TypeError` if *annotation* is incompatible with *spec*."""
+    if isinstance(spec, NDArraySpec):
+        if annotation not in (np.ndarray, object):
+            raise TypeError(
+                f"Column {name!r}: annotation {annotation!r} is incompatible with "
+                "NDArraySpec (expected np.ndarray or object)."
+            )
+        return
+
     if isinstance(spec, ListSpec):
         origin = typing.get_origin(annotation)
         if origin not in (list, list):
@@ -358,7 +371,7 @@ def compile_schema(row_cls: type[Any]) -> CompiledSchema:
         columns.append(
             CompiledColumn(
                 name=name,
-                py_type=object if isinstance(spec, timestamp) else annotation,
+                py_type=object if isinstance(spec, (timestamp, NDArraySpec)) else annotation,
                 spec=spec,
                 dtype=getattr(spec, "dtype", None),
                 default=default,
@@ -422,6 +435,8 @@ def spec_from_metadata_dict(data: dict[str, Any]) -> SchemaSpec:
         index_type = spec_from_metadata_dict(data.pop("index_type"))
         value_type = spec_from_metadata_dict(data.pop("value_type"))
         return DictionarySpec(index_type=index_type, value_type=value_type, **data)
+    if kind == "ndarray":
+        return NDArraySpec(item_shape=tuple(data.pop("item_shape")), dtype=np.dtype(data.pop("dtype_str")))
     spec_cls = _KIND_TO_SPEC.get(kind)
     if spec_cls is None:
         raise ValueError(f"Unknown column kind {kind!r}")

--- a/src/blosc2/schema_compiler.py
+++ b/src/blosc2/schema_compiler.py
@@ -436,7 +436,9 @@ def spec_from_metadata_dict(data: dict[str, Any]) -> SchemaSpec:
         value_type = spec_from_metadata_dict(data.pop("value_type"))
         return DictionarySpec(index_type=index_type, value_type=value_type, **data)
     if kind == "ndarray":
-        return NDArraySpec(item_shape=tuple(data.pop("item_shape")), dtype=np.dtype(data.pop("dtype_str")))
+        return NDArraySpec(
+            item_shape=tuple(data.pop("item_shape")), dtype=np.dtype(data.pop("dtype_str")), **data
+        )
     spec_cls = _KIND_TO_SPEC.get(kind)
     if spec_cls is None:
         raise ValueError(f"Unknown column kind {kind!r}")

--- a/src/blosc2/schema_validation.py
+++ b/src/blosc2/schema_validation.py
@@ -14,13 +14,15 @@ schema layer never import from Pydantic directly.
 
 from __future__ import annotations
 
+import math
 from dataclasses import MISSING
 from typing import Any
 
+import numpy as np
 from pydantic import BaseModel, Field, ValidationError, create_model
 
 from blosc2.list_array import _coerce_struct_item, coerce_list_cell
-from blosc2.schema import ListSpec, StructSpec
+from blosc2.schema import ListSpec, NDArraySpec, StructSpec
 from blosc2.schema_compiler import CompiledSchema  # noqa: TC001
 
 
@@ -98,7 +100,17 @@ def _mask_nulls(schema: CompiledSchema, row: dict[str, Any]) -> tuple[dict[str, 
         if nv is None:
             continue
         val = row.get(col.name)
-        if _is_null_value(val, nv):
+        if isinstance(col.spec, NDArraySpec):
+            try:
+                arr = np.asarray(val, dtype=col.spec.dtype)
+                is_null = arr.shape == col.spec.item_shape and bool(
+                    np.isnan(arr).all() if isinstance(nv, float) and math.isnan(nv) else (arr == nv).all()
+                )
+            except Exception:
+                is_null = val is None
+        else:
+            is_null = _is_null_value(val, nv)
+        if is_null:
             nulled[col.name] = val
             masked[col.name] = None
     return masked, nulled

--- a/src/blosc2/schema_validation.py
+++ b/src/blosc2/schema_validation.py
@@ -76,8 +76,8 @@ def _is_null_value(val, null_value) -> bool:
     if null_value is None:
         return False
     try:
-        if isinstance(null_value, float) and math.isnan(null_value):
-            return isinstance(val, float) and math.isnan(val)
+        if isinstance(null_value, (float, np.floating)) and math.isnan(null_value):
+            return isinstance(val, (float, np.floating)) and math.isnan(val)
     except TypeError:
         pass
     return val == null_value
@@ -104,7 +104,9 @@ def _mask_nulls(schema: CompiledSchema, row: dict[str, Any]) -> tuple[dict[str, 
             try:
                 arr = np.asarray(val, dtype=col.spec.dtype)
                 is_null = arr.shape == col.spec.item_shape and bool(
-                    np.isnan(arr).all() if isinstance(nv, float) and math.isnan(nv) else (arr == nv).all()
+                    np.isnan(arr).all()
+                    if isinstance(nv, (float, np.floating)) and math.isnan(nv)
+                    else (arr == nv).all()
                 )
             except Exception:
                 is_null = val is None

--- a/src/blosc2/schema_vectorized.py
+++ b/src/blosc2/schema_vectorized.py
@@ -20,7 +20,7 @@ from typing import Any
 import numpy as np
 
 from blosc2.list_array import _coerce_struct_item, coerce_list_cell
-from blosc2.schema import ListSpec, ObjectSpec, StructSpec
+from blosc2.schema import ListSpec, NDArraySpec, ObjectSpec, StructSpec
 from blosc2.schema_compiler import CompiledColumn, CompiledSchema  # noqa: TC001
 
 
@@ -87,6 +87,21 @@ def validate_column_values(col: CompiledColumn, values: Any) -> None:  # noqa: C
                 _coerce_struct_item(spec, value)
         return
     if isinstance(spec, ObjectSpec):
+        return
+    if isinstance(spec, NDArraySpec):
+        arr = np.asarray(values, dtype=spec.dtype)
+        if arr.ndim == len(spec.item_shape):
+            # A bare row value reached batch validation; accept it only when it
+            # has the declared per-row shape.
+            if arr.shape != spec.item_shape:
+                raise ValueError(
+                    f"Column '{col.name}': expected item shape {spec.item_shape}, got {arr.shape}"
+                )
+            return
+        if arr.shape[1:] != spec.item_shape:
+            raise ValueError(
+                f"Column '{col.name}': expected item shape {spec.item_shape}, got {arr.shape[1:]}"
+            )
         return
 
     arr = np.asarray(values)

--- a/src/blosc2/schema_vectorized.py
+++ b/src/blosc2/schema_vectorized.py
@@ -89,6 +89,14 @@ def validate_column_values(col: CompiledColumn, values: Any) -> None:  # noqa: C
     if isinstance(spec, ObjectSpec):
         return
     if isinstance(spec, NDArraySpec):
+        if getattr(spec, "null_value", None) is not None and not (
+            isinstance(values, np.ndarray) and values.dtype != object
+        ):
+            from blosc2.ctable import CTable
+
+            for value in values:
+                CTable._coerce_ndarray_value(col.name, spec, value)
+            return
         arr = np.asarray(values, dtype=spec.dtype)
         if arr.ndim == len(spec.item_shape):
             # A bare row value reached batch validation; accept it only when it

--- a/tests/ctable/test_column.py
+++ b/tests/ctable/test_column.py
@@ -74,16 +74,21 @@ def test_column_float32_repr_uses_numpy_formatting():
 
 
 def test_column_info():
-    """Column.info reports logical and physical storage details."""
+    """Column.info reports logical shape plus physical storage details."""
     tabla = CTable(Row, new_data=DATA20)
     info = tabla.score.info
     text = repr(info)
+    items = dict(tabla.score.info_items)
 
     assert len(info) == len(tabla.score.info_items)
     assert ("type", "Column") in tabla.score.info_items
     assert ("name", "score") in tabla.score.info_items
-    assert "logical_length" in text
-    assert "physical_length" in text
+    assert items["nrows"] == 20
+    assert items["shape"] == (20,)
+    assert "chunks" in items
+    assert "blocks" in items
+    assert "logical_length" not in text
+    assert "physical_length" not in text
     assert "logical_shape" not in text
     assert "table_physical_length" not in text
     assert "storage" in text

--- a/tests/ctable/test_csv_interop.py
+++ b/tests/ctable/test_csv_interop.py
@@ -445,6 +445,33 @@ def test_from_pandas_all_scalars_roundtrip():
 
 
 @dataclass
+class PandasSpecialRow:
+    vendor: str = blosc2.field(blosc2.dictionary())
+    note: str = blosc2.field(blosc2.vlstring(nullable=True))
+    tags: list[str] = blosc2.field(blosc2.list(blosc2.string(max_length=16), nullable=True))  # noqa: RUF009
+
+
+def test_from_pandas_special_columns_roundtrip():
+    """from_pandas creates the specialized backing storage required by non-ndarray columns."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "vendor": ["Uber", "Lyft", "Uber"],
+            "note": ["fast", None, "ok"],
+            "tags": [["airport", "night"], None, []],
+        }
+    )
+
+    t = CTable.from_pandas(df, PandasSpecialRow)
+
+    assert t["vendor"][:] == ["Uber", "Lyft", "Uber"]
+    assert t["note"][:] == ["fast", None, "ok"]
+    assert t["tags"][:] == [["airport", "night"], None, []]
+
+
+@dataclass
 class NdarrayMixedRow:
     id: int = blosc2.field(blosc2.int64())
     image: object = blosc2.field(blosc2.ndarray((2, 2, 3), dtype=blosc2.float32()))

--- a/tests/ctable/test_csv_interop.py
+++ b/tests/ctable/test_csv_interop.py
@@ -231,5 +231,256 @@ def test_from_csv_not_dataclass_raises(tmp_csv):
         CTable.from_csv(tmp_csv, int)
 
 
+# ===========================================================================
+# from_csv / to_csv with fixed-shape ndarray columns
+# ===========================================================================
+
+
+@dataclass
+class NdarrayRow:
+    id: int = blosc2.field(blosc2.int64(ge=0))
+    embedding: object = blosc2.field(blosc2.ndarray((3,), dtype=blosc2.float32()))
+
+
+@dataclass
+class NullableNdarrayRow:
+    id: int = blosc2.field(blosc2.int32())
+    codes: object = blosc2.field(blosc2.ndarray((2,), dtype=blosc2.int16(), nullable=True))
+    image: object = blosc2.field(blosc2.ndarray((2, 2, 3), dtype=blosc2.float32(), nullable=True))
+
+
+@pytest.fixture
+def ndarray_table():
+    return CTable(
+        NdarrayRow,
+        new_data=[
+            (1, np.array([1.0, 2.0, 3.0], dtype=np.float32)),
+            (2, np.array([4.0, 5.0, 6.0], dtype=np.float32)),
+        ],
+    )
+
+
+@pytest.fixture
+def nullable_ndarray_table():
+    return CTable(
+        NullableNdarrayRow,
+        new_data=[
+            (1, None, None),
+            (2, np.array([10, 20], dtype=np.int16), np.ones((2, 2, 3), dtype=np.float32)),
+            (3, np.array([1, 2], dtype=np.int16), None),
+        ],
+    )
+
+
+def test_to_csv_ndarray_roundtrip(ndarray_table, tmp_csv):
+    """1-D ndarray column values are serialised as JSON arrays and restored correctly."""
+    ndarray_table.to_csv(tmp_csv)
+    t2 = CTable.from_csv(tmp_csv, NdarrayRow)
+    assert len(t2) == 2
+    np.testing.assert_array_equal(t2["id"][:], ndarray_table["id"][:])
+    np.testing.assert_array_equal(t2["embedding"][:], ndarray_table["embedding"][:])
+
+
+def test_to_csv_ndarray_json_format(ndarray_table, tmp_csv):
+    """CSV cells hold valid JSON arrays."""
+    import csv
+    import json
+
+    ndarray_table.to_csv(tmp_csv)
+    with open(tmp_csv) as f:
+        reader = csv.reader(f)
+        header = next(reader)
+        row1 = next(reader)
+    assert header == ["id", "embedding"]
+    # CSV cell is a JSON array string; parse it
+    row1_embedding = json.loads(row1[1])
+    assert row1_embedding == [1.0, 2.0, 3.0]
+
+
+def test_to_csv_nullable_ndarray_writes_empty_cells(nullable_ndarray_table, tmp_csv):
+    """Null ndarray cells serialise as empty CSV fields."""
+    nullable_ndarray_table.to_csv(tmp_csv)
+    with open(tmp_csv) as f:
+        lines = f.read().strip().split("\n")
+    # Row 0: id=1, codes=null, image=null  → "1,,"
+    assert lines[1].endswith(",")
+
+
+def test_from_csv_nullable_ndarray_restores_nulls(nullable_ndarray_table, tmp_csv):
+    """Empty CSV cells restore as null sentinel arrays."""
+    nullable_ndarray_table.to_csv(tmp_csv)
+    t2 = CTable.from_csv(tmp_csv, NullableNdarrayRow)
+    assert t2["codes"].null_count() == 1
+    assert t2["image"].null_count() == 2
+    np.testing.assert_array_equal(t2["codes"].is_null(), np.array([True, False, False]))
+    np.testing.assert_array_equal(t2["image"].is_null(), np.array([True, False, True]))
+
+
+def test_to_csv_empty_ndarray_table(tmp_csv):
+    """Empty table with ndarray columns writes header only."""
+    t = CTable(NdarrayRow)
+    t.to_csv(tmp_csv)
+    with open(tmp_csv) as f:
+        content = f.read().strip()
+    assert content == "id,embedding"
+
+
+def test_to_csv_ndarray_select_view(ndarray_table, tmp_csv):
+    """Column-projection view with ndarray columns writes correctly."""
+    ndarray_table.select(["id", "embedding"]).to_csv(tmp_csv)
+    with open(tmp_csv) as f:
+        lines = f.read().strip().split("\n")
+    assert lines[0] == "id,embedding"
+    assert len(lines) == 3  # header + 2 rows
+
+
+def test_from_csv_ndarray_wrong_shape_raises(tmp_csv):
+    """CSV cell with wrong-shaped JSON array raises ValueError."""
+    with open(tmp_csv, "w") as f:
+        f.write("id,embedding\n")
+        f.write('1,"[1.0, 2.0]"\n')  # only 2 elements, expected 3
+    with pytest.raises(ValueError, match="expected item shape"):
+        CTable.from_csv(tmp_csv, NdarrayRow)
+
+
+# ===========================================================================
+# to_pandas / from_pandas with fixed-shape ndarray columns
+# ===========================================================================
+
+
+@pytest.fixture
+def pandas_table():
+    pytest.importorskip("pandas")
+    return CTable(
+        NdarrayRow,
+        new_data=[
+            (1, np.array([1.0, 2.0, 3.0], dtype=np.float32)),
+            (2, np.array([4.0, 5.0, 6.0], dtype=np.float32)),
+        ],
+    )
+
+
+def test_to_pandas_scalar_columns(pandas_table):
+    """Scalar columns become regular DataFrame columns."""
+    df = pandas_table.to_pandas()
+    assert df["id"].tolist() == [1, 2]
+    assert df["id"].dtype == np.int64
+
+
+def test_to_pandas_ndarray_columns_are_object_dtype(pandas_table):
+    """Ndarray columns become object-dtype with NumPy arrays in each cell."""
+    df = pandas_table.to_pandas()
+    assert df["embedding"].dtype == object
+    np.testing.assert_array_equal(df["embedding"][0], np.array([1.0, 2.0, 3.0], dtype=np.float32))
+    np.testing.assert_array_equal(df["embedding"][1], np.array([4.0, 5.0, 6.0], dtype=np.float32))
+
+
+def test_from_pandas_roundtrip(pandas_table):
+    """DataFrame roundtrip through from_pandas preserves all values."""
+    df = pandas_table.to_pandas()
+    t2 = CTable.from_pandas(df, NdarrayRow)
+    np.testing.assert_array_equal(t2["id"][:], pandas_table["id"][:])
+    np.testing.assert_array_equal(t2["embedding"][:], pandas_table["embedding"][:])
+
+
+def test_from_pandas_missing_columns_raises(pandas_table):
+    """DataFrame missing schema columns raises ValueError."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = pd.DataFrame({"id": [1, 2]})
+    with pytest.raises(ValueError, match="missing columns"):
+        CTable.from_pandas(df, NdarrayRow)
+
+
+def test_from_pandas_extra_columns_raises(pandas_table):
+    """DataFrame with extra columns beyond schema raises ValueError."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {"id": [1, 2], "embedding": [np.array([1, 2, 3], dtype=np.float32)] * 2, "extra": [99, 100]}
+    )
+    with pytest.raises(ValueError, match="has extra columns"):
+        CTable.from_pandas(df, NdarrayRow)
+
+
+def test_from_pandas_ndarray_not_object_dtype_raises():
+    """Non-object scalar column mapped to ndarray schema raises."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = pd.DataFrame({"id": [1, 2], "embedding": [1.0, 2.0]})  # float column, not object
+    with pytest.raises(ValueError, match="expected object dtype"):
+        CTable.from_pandas(df, NdarrayRow)
+
+
+@dataclass
+class AllScalarsRow:
+    a_int: int = blosc2.field(blosc2.int64())
+    a_float: float = blosc2.field(blosc2.float64())
+    a_bool: bool = blosc2.field(blosc2.bool())
+    a_str: str = blosc2.field(blosc2.string(max_length=32))
+
+
+def test_from_pandas_all_scalars_roundtrip():
+    """DataFrame with only scalar columns roundtrips correctly."""
+    pytest.importorskip("pandas")
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {
+            "a_int": [1, 2, 3],
+            "a_float": [1.0, 2.0, 3.0],
+            "a_bool": [True, False, True],
+            "a_str": ["hello", "world", "!"],
+        }
+    )
+    t = CTable.from_pandas(df, AllScalarsRow)
+    assert len(t) == 3
+    np.testing.assert_array_equal(t["a_int"][:], df["a_int"].to_numpy())
+    np.testing.assert_array_equal(t["a_float"][:], df["a_float"].to_numpy())
+    np.testing.assert_array_equal(t["a_bool"][:], df["a_bool"].to_numpy())
+    assert t["a_str"][:].tolist() == df["a_str"].tolist()
+
+
+@dataclass
+class NdarrayMixedRow:
+    id: int = blosc2.field(blosc2.int64())
+    image: object = blosc2.field(blosc2.ndarray((2, 2, 3), dtype=blosc2.float32()))
+    label: str = blosc2.field(blosc2.string(max_length=16))
+
+
+def test_to_pandas_multi_dim_ndarray():
+    """Multi-dimensional ndarray columns export as object-dtype cells."""
+    pytest.importorskip("pandas")
+    t = CTable(
+        NdarrayMixedRow,
+        new_data=[
+            (1, np.ones((2, 2, 3), dtype=np.float32), "a"),
+            (2, np.full((2, 2, 3), 2.0, dtype=np.float32), "b"),
+        ],
+    )
+    df = t.to_pandas()
+    assert df["image"].dtype == object
+    np.testing.assert_array_equal(df["image"][0], np.ones((2, 2, 3), dtype=np.float32))
+    assert df["label"].tolist() == ["a", "b"]
+
+
+def test_from_pandas_multi_dim_ndarray_roundtrip():
+    """Multi-dimensional ndarray roundtrip from DataFrame works."""
+    pytest.importorskip("pandas")
+    t = CTable(
+        NdarrayMixedRow,
+        new_data=[
+            (1, np.ones((2, 2, 3), dtype=np.float32), "a"),
+        ],
+    )
+    df = t.to_pandas()
+    t2 = CTable.from_pandas(df, NdarrayMixedRow)
+    np.testing.assert_array_equal(t2["image"][:], t["image"][:])
+    assert t2["label"][:].tolist() == t["label"][:].tolist()
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/ctable/test_csv_interop.py
+++ b/tests/ctable/test_csv_interop.py
@@ -343,6 +343,22 @@ def test_from_csv_ndarray_wrong_shape_raises(tmp_csv):
         CTable.from_csv(tmp_csv, NdarrayRow)
 
 
+def test_from_csv_nonnullable_ndarray_empty_cell_raises(tmp_csv):
+    with open(tmp_csv, "w") as f:
+        f.write("id,embedding\n")
+        f.write("1,\n")
+    with pytest.raises(ValueError, match="non-nullable column got empty cell"):
+        CTable.from_csv(tmp_csv, NdarrayRow)
+
+
+def test_from_csv_ndarray_invalid_json_raises(tmp_csv):
+    with open(tmp_csv, "w") as f:
+        f.write("id,embedding\n")
+        f.write('1,"not-json"\n')
+    with pytest.raises(ValueError, match="invalid JSON array cell"):
+        CTable.from_csv(tmp_csv, NdarrayRow)
+
+
 # ===========================================================================
 # to_pandas / from_pandas with fixed-shape ndarray columns
 # ===========================================================================

--- a/tests/ctable/test_ctable_dataclass_schema.py
+++ b/tests/ctable/test_ctable_dataclass_schema.py
@@ -320,6 +320,67 @@ def test_new_spec_constraints_enforced():
         t2.extend([(-1,)])  # violates ge=0
 
 
+# -------------------------------------------------------------------
+# Nested column namespaces
+# -------------------------------------------------------------------
+
+
+def test_nested_column_namespace_info():
+    @dataclass
+    class NestedRow:
+        trip_begin_lon: float
+        trip_begin_lat: float
+        payment_fare: float
+
+    t = CTable(NestedRow)
+    t.append((1.0, 2.0, 10.0))
+    t.append((3.0, 4.0, 20.0))
+    t.rename_column("trip_begin_lon", "trip.begin.lon")
+    t.rename_column("trip_begin_lat", "trip.begin.lat")
+    t.rename_column("payment_fare", "payment.fare")
+
+    info = t.trip.info
+
+    assert len(info) == len(t.trip.info_items)
+    items = dict(t.trip.info_items)
+    assert list(items) == ["type", "storage", "nrows", "nbytes", "cbytes", "cratio", "schema"]
+    assert items["nrows"] == 2
+    assert t.trip.col_names == ["begin.lon", "begin.lat"]
+
+    text = repr(info)
+    assert "NestedColumnNamespace" in text
+    assert "storage" in text
+    assert "schema" in text
+    assert "begin.lon" in text
+    assert "payment.fare" not in text
+
+
+def test_nested_column_namespace_nested_info():
+    @dataclass
+    class NestedRow:
+        trip_begin_lon: float
+        trip_begin_lat: float
+        payment_fare: float
+
+    t = CTable(NestedRow)
+    t.append((1.0, 2.0, 10.0))
+    t.rename_column("trip_begin_lon", "trip.begin.lon")
+    t.rename_column("trip_begin_lat", "trip.begin.lat")
+    t.rename_column("payment_fare", "payment.fare")
+
+    assert list(dict(t.trip.begin.info_items)) == [
+        "type",
+        "storage",
+        "nrows",
+        "nbytes",
+        "cbytes",
+        "cratio",
+        "schema",
+    ]
+    assert t.trip.begin.col_names == ["lon", "lat"]
+    assert "lon" in repr(t.trip.begin.info)
+
+
 if __name__ == "__main__":
     import pytest
 

--- a/tests/ctable/test_ctable_dataclass_schema.py
+++ b/tests/ctable/test_ctable_dataclass_schema.py
@@ -138,6 +138,43 @@ def test_extend_numpy_structured():
     assert t[1].score == 75.0
 
 
+def test_fixed_shape_ndarray_column_roundtrip(tmp_path):
+    @dataclass
+    class ArrayRow:
+        id: int
+        matrix: np.ndarray = blosc2.field(blosc2.ndarray((2, 3), dtype=np.float32))  # noqa: RUF009
+
+    data = np.arange(12, dtype=np.float32).reshape(2, 2, 3)
+    t = CTable(ArrayRow, expected_size=1)
+    t.append((0, data[0]))
+    t.extend({"id": [1], "matrix": data[1:2]})
+
+    assert t._cols["matrix"].shape == (2, 2, 3)
+    assert t.matrix.shape == (2, 2, 3)
+    assert np.array_equal(t[0].matrix, data[0])
+    assert np.array_equal(t.matrix[:], data)
+
+    arr = np.asarray(t)
+    assert arr.dtype["matrix"].shape == (2, 3)
+    assert np.array_equal(arr["matrix"], data)
+
+    path = tmp_path / "array-col.b2d"
+    t.save(path)
+    reopened = CTable.open(path)
+    assert reopened._cols["matrix"].shape == (2, 2, 3)
+    assert np.array_equal(reopened.matrix[:], data)
+
+
+def test_fixed_shape_ndarray_column_rejects_wrong_shape():
+    @dataclass
+    class ArrayRow:
+        matrix: np.ndarray = blosc2.field(blosc2.ndarray((2, 3), dtype=np.float64))  # noqa: RUF009
+
+    t = CTable(ArrayRow)
+    with pytest.raises(ValueError, match="expected item shape"):
+        t.append((np.arange(5),))
+
+
 # -------------------------------------------------------------------
 # extend — per-call validate override
 # -------------------------------------------------------------------

--- a/tests/ctable/test_ctable_ndarray_columns.py
+++ b/tests/ctable/test_ctable_ndarray_columns.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+import blosc2
+
+
+@dataclass
+class Row:
+    id: int = blosc2.field(blosc2.int32())
+    embedding: object = blosc2.field(blosc2.ndarray((3,), dtype=blosc2.float32()))
+    image: object = blosc2.field(blosc2.ndarray((2, 2, 3), dtype=blosc2.float32()))
+
+
+DATA = [
+    (1, np.array([1, 2, 3], dtype=np.float32), np.ones((2, 2, 3), dtype=np.float32)),
+    (2, np.array([4, 5, 6], dtype=np.float32), np.full((2, 2, 3), 2, dtype=np.float32)),
+]
+
+
+def table():
+    return blosc2.CTable(Row, new_data=DATA)
+
+
+def test_ndarray_column_metadata_and_tuple_indexing():
+    t = table()
+
+    assert t.embedding.shape == (2, 3)
+    assert t.embedding.item_shape == (3,)
+    assert t.embedding.ndim == 2
+    assert t.embedding.item_ndim == 1
+    assert t.embedding.size == 6
+    assert t.embedding.item_size == 3
+
+    np.testing.assert_array_equal(t.embedding[:, 0], np.array([1, 4], dtype=np.float32))
+    np.testing.assert_array_equal(t.embedding[1, :2], np.array([4, 5], dtype=np.float32))
+    np.testing.assert_array_equal(t.image[:, :, :, 0], np.stack([np.ones((2, 2)), np.full((2, 2), 2)]))
+
+
+def test_ndarray_column_comparison_and_scalar_operation_guards():
+    t = table()
+
+    with pytest.raises(TypeError, match="Cannot compare ndarray column 'embedding' directly"):
+        _ = t.embedding > 0
+    with pytest.raises(TypeError, match="String expressions only support scalar columns"):
+        t.where("embedding > 0")
+    with pytest.raises(TypeError, match="Cannot sort by ndarray column 'embedding'"):
+        t.sort_by("embedding")
+    with pytest.raises(TypeError, match="Cannot group by ndarray column 'embedding'"):
+        t.group_by("embedding")
+    with pytest.raises(ValueError, match="Cannot create an index on ndarray column 'embedding'"):
+        t.create_index("embedding")
+
+
+def test_ndarray_column_axis_reductions_and_where_projection():
+    t = table()
+
+    assert t.embedding.sum() == np.float32(21)
+    np.testing.assert_array_equal(t.embedding.sum(axis=0), np.array([5, 7, 9], dtype=np.float32))
+    np.testing.assert_array_equal(t.embedding.sum(axis=1), np.array([6, 15], dtype=np.float32))
+    np.testing.assert_allclose(t.embedding.norm(axis=1), np.linalg.norm(t.embedding[:], axis=1))
+
+    filtered = t.where(t.embedding[:, 0] > 1)
+    np.testing.assert_array_equal(filtered.id[:], np.array([2], dtype=np.int32))
+
+
+def test_generated_column_row_transformer_append_refresh_and_vector_output():
+    t = table()
+
+    t.add_generated_column(
+        "embedding_norm",
+        values=t.embedding.row_transformer.norm(axis=0),
+        dtype=blosc2.float64(),
+        create_index=True,
+    )
+    np.testing.assert_allclose(t.embedding_norm[:], np.linalg.norm(t.embedding[:], axis=1))
+
+    t.append((3, np.array([0, 3, 4], dtype=np.float32), np.zeros((2, 2, 3), dtype=np.float32)))
+    np.testing.assert_allclose(t.embedding_norm[:], np.linalg.norm(t.embedding[:], axis=1))
+
+    t.embedding[0] = np.array([0, 0, 0], dtype=np.float32)
+    assert t._materialized_cols["embedding_norm"]["stale"] is True
+    t.refresh_generated_column("embedding_norm")
+    np.testing.assert_allclose(t.embedding_norm[:], np.linalg.norm(t.embedding[:], axis=1))
+
+    t.add_generated_column(
+        "image_mean_rgb",
+        values=t.image.row_transformer.mean(axis=(0, 1)),
+        dtype=blosc2.ndarray((3,), dtype=blosc2.float32()),
+    )
+    np.testing.assert_allclose(t.image_mean_rgb[:], t.image[:].mean(axis=(1, 2)))
+
+
+def test_stale_generated_column_raises_and_read_stale_escape_hatch():
+    t = table()
+    t.add_generated_column(
+        "embedding_sum",
+        values=t.embedding.row_transformer.sum(axis=0),
+        dtype=blosc2.float64(),
+    )
+    t.add_generated_column(
+        "score",
+        values="embedding_sum + sin(id)",
+        dtype=blosc2.float64(),
+    )
+
+    old_sum = t.embedding_sum[:].copy()
+    t.embedding[0] = np.array([10, 20, 30], dtype=np.float32)
+
+    assert t._materialized_cols["embedding_sum"]["stale"] is True
+    assert t._materialized_cols["score"]["stale"] is True
+    with pytest.raises(ValueError, match="read_stale"):
+        _ = t.embedding_sum[:]
+    with pytest.raises(ValueError, match="read_stale"):
+        _ = t.score.sum()
+    np.testing.assert_array_equal(t.embedding_sum.read_stale(), old_sum)
+
+    t.refresh_generated_columns(source="embedding")
+    np.testing.assert_allclose(t.embedding_sum[:], t.embedding[:].sum(axis=1))
+    np.testing.assert_allclose(t.score[:], t.embedding_sum[:] + np.sin(t.id[:]))

--- a/tests/ctable/test_ctable_ndarray_columns.py
+++ b/tests/ctable/test_ctable_ndarray_columns.py
@@ -121,3 +121,74 @@ def test_stale_generated_column_raises_and_read_stale_escape_hatch():
     t.refresh_generated_columns(source="embedding")
     np.testing.assert_allclose(t.embedding_sum[:], t.embedding[:].sum(axis=1))
     np.testing.assert_allclose(t.score[:], t.embedding_sum[:] + np.sin(t.id[:]))
+
+
+@dataclass
+class NullableNDArrayRow:
+    id: int = blosc2.field(blosc2.int32())
+    embedding: object = blosc2.field(blosc2.ndarray((3,), dtype=blosc2.float32(), nullable=True))
+    codes: object = blosc2.field(blosc2.ndarray((2,), dtype=blosc2.int16(), nullable=True))
+
+
+def test_nullable_ndarray_columns_append_extend_assign_and_reduce():
+    t = blosc2.CTable(NullableNDArrayRow)
+
+    t.append((1, np.array([1, 2, 3], dtype=np.float32), [4, 5]))
+    t.append((2, None, None))
+    t.extend(
+        {
+            "id": [3, 4],
+            "embedding": [np.array([4, 5, 6], dtype=np.float32), None],
+            "codes": [[6, 7], None],
+        }
+    )
+
+    assert t.embedding.null_count() == 2
+    np.testing.assert_array_equal(t.embedding.is_null(), np.array([False, True, False, True]))
+    assert np.isnan(t.embedding[1]).all()
+    np.testing.assert_array_equal(t.codes[1], np.full((2,), np.iinfo(np.int16).min, dtype=np.int16))
+    np.testing.assert_array_equal(t.codes.is_null(), np.array([False, True, False, True]))
+
+    np.testing.assert_allclose(t.embedding.sum(axis=0), np.array([5, 7, 9], dtype=np.float32))
+
+    t.embedding[0] = None
+    assert t.embedding.null_count() == 3
+
+
+@pytest.mark.parametrize("null_value", [-999, np.int16(123)])
+def test_nullable_ndarray_explicit_null_value(null_value):
+    spec = blosc2.ndarray((2,), dtype=blosc2.int16(), null_value=null_value)
+
+    @dataclass
+    class RowWithExplicitNull:
+        x: object = blosc2.field(spec)
+
+    t = blosc2.CTable(RowWithExplicitNull, new_data=[(None,), ([1, 2],)])
+    np.testing.assert_array_equal(t.x[0], np.full((2,), null_value, dtype=np.int16))
+    np.testing.assert_array_equal(t.x.is_null(), np.array([True, False]))
+
+
+def test_nullable_bool_ndarray_uses_uint8_sentinel():
+    @dataclass
+    class BoolRows:
+        flags: object = blosc2.field(blosc2.ndarray((2,), dtype=np.bool_, nullable=True))
+
+    t = blosc2.CTable(BoolRows, new_data=[(None,), ([True, False],)])
+    assert t.flags.dtype == np.dtype(np.uint8)
+    np.testing.assert_array_equal(t.flags[0], np.full((2,), 255, dtype=np.uint8))
+    np.testing.assert_array_equal(t.flags.is_null(), np.array([True, False]))
+
+
+def test_nullable_ndarray_arrow_roundtrip():
+    pytest.importorskip("pyarrow")
+    t = blosc2.CTable(NullableNDArrayRow)
+    t.extend({"id": [1, 2], "embedding": [None, [1, 2, 3]], "codes": [[1, 2], None]})
+
+    arrow = t.to_arrow()
+    assert arrow.column("embedding").null_count == 1
+
+    rt = blosc2.CTable.from_arrow(arrow.schema, arrow.to_batches())
+    assert rt.embedding.null_count() == 1
+    assert rt.codes.null_count() == 1
+    np.testing.assert_array_equal(rt.embedding.is_null(), t.embedding.is_null())
+    np.testing.assert_array_equal(rt.codes.is_null(), t.codes.is_null())

--- a/tests/ctable/test_ctable_ndarray_columns.py
+++ b/tests/ctable/test_ctable_ndarray_columns.py
@@ -190,6 +190,21 @@ def test_nullable_ndarray_numpy_nan_null_value():
     assert t.x.null_count() == 1
 
 
+def test_mask_nulls_ndarray_numpy_nan_null_value():
+    from blosc2.schema_compiler import compile_schema
+    from blosc2.schema_validation import _mask_nulls
+
+    @dataclass
+    class FloatRows:
+        x: object = blosc2.field(blosc2.ndarray((2,), dtype=np.float32, null_value=np.float32(np.nan)))
+
+    row = {"x": np.full((2,), np.nan, dtype=np.float32)}
+    masked, nulled = _mask_nulls(compile_schema(FloatRows), row)
+
+    assert masked["x"] is None
+    np.testing.assert_array_equal(nulled["x"], row["x"])
+
+
 def test_nullable_ndarray_arrow_roundtrip():
     pytest.importorskip("pyarrow")
     t = blosc2.CTable(NullableNDArrayRow)

--- a/tests/ctable/test_ctable_ndarray_columns.py
+++ b/tests/ctable/test_ctable_ndarray_columns.py
@@ -179,6 +179,17 @@ def test_nullable_bool_ndarray_uses_uint8_sentinel():
     np.testing.assert_array_equal(t.flags.is_null(), np.array([True, False]))
 
 
+def test_nullable_ndarray_numpy_nan_null_value():
+    @dataclass
+    class FloatRows:
+        x: object = blosc2.field(blosc2.ndarray((2,), dtype=np.float32, null_value=np.float32(np.nan)))
+
+    t = blosc2.CTable(FloatRows, new_data=[(None,), ([1.0, 2.0],)])
+
+    np.testing.assert_array_equal(t.x.is_null(), np.array([True, False]))
+    assert t.x.null_count() == 1
+
+
 def test_nullable_ndarray_arrow_roundtrip():
     pytest.importorskip("pyarrow")
     t = blosc2.CTable(NullableNDArrayRow)

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -236,6 +236,41 @@ def test_group_reduce_object_numeric_keys_sort_with_none():
     assert sizes.tolist() == [1, 1, 2]
 
 
+@pytest.mark.parametrize(
+    ("kernel_name", "value_dtype"),
+    [
+        ("groupby_dense_int_f64_min_checked", np.float64),
+        ("groupby_dense_int_f64_max_checked", np.float64),
+        ("groupby_dense_int_i64_min_checked", np.int64),
+        ("groupby_dense_int_i64_max_checked", np.int64),
+    ],
+)
+@pytest.mark.parametrize("bad_arg", ["values", "valid", "state"])
+def test_groupby_ext_min_max_checked_validate_shapes(kernel_name, value_dtype, bad_arg):
+    groupby_ext = pytest.importorskip("blosc2.groupby_ext")
+    kernel = getattr(groupby_ext, kernel_name)
+
+    keys = np.array([0, 1], dtype=np.int64)
+    values = np.array([10, 20], dtype=value_dtype)
+    valid = np.array([True, True], dtype=np.bool_)
+    state = np.zeros(2, dtype=value_dtype)
+    has_value = np.zeros(2, dtype=np.bool_)
+    keys_present = np.zeros(2, dtype=np.bool_)
+
+    if bad_arg == "values":
+        values = values[:1]
+        match = "keys, values and valid must have the same length"
+    elif bad_arg == "valid":
+        valid = valid[:1]
+        match = "keys, values and valid must have the same length"
+    else:
+        has_value = has_value[:1]
+        match = "state arrays must have the same length"
+
+    with pytest.raises(ValueError, match=match):
+        kernel(keys, values, valid, state, has_value, keys_present)
+
+
 def test_groupby_rejects_bad_engine():
     t = CTable(SalesRow, new_data=DATA)
 

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -220,6 +220,22 @@ def test_groupby_float_integral_fast_path_falls_back_for_nan_group_when_kept():
     assert got[1][1] == 2.0
 
 
+def test_group_reduce_object_keys_sort_with_none():
+    groups, sizes = blosc2.group_reduce(
+        np.array([None, "b", "a", "b"], dtype=object), sort=True, dropna=False
+    )
+
+    assert groups.tolist() == [None, "a", "b"]
+    assert sizes.tolist() == [1, 1, 2]
+
+
+def test_group_reduce_object_numeric_keys_sort_with_none():
+    groups, sizes = blosc2.group_reduce(np.array([None, 2, 1, 2], dtype=object), sort=True, dropna=False)
+
+    assert groups.tolist() == [None, 1, 2]
+    assert sizes.tolist() == [1, 1, 2]
+
+
 def test_groupby_rejects_bad_engine():
     t = CTable(SalesRow, new_data=DATA)
 

--- a/tests/ctable/test_nullable.py
+++ b/tests/ctable/test_nullable.py
@@ -78,6 +78,17 @@ def test_null_value_property_set():
     assert t["score"].null_value == -1
 
 
+def test_numpy_nan_null_value_skips_scalar_validation_constraints():
+    @dataclass
+    class NumpyNaNFloatRow:
+        value: float = blosc2.field(blosc2.float32(ge=0, null_value=np.float32(np.nan)))
+
+    t = CTable(NumpyNaNFloatRow)
+    t.append((np.float32(np.nan),))
+
+    assert t.value.null_count() == 1
+
+
 def test_null_value_property_not_set():
     t = CTable(IntRow, new_data=[(1, 10)])
     assert t["id"].null_value is None

--- a/tests/ctable/test_schema_specs.py
+++ b/tests/ctable/test_schema_specs.py
@@ -7,6 +7,8 @@
 
 """Tests for schema spec objects (blosc2.schema)."""
 
+import json
+
 import numpy as np
 import pytest
 
@@ -196,6 +198,15 @@ def test_string_metadata_dict():
 
 def test_complex128_metadata_dict():
     assert complex128().to_metadata_dict() == {"kind": "complex128"}
+
+
+def test_ndarray_metadata_dict_normalizes_numpy_scalar_null_value():
+    spec = blosc2.ndarray((2,), dtype=np.int16, null_value=np.int16(123))
+    d = spec.to_metadata_dict()
+
+    assert d["null_value"] == 123
+    assert isinstance(d["null_value"], int)
+    json.dumps(d)
 
 
 # -------------------------------------------------------------------

--- a/tests/ndarray/test_indexing.py
+++ b/tests/ndarray/test_indexing.py
@@ -734,6 +734,26 @@ def test_intra_chunk_merge_sorted_slices_matches_lexsort_merge():
     np.testing.assert_array_equal(merged_positions, all_positions[order])
 
 
+def test_intra_chunk_merge_sorted_slices_validates_lengths():
+    indexing_ext = __import__("blosc2.indexing_ext", fromlist=["intra_chunk_merge_sorted_slices"])
+    values = np.array([1.0, 2.0], dtype=np.float64)
+    positions = np.array([0, 1], dtype=np.uint16)
+
+    with pytest.raises(ValueError, match="values and positions must have matching lengths"):
+        indexing_ext.intra_chunk_merge_sorted_slices(
+            values, positions[:1], values, positions, np.dtype(np.uint16)
+        )
+
+
+def test_index_search_boundary_bounds_validates_lengths():
+    indexing_ext = __import__("blosc2.indexing_ext", fromlist=["index_search_boundary_bounds"])
+    starts = np.array([1, 3], dtype=np.int64)
+    ends = np.array([2], dtype=np.int64)
+
+    with pytest.raises(ValueError, match="starts and ends must have the same length"):
+        indexing_ext.index_search_boundary_bounds(starts, ends, None, True, None, True)
+
+
 def test_mutation_marks_index_stale_and_rebuild_restores_it():
     data = np.arange(50_000, dtype=np.int64)
     arr = blosc2.asarray(data, chunks=(5_000,), blocks=(1_000,))

--- a/tests/test_group_reduce.py
+++ b/tests/test_group_reduce.py
@@ -54,6 +54,16 @@ def test_group_reduce_arbitrary_float_keys_and_nan_key_group():
     assert sums[2] == 7.0
 
 
+def test_group_reduce_object_keys_sort_none_first_nan_last():
+    keys = np.array([np.nan, None, "b", "a", np.nan, None], dtype=object)
+
+    groups, sizes = blosc2.group_reduce(keys, op="size", sort=True, dropna=False)
+
+    assert groups[:3].tolist() == [None, "a", "b"]
+    assert np.isnan(groups[3])
+    np.testing.assert_array_equal(sizes, np.array([2, 1, 1, 2]))
+
+
 def test_group_reduce_dropna_default_skips_nan_keys():
     keys = np.array([1.0, np.nan, 1.0])
     values = np.array([2.0, 10.0, 3.0])


### PR DESCRIPTION
Summary:
 - Added blosc2.ndarray(...) schema support for per-row fixed-shape array columns.
 - Extended CTable append/extend/read paths to validate and preserve ndarray item shapes.
 - Added logical Column.shape, ndim, size, and item-shape helpers.
 - Added ndarray-column reductions and row-wise generated-column helpers.
 - Improved display/info output for ndarray-backed columns and nested column namespaces.
 - Extended Arrow/Parquet/CSV/Pandas interop to handle ndarray columns where supported.
 - Added validation around groupby/indexing Cython helpers and fixed object-key group_reduce sorting with None.
 - Added/updated tests covering ndarray columns, nested namespace info, groupby fallback sorting, and low-level validation paths.