### PR TITLE
Undefined name in `__all__`

### DIFF
--- a/src/blosc2/__init__.py
+++ b/src/blosc2/__init__.py
@@ -957,7 +957,6 @@ __all__ = [  # noqa : RUF022
     "hypot",
     "imag",
     "iinfo",
-    "indices",
     "isdtype",
     "isfinite",
     "isinf",


### PR DESCRIPTION
Follow-up of d326cc3.