### PR TITLE
Remove useless else clause detected on the loop

### DIFF
--- a/tests/ndarray/test_dsl_kernels.py
+++ b/tests/ndarray/test_dsl_kernels.py
@@ -141,9 +141,9 @@ def kernel_fallback_for_else(x, y):
     acc = x
     for i in range(2):
         acc = acc + i
+        break
     else:
-        acc = acc + y
-    return acc
+        return acc + y
 
 
 @blosc2.dsl_kernel


### PR DESCRIPTION
When a loop specifies no break statement, the else clause will always execute when the loop sequence is empty, thus making it useless.