### PR TITLE
 group-by views: core `group_by` overhaul + b2view grouping/plots

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,27 @@
 
 XXX version-specific blurb XXX
 
+### `group_by`: flexible aggregation naming
+
+- `CTable.group_by(...).agg()` now accepts a **list of `(column, ops)` pairs**
+  and **explicit output names** (pandas-style keyword arguments), alongside the
+  existing auto-suffixed mapping; the forms can be combined::
+
+      g.agg({"sales": ["sum", "mean"]})              # auto: sales_sum, sales_mean
+      g.agg([(t.sales, ["sum", "mean"])])            # auto, but accepts Column objects
+      g.agg(revenue=("sales", "sum"))                # explicit: revenue
+      g.agg({"sales": "sum"}, n=("*", "size"))       # combined, with a named row count
+
+  The list-of-pairs and named forms accept `Column` objects (`t.sales`), which
+  the mapping form cannot because `Column` is unhashable and so cannot be a dict
+  key.
+- Aggregation ops may also be given as the matching blosc2 reduction *functions*
+  (`blosc2.sum`, `mean`, `min`, `max`, `argmin`, `argmax`), matched **by
+  identity** -- e.g. `g.agg([(t.sales, [blosc2.sum, "mean"])])`.  This is a
+  naming shorthand only; arbitrary/UDF callables (and look-alikes such as
+  `np.sum` or a user function named `sum`) are rejected rather than silently
+  misinterpreted.
+
 ### `group_by` / `group_reduce`: tri-state `sort=`
 
 - **Vectorized dictionary group ordering**: `group_by()` result building now

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,35 @@
 
 XXX version-specific blurb XXX
 
+### `group_by` / `group_reduce`: tri-state `sort=`
+
+- **Vectorized dictionary group ordering**: `group_by()` result building now
+  batch-decodes dictionary (string) keys in one pass (`decode_batch`) instead of
+  one `decode()` per group, making high-cardinality string group-bys dramatically
+  faster (end-to-end `group_by().size()` dropped from seconds to milliseconds on
+  ~100k-group workloads).
+- **`sort=` is now a tri-state** (`None` / `True` / `False`) on both
+  `CTable.group_by()` and `blosc2.group_reduce()`:
+  - `True` — always return groups sorted by key.
+  - `False` — never sort; deterministic but unspecified order.
+  - `None` (the **new default**) — *auto*: sort only when cheap. Integer and
+    dictionary keys are sorted (free / vectorized); float and multi-key results,
+    whose only ordering is an O(G log G) Python sort over every distinct group,
+    are left unsorted to avoid a cost that can rival the grouping itself on
+    high-cardinality data.
+- **Behavior changes** (the two APIs had different prior defaults, so they move
+  in opposite directions):
+  - `CTable.group_by()` previously returned results *always* sorted. Under the
+    new `None` default, **float-key and multi-key group-bys are no longer
+    key-sorted by default** — pass `sort=True` to restore sorted output. This is
+    a deliberate divergence from pandas (which defaults to `sort=True`), suited
+    to blosc2's large / on-disk datasets.
+  - `blosc2.group_reduce()` previously defaulted to `sort=False` (unsorted).
+    Under the new `None` default its **cheap kernels now sort by default** —
+    most visibly float keys, which previously came out in hash order. Integer
+    keys were already ascending; the generic Python fallback stays unsorted.
+    Pass `sort=False` to opt out.
+
 ## Changes from 4.5.0 to 4.5.1
 
 This follow-up release builds the `b2view` terminal viewer into a richer

--- a/doc/reference/ctable.rst
+++ b/doc/reference/ctable.rst
@@ -299,6 +299,46 @@ one row per group::
     min_rows = by_city.argmin("sales")       # logical row position of min sales
     max_rows = by_city.argmax("sales")       # logical row position of max sales
 
+:meth:`~blosc2.CTableGroupBy.agg` applies several aggregations at once and offers
+three ways to name the result columns, which can be combined::
+
+    # Auto-named mapping: result columns are "<column>_<op>", e.g. sales_sum.
+    by_city.agg({"sales": ["sum", "mean"]})
+
+    # Auto-named list of pairs: same naming, but accepts Column objects
+    # (t.sales), which cannot be dict keys because Column is unhashable.  Ops
+    # may also be blosc2 reduction functions (blosc2.sum), matched by identity.
+    by_city.agg([(t.sales, [blosc2.sum, "mean"])])
+
+    # Explicitly named (pandas-style): output_name=(column, op).
+    by_city.agg(revenue=("sales", "sum"), avg_sale=("sales", "mean"))
+
+    # Forms combine, e.g. a list of pairs with a named row count via ("*", "size").
+    by_city.agg([(t.sales, "sum")], n=("*", "size"))
+
+The auto-suffix naming is compact and collision-safe when a column is aggregated
+several ways; the list-of-pairs form additionally lets you pass ``Column``
+objects (``t.sales``) instead of name strings; use explicit names when you want a
+specific (and easily addressable) output column name.
+
+**Output ordering.**  ``sort`` controls how groups are ordered, and is *always
+by the group key(s), never by the aggregated value*:
+
+* ``sort=True`` -- always sorted by key.
+* ``sort=False`` -- unsorted (deterministic but unspecified order).
+* ``sort=None`` (default) -- *auto*: integer and dictionary/string keys are
+  sorted (free or vectorized); float and multi-key results are left unsorted, as
+  their only ordering is an O(*G* log *G*) Python sort that can rival the grouping
+  cost on high-cardinality data.  This differs from pandas, which defaults to
+  ``sort=True``.
+
+To order a result **by an aggregated value** (e.g. top spenders), sort the output
+table afterwards with :meth:`CTable.sort_by`, referencing the result column name::
+
+    top = by_city.agg(revenue=("sales", "sum")).sort_by("revenue", ascending=False)
+    # or, with the auto-suffix name:
+    top = by_city.sum("sales").sort_by("sales_sum", ascending=False)
+
 Grouped results are in-memory by default.  Pass ``urlpath=`` to a terminal
 method to write the result as a persistent :class:`CTable`::
 

--- a/examples/ctable/group_by.py
+++ b/examples/ctable/group_by.py
@@ -57,6 +57,41 @@ print(by_city.mean("price"))
 print("\n=== Multiple aggregations in one call ===================================")
 print(by_city.agg({"price": ["sum", "mean", "min", "max"], "qty": "sum"}))
 
+# -- Naming the output columns ----------------------------------------------
+#
+# agg() offers three interchangeable (and combinable) ways to name results:
+#
+#   1. Auto-named mapping     {column: op-or-ops}      -> "<column>_<op>"
+#   2. Auto-named list pairs  [(column, op-or-ops)]    -> "<column>_<op>"
+#                             (accepts Column objects, which can't be dict keys)
+#   3. Explicitly named       output_name=(column, op) -> exactly that name
+
+print("\n=== Output column naming ================================================")
+
+# 1) Auto-named mapping (string column names): price_sum / price_mean.
+print(by_city.agg({"price": ["sum", "mean"]}))
+
+# 2) Auto-named list of pairs: same names, but lets you pass Column objects
+#    (t.price) instead of strings -- handy for editor autocomplete / refactors.
+#    Ops may also be blosc2 reduction functions (blosc2.sum), matched by identity
+#    -- a naming shorthand only, not a UDF mechanism.
+print(by_city.agg([(t.price, [blosc2.sum, blosc2.mean])]))
+
+# 3) Explicitly named: choose the result column names yourself.
+print(by_city.agg(revenue=(t.price, "sum"), avg_price=(t.price, "mean")))
+
+# Forms combine -- e.g. a list of pairs plus a named row count via ("*", "size").
+print(by_city.agg([(t.price, "sum")], n=("*", "size")))
+
+# -- Sorting by an aggregated value -----------------------------------------
+#
+# group_by() sorts by the *key*, never by the aggregation.  To rank groups by an
+# aggregated value, sort the resulting CTable with sort_by().
+
+print("\n=== Top cities by total price ===========================================")
+totals = by_city.agg(revenue=(t.price, "sum"))
+print(totals.sort_by("revenue", ascending=False).head(3))
+
 # -- Multi-key grouping -----------------------------------------------------
 
 print("\n=== Group by city + product =============================================")

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -930,7 +930,8 @@ class GroupByScreen(ModalScreen["tuple[str, str, str | None] | None"]):
 
 class GroupBarScreen(ModalScreen[None]):
     """Plot of a grouped view: bars for a categorical key (capped to the top
-    groups), or a line curve over all groups for a numeric key."""
+    groups), or a stem/impulse plot over all groups for a numeric key (discrete
+    groups, so no connecting line between adjacent key values)."""
 
     CSS = """
     GroupBarScreen {
@@ -990,8 +991,12 @@ class GroupBarScreen(ModalScreen[None]):
         plt = widget.plt
         plt.clear_figure()
         if self.numeric:
+            # Stem/impulse, not a connected line: groups are discrete points, so
+            # bars-to-baseline show each group's magnitude without inventing a
+            # curve between adjacent key values (which, on spiky/quantised data,
+            # reads as a phantom baseline).
             if self.values:
-                plt.plot(self.x, self.values)
+                plt.bar(self.x, self.values)
                 plt.xlabel(self.xlabel)
                 plt.ylabel(self.agg)
         elif self.labels:
@@ -1011,9 +1016,9 @@ class GroupBarScreen(ModalScreen[None]):
             return
         if self.numeric:
             screen = HiResPlotScreen(
-                mode="line",
+                mode="stem",
                 title=self.plot_title,
-                line_data=(self.x, self.values),
+                stem_data=(self.x, self.values),
                 xlabel=self.xlabel,
                 ylabel=self.agg,
             )
@@ -1483,6 +1488,8 @@ class HiResPlotScreen(ModalScreen[None]):
     Modes:
 
     - ``"scatter"`` — a static col-vs-col scatter (from ``ScatterPlotScreen``).
+    - ``"bar"`` / ``"stem"`` — a grouped result: bars for a categorical key,
+      impulses (vertical lines to a 0 baseline) for a numeric key.
     - ``"envelope"`` — the min/max envelope of a column (from ``PlotScreen``'s
       ``h``), reusing the on-screen braille envelope data.
     - ``"raw"`` — the column's raw values, reached by toggling with ``r`` from
@@ -1533,11 +1540,11 @@ class HiResPlotScreen(ModalScreen[None]):
         mode: str = "raw",
         xlabel: str = "row",
         ylabel: str | None = None,
-        # scatter / bar / line modes:
+        # scatter / bar / stem modes:
         title: str | None = None,
         scatter_xy: tuple | None = None,
         bar_data: tuple | None = None,
-        line_data: tuple | None = None,
+        stem_data: tuple | None = None,
         # column (envelope/raw) modes:
         title_prefix: str | None = None,
         n: int | None = None,
@@ -1553,7 +1560,7 @@ class HiResPlotScreen(ModalScreen[None]):
         self._static_title = title
         self._scatter_xy = scatter_xy
         self._bar_data = bar_data
-        self._line_data = line_data
+        self._stem_data = stem_data
         self._title_prefix = title_prefix
         self._n = n
         self._row_start = row_start
@@ -1568,12 +1575,12 @@ class HiResPlotScreen(ModalScreen[None]):
     def _keys_hint(self) -> str:
         if self._can_toggle:
             return "r raw/envelope · esc back to braille"
-        if self._mode in ("bar", "line"):
+        if self._mode in ("bar", "stem"):
             return "esc · back to chart"
         return "esc · back to braille"
 
     def _current_title(self) -> str:
-        if self._mode in ("scatter", "bar", "line"):
+        if self._mode in ("scatter", "bar", "stem"):
             return self._static_title or ""
         full = self._row_start == 0 and self._row_stop == self._n
         rng = "" if full else f" · rows {self._row_start}:{self._row_stop}"
@@ -1628,9 +1635,11 @@ class HiResPlotScreen(ModalScreen[None]):
             ax.bar(positions, values, color="#1f77b4")
             ax.set_xticks(list(positions))
             ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
-        elif self._mode == "line":
-            x, y = self._line_data
-            ax.plot(x, y, linewidth=0.8, color="#1f77b4")
+        elif self._mode == "stem":
+            # Impulses from a 0 baseline — discrete groups, not a continuous line.
+            x, y = self._stem_data
+            ax.vlines(x, 0, y, linewidth=0.8, color="#1f77b4")
+            ax.set_ylim(bottom=0)
             ax.margins(x=0)
         elif self._mode == "envelope":
             env = self._envelope

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -717,10 +717,12 @@ class FilterScreen(ModalScreen[str | None]):
 
 
 class SortByScreen(ModalScreen["tuple[str, bool] | None"]):
-    """Dropdown to sort a CTable by one of its FULL-indexed columns.
+    """Dropdown to sort a CTable by one of its columns.
 
     ↑/↓ to pick a column, ``r`` (or click) toggles reverse/descending, Enter
-    applies.  Dismisses with ``(column, reverse)`` or None on cancel.
+    applies.  ``labels`` may decorate the displayed names (e.g. mark indexed
+    columns) while ``columns`` carries the real names returned on selection.
+    Dismisses with ``(column, reverse)`` or None on cancel.
     """
 
     CSS = """
@@ -751,11 +753,13 @@ class SortByScreen(ModalScreen["tuple[str, bool] | None"]):
         self,
         *,
         columns: list[str],
+        labels: list[str] | None = None,
         current: tuple[str, bool] | None = None,
-        title: str = "Sort by indexed column (Enter applies, R reverses)",
+        title: str = "Sort by column (Enter applies, R reverses)",
     ):
         super().__init__()
         self.columns = columns
+        self._labels = labels or columns
         self._current = current
         self._title = title
 
@@ -764,7 +768,7 @@ class SortByScreen(ModalScreen["tuple[str, bool] | None"]):
         with Vertical(id="sortby-dialog"):
             yield Static(self._title, id="sortby-title")
             yield OptionList(
-                *(Option(name, id=str(i)) for i, name in enumerate(self.columns)), id="sortby-list"
+                *(Option(name, id=str(i)) for i, name in enumerate(self._labels)), id="sortby-list"
             )
             yield Checkbox("Reverse (descending)", value=cur_rev, id="sortby-reverse")
 
@@ -3190,22 +3194,62 @@ class B2ViewApp(App):
             )
             self.push_screen(screen, self._apply_group_sort)
             return
-        columns = self.browser.full_index_columns(self.selected_path)
+        # Offer every column. FULL-indexed columns reuse their pre-sorted
+        # positions (instant); the rest materialise the sort key and lexsort on
+        # demand — slower on a big table, but no whole-table copy.
+        columns = self.browser.column_names(self.selected_path) or []
         if not columns:
-            self.notify("No FULL-indexed columns to sort by", severity="warning")
+            self.notify("No columns to sort by", severity="warning")
             return
-        screen = SortByScreen(columns=columns, current=self.browser.get_sort(self.selected_path))
+        indexed = set(self.browser.full_index_columns(self.selected_path))
+        title = (
+            "Sort by column (Enter applies, R reverses)\n◆ = indexed (fast)"
+            if indexed
+            else "Sort by column (Enter applies, R reverses)\nnon-indexed columns are scanned"
+        )
+        labels = [f"◆ {c}" if c in indexed else c for c in columns]
+        screen = SortByScreen(
+            columns=columns,
+            labels=labels,
+            current=self.browser.get_sort(self.selected_path),
+            title=title,
+        )
         self.push_screen(screen, self._apply_sort)
 
     def _apply_sort(self, choice: tuple[str, bool] | None, *, reposition: bool = True) -> None:
         if choice is None or self.browser is None or self.table_page is None:
             return  # cancelled
         column, reverse = choice
+        # A FULL-indexed column reuses its pre-sorted positions instantly; a
+        # non-indexed column must materialise the key and lexsort, which can take
+        # a while on a big table — run that off the UI thread with a spinner so
+        # the app stays responsive.
+        if column in set(self.browser.full_index_columns(self.selected_path)):
+            try:
+                self.browser.set_sort(self.selected_path, column, reverse)
+            except Exception as exc:
+                self.notify(f"Cannot sort: {exc}", severity="error")
+                return
+            self._finish_sort(column, reverse, reposition)
+        else:
+            self._sort_in_background(column, reverse, reposition)
+
+    @work(thread=True, exclusive=True)
+    def _sort_in_background(self, column: str, reverse: bool, reposition: bool) -> None:
+        """Build the sort permutation off the UI thread, with a loading spinner."""
+        table = self.query_one("#data-table", DataTable)
+        self.app.call_from_thread(setattr, table, "loading", True)
         try:
             self.browser.set_sort(self.selected_path, column, reverse)
         except Exception as exc:
-            self.notify(f"Cannot sort: {exc}", severity="error")
+            self.app.call_from_thread(setattr, table, "loading", False)
+            self.app.call_from_thread(self.notify, f"Cannot sort: {exc}", severity="error")
             return
+        self.app.call_from_thread(self._finish_sort, column, reverse, reposition)
+
+    def _finish_sort(self, column: str, reverse: bool, reposition: bool) -> None:
+        """Repaint the grid after the sort view is in place (UI thread)."""
+        self.query_one("#data-table", DataTable).loading = False
         self.row_window = None  # set_sort drops any window/filter; keep the chip in sync
         self.table_buffer = None
         # Park the cursor on the sorted column's first row.  On the initial sort

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -261,7 +261,7 @@ class HelpScreen(ModalScreen[None]):
                 ("f", "filter rows (CTable)"),
                 ("S", "sort by an indexed column, or the grouped result (CTable; R reverses)"),
                 ("R", "reverse the current sort order (when sorted)"),
-                ("G", "group by a dictionary/integer column (CTable; p shows a bar chart)"),
+                ("G", "group by a dictionary/numeric column (CTable; p shows a bar chart)"),
                 ("escape", "unlock a row window / clear the active filter, sort or group"),
             ],
         ),
@@ -3275,7 +3275,7 @@ class B2ViewApp(App):
             return
         keys = self.browser.group_key_columns(self.selected_path)
         if not keys:
-            self.notify("No dictionary/integer columns to group by", severity="warning")
+            self.notify("No dictionary/numeric columns to group by", severity="warning")
             return
         # Pre-fill with this table's active group, else the last one used
         # anywhere; GroupByScreen ignores any field whose column is absent here.

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -3246,8 +3246,10 @@ class B2ViewApp(App):
         # A FULL-indexed column reuses its pre-sorted positions instantly; a
         # non-indexed column must materialise the key and lexsort, which can take
         # a while on a big table — run that off the UI thread with a spinner so
-        # the app stays responsive.
-        if column in set(self.browser.full_index_columns(self.selected_path)):
+        # the app stays responsive.  An active filter forces the scan path too:
+        # the index can't be reused over a filtered (where) view.
+        indexed = column in set(self.browser.full_index_columns(self.selected_path))
+        if indexed and not self.browser.get_filter(self.selected_path):
             try:
                 self.browser.set_sort(self.selected_path, column, reverse)
             except Exception as exc:
@@ -3702,8 +3704,9 @@ class B2ViewApp(App):
     def action_dim_exit(self) -> None:
         """Escape: exit dim mode, unlock a row window, or clear a CTable filter.
 
-        One layer per press: dim mode, then the locked row window, then the
-        row filter, then the column filter.
+        One layer per press, peeling derived views before their base: dim mode,
+        then the locked row window, group-sort, group, then the sort (built on
+        the filter), then the row filter, then the column filter.
         """
         if self._dim_mode:
             self._dim_mode = False
@@ -3723,10 +3726,10 @@ class B2ViewApp(App):
             self._clear_group_sort()
         elif self.browser.get_group(self.selected_path):
             self._clear_group()
-        elif self.browser.get_filter(self.selected_path):
-            self._apply_filter("")
         elif self.browser.get_sort(self.selected_path):
             self._clear_sort()
+        elif self.browser.get_filter(self.selected_path):
+            self._apply_filter("")
         elif self.browser.get_column_filter(self.selected_path):
             self.browser.set_column_selection(self.selected_path, None)
             self._reload_columns()

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -929,7 +929,8 @@ class GroupByScreen(ModalScreen["tuple[str, str, str | None] | None"]):
 
 
 class GroupBarScreen(ModalScreen[None]):
-    """Bar chart of a grouped view: one bar per group, capped to the top groups."""
+    """Plot of a grouped view: bars for a categorical key (capped to the top
+    groups), or a line curve over all groups for a numeric key."""
 
     CSS = """
     GroupBarScreen {
@@ -966,12 +967,15 @@ class GroupBarScreen(ModalScreen[None]):
     def __init__(self, *, title_prefix: str, bars: dict):
         super().__init__()
         self.title_prefix = title_prefix
+        self.numeric = bars.get("numeric", False)
         self.labels = [str(label) for label in bars.get("labels", [])]
+        self.x = list(bars.get("x", []))
         self.values = list(bars.get("values", []))
         self.key = bars.get("key", "")
         self.agg = bars.get("agg", "")
-        total = bars.get("total", len(self.labels))
-        shown = len(self.labels)
+        self.xlabel = bars.get("xlabel", self.key)
+        total = bars.get("total", len(self.values))
+        shown = len(self.values)
         cap = f" · top {shown} of {total} groups" if shown < total else f" · {total} groups"
         self.plot_title = f"{title_prefix}{cap}"
 
@@ -985,30 +989,43 @@ class GroupBarScreen(ModalScreen[None]):
         widget = self.query_one(PlotextPlot)
         plt = widget.plt
         plt.clear_figure()
-        if self.labels:
+        if self.numeric:
+            if self.values:
+                plt.plot(self.x, self.values)
+                plt.xlabel(self.xlabel)
+                plt.ylabel(self.agg)
+        elif self.labels:
             plt.bar(self.labels, self.values)
         widget.refresh()
 
     def action_hires(self) -> None:
-        """h key — open a high-res matplotlib bar chart over the plotext bars."""
+        """h key — open a high-res matplotlib plot over the plotext braille one."""
         if TextualImage is None or not _matplotlib_available():
             self.app.notify(
                 "High-res view needs the 'textual-image' and 'matplotlib' packages",
                 severity="warning",
             )
             return
-        if not self.labels:
+        if not self.values:
             self.app.notify("No groups to plot", severity="warning")
             return
-        self.app.push_screen(
-            HiResPlotScreen(
+        if self.numeric:
+            screen = HiResPlotScreen(
+                mode="line",
+                title=self.plot_title,
+                line_data=(self.x, self.values),
+                xlabel=self.xlabel,
+                ylabel=self.agg,
+            )
+        else:
+            screen = HiResPlotScreen(
                 mode="bar",
                 title=self.plot_title,
                 bar_data=(self.labels, self.values),
                 xlabel=self.key,
                 ylabel=self.agg,
             )
-        )
+        self.app.push_screen(screen)
 
     def action_close(self) -> None:
         self.dismiss(None)
@@ -1516,10 +1533,11 @@ class HiResPlotScreen(ModalScreen[None]):
         mode: str = "raw",
         xlabel: str = "row",
         ylabel: str | None = None,
-        # scatter / bar modes:
+        # scatter / bar / line modes:
         title: str | None = None,
         scatter_xy: tuple | None = None,
         bar_data: tuple | None = None,
+        line_data: tuple | None = None,
         # column (envelope/raw) modes:
         title_prefix: str | None = None,
         n: int | None = None,
@@ -1535,6 +1553,7 @@ class HiResPlotScreen(ModalScreen[None]):
         self._static_title = title
         self._scatter_xy = scatter_xy
         self._bar_data = bar_data
+        self._line_data = line_data
         self._title_prefix = title_prefix
         self._n = n
         self._row_start = row_start
@@ -1549,12 +1568,12 @@ class HiResPlotScreen(ModalScreen[None]):
     def _keys_hint(self) -> str:
         if self._can_toggle:
             return "r raw/envelope · esc back to braille"
-        if self._mode == "bar":
-            return "esc · back to bar chart"
+        if self._mode in ("bar", "line"):
+            return "esc · back to chart"
         return "esc · back to braille"
 
     def _current_title(self) -> str:
-        if self._mode in ("scatter", "bar"):
+        if self._mode in ("scatter", "bar", "line"):
             return self._static_title or ""
         full = self._row_start == 0 and self._row_stop == self._n
         rng = "" if full else f" · rows {self._row_start}:{self._row_stop}"
@@ -1609,6 +1628,10 @@ class HiResPlotScreen(ModalScreen[None]):
             ax.bar(positions, values, color="#1f77b4")
             ax.set_xticks(list(positions))
             ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
+        elif self._mode == "line":
+            x, y = self._line_data
+            ax.plot(x, y, linewidth=0.8, color="#1f77b4")
+            ax.margins(x=0)
         elif self._mode == "envelope":
             env = self._envelope
             x, ymin, ymax = env["x"], env["ymin"], env["ymax"]
@@ -3000,7 +3023,7 @@ class B2ViewApp(App):
             return
         if self.browser is not None and self.browser.get_group(self.selected_path):
             bars = self.browser.group_bars(self.selected_path)
-            if not bars["labels"]:
+            if not bars["values"]:
                 self.notify("Nothing to plot for this group-by", severity="warning")
                 return
             title = f"{self.selected_path} · {bars['agg']} by {bars['key']}"

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -1952,7 +1952,7 @@ class B2ViewApp(App):
                 with B2ViewPanel(id="data-pane") as data_pane:
                     data_pane.border_title = "data"
                     data_pane.border_subtitle = (
-                        "?(help) | d(im mode) | filter: f(rows) /(cols) | S(ort) | "
+                        "?(help) | d(im mode) | filter: f(rows) /(cols) | S(ort) | G(roup) | "
                         "rows: t/b/g(oto) | cols: s/e/c(goto) | p(lot)"
                     )
                     yield Static("", id="data-header")

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -951,13 +951,21 @@ class GroupBarScreen(ModalScreen[None]):
     }
     """
 
-    BINDINGS: ClassVar = [("escape", "close", "Close"), ("q", "app.quit", "Quit b2view")]
+    _KEYS_HINT = "h hi-res · esc close"
+
+    BINDINGS: ClassVar = [
+        ("escape", "close", "Close"),
+        ("q", "app.quit", "Quit b2view"),
+        ("h", "hires", "High-res"),
+    ]
 
     def __init__(self, *, title_prefix: str, bars: dict):
         super().__init__()
         self.title_prefix = title_prefix
         self.labels = [str(label) for label in bars.get("labels", [])]
         self.values = list(bars.get("values", []))
+        self.key = bars.get("key", "")
+        self.agg = bars.get("agg", "")
         total = bars.get("total", len(self.labels))
         shown = len(self.labels)
         cap = f" · top {shown} of {total} groups" if shown < total else f" · {total} groups"
@@ -967,7 +975,7 @@ class GroupBarScreen(ModalScreen[None]):
         with Vertical(id="groupbar-dialog"):
             yield Static(markup_escape(self.plot_title), id="groupbar-title")
             yield PlotextPlot(id="groupbar-widget")
-            yield Static("esc close", id="groupbar-keys")
+            yield Static(self._KEYS_HINT, id="groupbar-keys")
 
     def on_mount(self) -> None:
         widget = self.query_one(PlotextPlot)
@@ -976,6 +984,27 @@ class GroupBarScreen(ModalScreen[None]):
         if self.labels:
             plt.bar(self.labels, self.values)
         widget.refresh()
+
+    def action_hires(self) -> None:
+        """h key — open a high-res matplotlib bar chart over the plotext bars."""
+        if TextualImage is None or not _matplotlib_available():
+            self.app.notify(
+                "High-res view needs the 'textual-image' and 'matplotlib' packages",
+                severity="warning",
+            )
+            return
+        if not self.labels:
+            self.app.notify("No groups to plot", severity="warning")
+            return
+        self.app.push_screen(
+            HiResPlotScreen(
+                mode="bar",
+                title=self.plot_title,
+                bar_data=(self.labels, self.values),
+                xlabel=self.key,
+                ylabel=self.agg,
+            )
+        )
 
     def action_close(self) -> None:
         self.dismiss(None)
@@ -1483,9 +1512,10 @@ class HiResPlotScreen(ModalScreen[None]):
         mode: str = "raw",
         xlabel: str = "row",
         ylabel: str | None = None,
-        # scatter mode:
+        # scatter / bar modes:
         title: str | None = None,
         scatter_xy: tuple | None = None,
+        bar_data: tuple | None = None,
         # column (envelope/raw) modes:
         title_prefix: str | None = None,
         n: int | None = None,
@@ -1500,6 +1530,7 @@ class HiResPlotScreen(ModalScreen[None]):
         self._ylabel = ylabel
         self._static_title = title
         self._scatter_xy = scatter_xy
+        self._bar_data = bar_data
         self._title_prefix = title_prefix
         self._n = n
         self._row_start = row_start
@@ -1514,10 +1545,12 @@ class HiResPlotScreen(ModalScreen[None]):
     def _keys_hint(self) -> str:
         if self._can_toggle:
             return "r raw/envelope · esc back to braille"
+        if self._mode == "bar":
+            return "esc · back to bar chart"
         return "esc · back to braille"
 
     def _current_title(self) -> str:
-        if self._mode == "scatter":
+        if self._mode in ("scatter", "bar"):
             return self._static_title or ""
         full = self._row_start == 0 and self._row_stop == self._n
         rng = "" if full else f" · rows {self._row_start}:{self._row_stop}"
@@ -1566,6 +1599,12 @@ class HiResPlotScreen(ModalScreen[None]):
         if self._mode == "scatter":
             x, y = self._scatter_xy
             ax.scatter(x, y, s=6, color="#1f77b4", alpha=0.6)
+        elif self._mode == "bar":
+            labels, values = self._bar_data
+            positions = range(len(labels))
+            ax.bar(positions, values, color="#1f77b4")
+            ax.set_xticks(list(positions))
+            ax.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
         elif self._mode == "envelope":
             env = self._envelope
             x, ymin, ymax = env["x"], env["ymin"], env["ymax"]

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -259,7 +259,8 @@ class HelpScreen(ModalScreen[None]):
                 ("f", "filter rows (CTable)"),
                 ("S", "sort by an indexed column (CTable; R reverses)"),
                 ("R", "reverse the current sort order (when sorted)"),
-                ("escape", "unlock a row window / clear the active filter or sort"),
+                ("G", "group by a dictionary/integer column (CTable; p shows a bar chart)"),
+                ("escape", "unlock a row window / clear the active filter, sort or group"),
             ],
         ),
         (
@@ -774,6 +775,156 @@ class SortByScreen(ModalScreen["tuple[str, bool] | None"]):
             self.dismiss((self.columns[int(event.option.id)], reverse))
 
     def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class GroupByScreen(ModalScreen["tuple[str, str, str | None] | None"]):
+    """Group a CTable by a key column and one aggregation.
+
+    Two lists: pick the key (↑/↓), Tab to the aggregation list, Enter applies.
+    Each aggregation entry encodes ``(op, value_col)`` — ``count rows`` is the
+    keyless ``size`` aggregation; the rest are ``op(value_col)``.  Dismisses with
+    ``(key, op, value_col|None)`` or None on cancel.
+    """
+
+    CSS = """
+    GroupByScreen {
+        align: center middle;
+    }
+    #groupby-dialog {
+        width: 64;
+        height: auto;
+        max-height: 80%;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    #groupby-title {
+        text-style: bold;
+        margin-bottom: 1;
+    }
+    .groupby-label {
+        color: $text-muted;
+    }
+    #groupby-key, #groupby-agg {
+        height: auto;
+        max-height: 10;
+    }
+    """
+
+    BINDINGS: ClassVar = [("escape", "cancel", "Cancel")]
+
+    _OPS: ClassVar = ["sum", "mean", "min", "max"]
+
+    def __init__(
+        self,
+        *,
+        keys: list[str],
+        values: list[str],
+        current: tuple[str, str, str | None] | None = None,
+    ):
+        super().__init__()
+        self.keys = keys
+        # (op, value_col) per aggregation row; "count rows" is size (no column).
+        self.aggs: list[tuple[str, str | None]] = [("size", None)]
+        for v in values:
+            self.aggs.extend((op, v) for op in self._OPS)
+        self._current = current
+
+    def _agg_label(self, op: str, value_col: str | None) -> str:
+        return "count rows" if op == "size" else f"{op}({value_col})"
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="groupby-dialog"):
+            yield Static("Group by (Tab to aggregation, Enter applies)", id="groupby-title")
+            yield Static("Key column", classes="groupby-label")
+            yield OptionList(
+                *(Option(name, id=str(i)) for i, name in enumerate(self.keys)), id="groupby-key"
+            )
+            yield Static("Aggregation", classes="groupby-label")
+            yield OptionList(
+                *(Option(self._agg_label(op, v), id=str(i)) for i, (op, v) in enumerate(self.aggs)),
+                id="groupby-agg",
+            )
+
+    def on_mount(self) -> None:
+        key_list = self.query_one("#groupby-key", OptionList)
+        agg_list = self.query_one("#groupby-agg", OptionList)
+        cur_key, cur_op, cur_val = self._current or (None, None, None)
+        key_list.highlighted = self.keys.index(cur_key) if cur_key in self.keys else 0
+        agg_list.highlighted = self.aggs.index((cur_op, cur_val)) if (cur_op, cur_val) in self.aggs else 0
+        key_list.focus()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        # Enter on the key list advances to the aggregation list; Enter there
+        # applies, reading the key list's current highlight.
+        if event.option_list.id == "groupby-key":
+            self.query_one("#groupby-agg", OptionList).focus()
+            return
+        key_idx = self.query_one("#groupby-key", OptionList).highlighted
+        if key_idx is None:
+            return
+        op, value_col = self.aggs[int(event.option.id)]
+        self.dismiss((self.keys[key_idx], op, value_col))
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+
+class GroupBarScreen(ModalScreen[None]):
+    """Bar chart of a grouped view: one bar per group, capped to the top groups."""
+
+    CSS = """
+    GroupBarScreen {
+        align: center middle;
+    }
+    #groupbar-dialog {
+        width: 90%;
+        height: 80%;
+        border: thick $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    #groupbar-title {
+        text-style: bold;
+        height: 1;
+    }
+    #groupbar-widget {
+        height: 1fr;
+    }
+    #groupbar-keys {
+        height: 1;
+        color: $text-muted;
+    }
+    """
+
+    BINDINGS: ClassVar = [("escape", "close", "Close"), ("q", "app.quit", "Quit b2view")]
+
+    def __init__(self, *, title_prefix: str, bars: dict):
+        super().__init__()
+        self.title_prefix = title_prefix
+        self.labels = [str(label) for label in bars.get("labels", [])]
+        self.values = list(bars.get("values", []))
+        total = bars.get("total", len(self.labels))
+        shown = len(self.labels)
+        cap = f" · top {shown} of {total} groups" if shown < total else f" · {total} groups"
+        self.plot_title = f"{title_prefix}{cap}"
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="groupbar-dialog"):
+            yield Static(markup_escape(self.plot_title), id="groupbar-title")
+            yield PlotextPlot(id="groupbar-widget")
+            yield Static("esc close", id="groupbar-keys")
+
+    def on_mount(self) -> None:
+        widget = self.query_one(PlotextPlot)
+        plt = widget.plt
+        plt.clear_figure()
+        if self.labels:
+            plt.bar(self.labels, self.values)
+        widget.refresh()
+
+    def action_close(self) -> None:
         self.dismiss(None)
 
 
@@ -1723,6 +1874,7 @@ class B2ViewApp(App):
         Binding("f", "filter_rows", "Filter rows", show=False),
         Binding("S", "sort_rows", "Sort by", show=False),
         Binding("R", "reverse_sort", "Reverse sort", show=False),
+        Binding("G", "group_rows", "Group by", show=False),
         Binding("slash", "filter_columns", "Filter columns", show=False),
         Binding("p", "plot_column", "Plot column", show=False),
         Binding("d", "dim_cycle", "Dim mode", show=False),
@@ -2538,6 +2690,11 @@ class B2ViewApp(App):
             flt = self.browser.get_filter(self.selected_path)
             col_flt = self.browser.get_column_filter(self.selected_path)
             sort = self.browser.get_sort(self.selected_path)
+            group = self.browser.get_group(self.selected_path)
+            if group:
+                key, op, value_col = group
+                label = "count" if op == "size" else f"{op}({markup_escape(value_col)})"
+                chips.append(_accent_chip(f"GROUPED {markup_escape(key)} · {label}"))
             if flt:
                 total = self.browser.base_nrows(self.selected_path)
                 chips.append(f"filter: [bold]{markup_escape(flt)}[/bold] ({total} total)")
@@ -2547,10 +2704,13 @@ class B2ViewApp(App):
                 chips.append(_accent_chip(f"SORTED {arrow} {markup_escape(col)}"))
             if col_flt:
                 chips.append(f"cols: [bold]{markup_escape(col_flt)}[/bold]")
-            if sort:
-                chips.append("<R>everse")
-            if flt or col_flt or sort or self.row_window is not None:
-                chips.append("<Esc>unlock/clear")
+            if group:
+                chips.append("<Esc>ungroup")
+            else:
+                if sort:
+                    chips.append("<R>everse")
+                if flt or col_flt or sort or self.row_window is not None:
+                    chips.append("<Esc>unlock/clear")
         return chips
 
     def _make_global_scrollbar(self, *, start: int, stop: int, total: int, size: int, track: str) -> str:
@@ -2697,6 +2857,14 @@ class B2ViewApp(App):
             return
         if PlotextPlot is None:
             self.notify("Plotting needs the 'textual-plotext' package", severity="warning")
+            return
+        if self.browser is not None and self.browser.get_group(self.selected_path):
+            bars = self.browser.group_bars(self.selected_path)
+            if not bars["labels"]:
+                self.notify("Nothing to plot for this group-by", severity="warning")
+                return
+            title = f"{self.selected_path} · {bars['agg']} by {bars['key']}"
+            self.push_screen(GroupBarScreen(title_prefix=title, bars=bars))
             return
         buffer = self.table_buffer or self.table_page
         columns = buffer["columns"]
@@ -2864,6 +3032,9 @@ class B2ViewApp(App):
         if self.table_page.get("source_kind") != "ctable":
             self.notify("Filtering is only supported for CTable nodes", severity="warning")
             return
+        if self.browser.get_group(self.selected_path):
+            self.notify("Ungroup (Esc) before filtering", severity="warning")
+            return
         screen = FilterScreen(current=self.browser.get_filter(self.selected_path))
         self.push_screen(screen, self._apply_filter)
 
@@ -2872,6 +3043,9 @@ class B2ViewApp(App):
             return
         if self.table_page.get("source_kind") != "ctable":
             self.notify("Sorting is only supported for CTable nodes", severity="warning")
+            return
+        if self.browser.get_group(self.selected_path):
+            self.notify("Ungroup (Esc) before sorting", severity="warning")
             return
         columns = self.browser.full_index_columns(self.selected_path)
         if not columns:
@@ -2906,6 +3080,44 @@ class B2ViewApp(App):
         self._update_data_header(data)
         self.query_one("#data-table", DataTable).focus()
 
+    def action_group_rows(self) -> None:
+        if not self._in_data_grid():
+            return
+        if self.table_page.get("source_kind") != "ctable":
+            self.notify("Grouping is only supported for CTable nodes", severity="warning")
+            return
+        keys = self.browser.group_key_columns(self.selected_path)
+        if not keys:
+            self.notify("No dictionary/integer columns to group by", severity="warning")
+            return
+        screen = GroupByScreen(
+            keys=keys,
+            values=self.browser.group_value_columns(self.selected_path),
+            current=self.browser.get_group(self.selected_path),
+        )
+        self.push_screen(screen, self._apply_group)
+
+    def _apply_group(self, choice: tuple[str, str, str | None] | None) -> None:
+        if choice is None or self.browser is None or self.table_page is None:
+            return
+        key, op, value_col = choice
+        try:
+            self.browser.set_group(self.selected_path, key, op, value_col)
+        except Exception as exc:
+            self.notify(f"Cannot group: {exc}", severity="error")
+            return
+        self.row_window = None  # set_group drops any window/filter; keep chips in sync
+        self.table_buffer = None
+        self.grid_col_start = 0
+        data = self._load_table_page(self.selected_path, 0)
+        # Park the cursor on the aggregate column (last column of the result).
+        agg = self.browser.group_agg_column(self.selected_path)
+        cols = data.get("columns", [])
+        cursor_col = cols.index(agg) if agg in cols else 0
+        self._update_data_table(data, cursor_row=0, cursor_col=cursor_col)
+        self._update_data_header(data)
+        self.query_one("#data-table", DataTable).focus()
+
     def action_reverse_sort(self) -> None:
         """Flip ascending/descending on the currently sorted column."""
         if (
@@ -2924,6 +3136,16 @@ class B2ViewApp(App):
         """Escape out of a sort view, restoring original row order."""
         self.browser.clear_sort(self.selected_path)
         self.table_buffer = None
+        data = self._load_table_page(self.selected_path, 0)
+        self._update_data_table(data, cursor_row=0, cursor_col=0)
+        self._update_data_header(data)
+        self.query_one("#data-table", DataTable).focus()
+
+    def _clear_group(self) -> None:
+        """Escape out of a group-by view, restoring the base table."""
+        self.browser.clear_group(self.selected_path)
+        self.table_buffer = None
+        self.grid_col_start = 0
         data = self._load_table_page(self.selected_path, 0)
         self._update_data_table(data, cursor_row=0, cursor_col=0)
         self._update_data_header(data)
@@ -2950,6 +3172,9 @@ class B2ViewApp(App):
             return
         if self.table_page.get("source_kind") != "ctable":
             self.notify("Column filtering is only supported for CTable nodes", severity="warning")
+            return
+        if self.browser.get_group(self.selected_path):
+            self.notify("Ungroup (Esc) before filtering columns", severity="warning")
             return
         # Preselect the currently-shown columns (column_names honors any active
         # selection); the picker universe is the full, unfiltered column set.
@@ -3234,7 +3459,9 @@ class B2ViewApp(App):
             or self.browser is None
         ):
             return
-        if self.browser.get_filter(self.selected_path):
+        if self.browser.get_group(self.selected_path):
+            self._clear_group()
+        elif self.browser.get_filter(self.selected_path):
             self._apply_filter("")
         elif self.browser.get_sort(self.selected_path):
             self._clear_sort()

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -257,7 +257,7 @@ class HelpScreen(ModalScreen[None]):
                 ("t / b", "first / last row"),
                 ("g", "go to row..."),
                 ("f", "filter rows (CTable)"),
-                ("S", "sort by an indexed column (CTable; R reverses)"),
+                ("S", "sort by an indexed column, or the grouped result (CTable; R reverses)"),
                 ("R", "reverse the current sort order (when sorted)"),
                 ("G", "group by a dictionary/integer column (CTable; p shows a bar chart)"),
                 ("escape", "unlock a row window / clear the active filter, sort or group"),
@@ -745,15 +745,22 @@ class SortByScreen(ModalScreen["tuple[str, bool] | None"]):
 
     BINDINGS: ClassVar = [("escape", "cancel", "Cancel"), ("R", "toggle_reverse", "Reverse")]
 
-    def __init__(self, *, columns: list[str], current: tuple[str, bool] | None = None):
+    def __init__(
+        self,
+        *,
+        columns: list[str],
+        current: tuple[str, bool] | None = None,
+        title: str = "Sort by indexed column (Enter applies, R reverses)",
+    ):
         super().__init__()
         self.columns = columns
         self._current = current
+        self._title = title
 
     def compose(self) -> ComposeResult:
         cur_col, cur_rev = self._current or (None, False)
         with Vertical(id="sortby-dialog"):
-            yield Static("Sort by indexed column (Enter applies, R reverses)", id="sortby-title")
+            yield Static(self._title, id="sortby-title")
             yield OptionList(
                 *(Option(name, id=str(i)) for i, name in enumerate(self.columns)), id="sortby-list"
             )
@@ -2691,10 +2698,15 @@ class B2ViewApp(App):
             col_flt = self.browser.get_column_filter(self.selected_path)
             sort = self.browser.get_sort(self.selected_path)
             group = self.browser.get_group(self.selected_path)
+            gsort = self.browser.get_group_sort(self.selected_path)
             if group:
                 key, op, value_col = group
                 label = "count" if op == "size" else f"{op}({markup_escape(value_col)})"
                 chips.append(_accent_chip(f"GROUPED {markup_escape(key)} · {label}"))
+                if gsort:
+                    col, reverse = gsort
+                    arrow = "▼" if reverse else "▲"
+                    chips.append(_accent_chip(f"SORTED {arrow} {markup_escape(col)}"))
             if flt:
                 total = self.browser.base_nrows(self.selected_path)
                 chips.append(f"filter: [bold]{markup_escape(flt)}[/bold] ({total} total)")
@@ -2705,7 +2717,9 @@ class B2ViewApp(App):
             if col_flt:
                 chips.append(f"cols: [bold]{markup_escape(col_flt)}[/bold]")
             if group:
-                chips.append("<Esc>ungroup")
+                if gsort:
+                    chips.append("<R>everse")
+                chips.append("<Esc>ungroup" if not gsort else "<Esc>unsort")
             else:
                 if sort:
                     chips.append("<R>everse")
@@ -3045,7 +3059,14 @@ class B2ViewApp(App):
             self.notify("Sorting is only supported for CTable nodes", severity="warning")
             return
         if self.browser.get_group(self.selected_path):
-            self.notify("Ungroup (Esc) before sorting", severity="warning")
+            # Sort the (tiny) grouped result by any of its columns — key or aggregate.
+            columns = self.browser.column_names(self.selected_path) or []
+            screen = SortByScreen(
+                columns=columns,
+                current=self.browser.get_group_sort(self.selected_path),
+                title="Sort grouped result (Enter applies, R reverses)",
+            )
+            self.push_screen(screen, self._apply_group_sort)
             return
         columns = self.browser.full_index_columns(self.selected_path)
         if not columns:
@@ -3118,6 +3139,23 @@ class B2ViewApp(App):
         self._update_data_header(data)
         self.query_one("#data-table", DataTable).focus()
 
+    def _apply_group_sort(self, choice: tuple[str, bool] | None) -> None:
+        if choice is None or self.browser is None or self.table_page is None:
+            return  # cancelled
+        column, reverse = choice
+        try:
+            self.browser.set_group_sort(self.selected_path, column, reverse)
+        except Exception as exc:
+            self.notify(f"Cannot sort: {exc}", severity="error")
+            return
+        self.table_buffer = None
+        data = self._load_table_page(self.selected_path, 0)
+        cols = data.get("columns", [])
+        cursor_col = cols.index(column) if column in cols else 0
+        self._update_data_table(data, cursor_row=0, cursor_col=cursor_col)
+        self._update_data_header(data)
+        self.query_one("#data-table", DataTable).focus()
+
     def action_reverse_sort(self) -> None:
         """Flip ascending/descending on the currently sorted column."""
         if (
@@ -3125,6 +3163,12 @@ class B2ViewApp(App):
             or self.table_page.get("source_kind") != "ctable"
             or self.browser is None
         ):
+            return
+        # While grouped, 'R' flips the sort on the grouped result.
+        gsort = self.browser.get_group_sort(self.selected_path)
+        if self.browser.get_group(self.selected_path) is not None:
+            if gsort is not None:
+                self._apply_group_sort((gsort[0], not gsort[1]))
             return
         sort = self.browser.get_sort(self.selected_path)
         if sort is None:
@@ -3146,6 +3190,15 @@ class B2ViewApp(App):
         self.browser.clear_group(self.selected_path)
         self.table_buffer = None
         self.grid_col_start = 0
+        data = self._load_table_page(self.selected_path, 0)
+        self._update_data_table(data, cursor_row=0, cursor_col=0)
+        self._update_data_header(data)
+        self.query_one("#data-table", DataTable).focus()
+
+    def _clear_group_sort(self) -> None:
+        """Drop the sort on a grouped result, keeping the group itself."""
+        self.browser.clear_group_sort(self.selected_path)
+        self.table_buffer = None
         data = self._load_table_page(self.selected_path, 0)
         self._update_data_table(data, cursor_row=0, cursor_col=0)
         self._update_data_header(data)
@@ -3459,7 +3512,9 @@ class B2ViewApp(App):
             or self.browser is None
         ):
             return
-        if self.browser.get_group(self.selected_path):
+        if self.browser.get_group_sort(self.selected_path):
+            self._clear_group_sort()
+        elif self.browser.get_group(self.selected_path):
             self._clear_group()
         elif self.browser.get_filter(self.selected_path):
             self._apply_filter("")

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -161,6 +161,8 @@ class BufferedDataTable(DataTable):
         if getattr(app, "_dim_mode", False):
             getattr(app, "action_dim_toggle_nav", lambda: None)()
             return
+        if getattr(app, "_drilldown_arg_cell", lambda: False)():
+            return
         if getattr(app, "_inspect_cursor_cell", lambda: False)():
             return
         super().action_select_cursor()
@@ -271,7 +273,7 @@ class HelpScreen(ModalScreen[None]):
                 ("c", "go to column (searchable name list; CTable, else index)"),
                 ("/", "pick which columns to show (searchable multi-select; CTable)"),
                 ("p", "plot a whole-column overview (needs textual-plotext)"),
-                ("enter", "decode a skipped cell (list/struct/object column)"),
+                ("enter", "decode a skipped cell; or jump to an argmin/argmax row (grouped)"),
             ],
         ),
         (
@@ -1976,6 +1978,9 @@ class B2ViewApp(App):
         self._apply_focus_on_next_update = False
         # Absolute (start, stop) of a locked row window from the plot's 'v' key.
         self.row_window: tuple[int, int] | None = None
+        # Last applied group-by config (key, op, value_col), reused to pre-fill
+        # the 'G' modal on any table — survives navigating to other nodes.
+        self._last_group: tuple[str, str, str | None] | None = None
 
     def compose(self) -> ComposeResult:
         yield B2ViewHeader()
@@ -2763,6 +2768,8 @@ class B2ViewApp(App):
             if group:
                 if gsort:
                     chips.append("<R>everse")
+                if group[1] in ("argmin", "argmax"):
+                    chips.append("<Enter>go to row")
                 chips.append("<Esc>ungroup" if not gsort else "<Esc>unsort")
             else:
                 if sort:
@@ -2907,6 +2914,38 @@ class B2ViewApp(App):
             self.notify(f"Could not decode cell: {exc}", severity="error")
             return True  # we owned the key; surface the failure
         self.push_screen(CellDetailScreen(row=row, name=name, label=skipped[name], value=value))
+        return True
+
+    def _drilldown_arg_cell(self) -> bool:
+        """On an argmin/argmax cell of a grouped view, jump to that base-table row.
+
+        The cell holds the logical row position of the group's extreme value, so
+        we ungroup and land the cursor on that row, on the column the extreme was
+        computed over.  Returns True when the key was consumed.
+        """
+        if not self._in_data_grid() or self.table_page is None or self.browser is None:
+            return False
+        group = self.browser.get_group(self.selected_path)
+        if group is None:
+            return False
+        _key, op, value_col = group
+        if op not in ("argmin", "argmax"):
+            return False
+        agg_col = self.browser.group_agg_column(self.selected_path)
+        columns = self.table_page["columns"]
+        table = self.query_one("#data-table", DataTable)
+        cursor_col = table.cursor_column
+        if not (0 <= cursor_col < len(columns)) or columns[cursor_col] != agg_col:
+            return False
+        cells = self.table_page["data"][agg_col]
+        if not (0 <= table.cursor_row < len(cells)):
+            return False
+        pos = int(cells[table.cursor_row])
+        if pos < 0:
+            self.notify(f"No {op} row for this group (no non-null values)", severity="warning")
+            return True
+        self._clear_group()  # back to the base table...
+        self._go_to_row_col(pos, value_col)  # ...landing on the extreme row/column
         return True
 
     def action_plot_column(self) -> None:
@@ -3155,10 +3194,12 @@ class B2ViewApp(App):
         if not keys:
             self.notify("No dictionary/integer columns to group by", severity="warning")
             return
+        # Pre-fill with this table's active group, else the last one used
+        # anywhere; GroupByScreen ignores any field whose column is absent here.
         screen = GroupByScreen(
             keys=keys,
             values=self.browser.group_value_columns(self.selected_path),
-            current=self.browser.get_group(self.selected_path),
+            current=self.browser.get_group(self.selected_path) or self._last_group,
         )
         self.push_screen(screen, self._apply_group)
 
@@ -3171,6 +3212,7 @@ class B2ViewApp(App):
         except Exception as exc:
             self.notify(f"Cannot group: {exc}", severity="error")
             return
+        self._last_group = (key, op, value_col)  # remember for the next 'G' anywhere
         self.row_window = None  # set_group drops any window/filter; keep chips in sync
         self.table_buffer = None
         self.grid_col_start = 0
@@ -3376,6 +3418,21 @@ class B2ViewApp(App):
         start = (row // page_size) * page_size
         data = self._load_table_page(self.selected_path, start)
         self._update_data_table(data, cursor_row=row - data["start"])
+        self._update_data_header(data)
+        self.query_one("#data-table", DataTable).focus()
+
+    def _go_to_row_col(self, row: int, column: str) -> None:
+        """Jump to *row* with the cursor on *column*, scrolling it into view."""
+        if self.table_page is None:
+            return
+        names = self.browser.column_names(self.selected_path) or []
+        col_idx = names.index(column) if column in names else 0
+        self.grid_col_start = min(col_idx, self._fit_col_start_backward(self.table_page["ncols"]))
+        page_size = self._table_page_size()
+        start = (row // page_size) * page_size
+        data = self._load_table_page(self.selected_path, start)
+        cursor_col = max(0, col_idx - data.get("col_start", 0))
+        self._update_data_table(data, cursor_row=row - data["start"], cursor_col=cursor_col)
         self._update_data_header(data)
         self.query_one("#data-table", DataTable).focus()
 

--- a/src/blosc2/b2view/app.py
+++ b/src/blosc2/b2view/app.py
@@ -788,10 +788,10 @@ class SortByScreen(ModalScreen["tuple[str, bool] | None"]):
 class GroupByScreen(ModalScreen["tuple[str, str, str | None] | None"]):
     """Group a CTable by a key column and one aggregation.
 
-    Two lists: pick the key (↑/↓), Tab to the aggregation list, Enter applies.
-    Each aggregation entry encodes ``(op, value_col)`` — ``count rows`` is the
-    keyless ``size`` aggregation; the rest are ``op(value_col)``.  Dismisses with
-    ``(key, op, value_col|None)`` or None on cancel.
+    Three lists, Enter advances then applies: pick the key, the operation, and —
+    for every operation but ``count rows`` — the value column.  ``count rows``
+    (the keyless ``size`` aggregation) applies straight from the operation list.
+    Dismisses with ``(key, op, value_col|None)`` or None on cancel.
     """
 
     CSS = """
@@ -799,7 +799,7 @@ class GroupByScreen(ModalScreen["tuple[str, str, str | None] | None"]):
         align: center middle;
     }
     #groupby-dialog {
-        width: 64;
+        width: 80;
         height: auto;
         max-height: 80%;
         border: thick $accent;
@@ -813,15 +813,39 @@ class GroupByScreen(ModalScreen["tuple[str, str, str | None] | None"]):
     .groupby-label {
         color: $text-muted;
     }
-    #groupby-key, #groupby-agg {
+    #groupby-cols {
+        height: auto;
+    }
+    .groupby-col {
+        width: 1fr;
+        height: auto;
+    }
+    #groupby-col-left {
+        margin-right: 2;
+    }
+    #groupby-key, #groupby-op {
         height: auto;
         max-height: 10;
+    }
+    #groupby-value {
+        height: auto;
+        max-height: 20;
     }
     """
 
     BINDINGS: ClassVar = [("escape", "cancel", "Cancel")]
 
-    _OPS: ClassVar = ["sum", "mean", "min", "max"]
+    # (label, library op); "count rows" is size (no value column needed).
+    _ALL_OPS: ClassVar = [
+        ("count rows", "size"),
+        ("count (non-null)", "count"),
+        ("sum", "sum"),
+        ("mean", "mean"),
+        ("min", "min"),
+        ("max", "max"),
+        ("argmin", "argmin"),
+        ("argmax", "argmax"),
+    ]
 
     def __init__(
         self,
@@ -832,46 +856,66 @@ class GroupByScreen(ModalScreen["tuple[str, str, str | None] | None"]):
     ):
         super().__init__()
         self.keys = keys
-        # (op, value_col) per aggregation row; "count rows" is size (no column).
-        self.aggs: list[tuple[str, str | None]] = [("size", None)]
-        for v in values:
-            self.aggs.extend((op, v) for op in self._OPS)
+        self.values = values
+        # Every op but "count rows" needs a value column; offer only it if none.
+        self.ops = self._ALL_OPS if values else self._ALL_OPS[:1]
         self._current = current
-
-    def _agg_label(self, op: str, value_col: str | None) -> str:
-        return "count rows" if op == "size" else f"{op}({value_col})"
 
     def compose(self) -> ComposeResult:
         with Vertical(id="groupby-dialog"):
-            yield Static("Group by (Tab to aggregation, Enter applies)", id="groupby-title")
-            yield Static("Key column", classes="groupby-label")
-            yield OptionList(
-                *(Option(name, id=str(i)) for i, name in enumerate(self.keys)), id="groupby-key"
-            )
-            yield Static("Aggregation", classes="groupby-label")
-            yield OptionList(
-                *(Option(self._agg_label(op, v), id=str(i)) for i, (op, v) in enumerate(self.aggs)),
-                id="groupby-agg",
-            )
+            yield Static("Group by (Enter advances / applies)", id="groupby-title")
+            with Horizontal(id="groupby-cols"):
+                with Vertical(id="groupby-col-left", classes="groupby-col"):
+                    yield Static("Key column", classes="groupby-label")
+                    yield OptionList(
+                        *(Option(name, id=str(i)) for i, name in enumerate(self.keys)),
+                        id="groupby-key",
+                    )
+                    yield Static("Operation", classes="groupby-label")
+                    yield OptionList(
+                        *(Option(label, id=str(i)) for i, (label, _op) in enumerate(self.ops)),
+                        id="groupby-op",
+                    )
+                with Vertical(classes="groupby-col"):
+                    yield Static("Value column", classes="groupby-label")
+                    yield OptionList(
+                        *(Option(name, id=str(i)) for i, name in enumerate(self.values)),
+                        id="groupby-value",
+                    )
 
     def on_mount(self) -> None:
         key_list = self.query_one("#groupby-key", OptionList)
-        agg_list = self.query_one("#groupby-agg", OptionList)
+        op_list = self.query_one("#groupby-op", OptionList)
+        value_list = self.query_one("#groupby-value", OptionList)
         cur_key, cur_op, cur_val = self._current or (None, None, None)
         key_list.highlighted = self.keys.index(cur_key) if cur_key in self.keys else 0
-        agg_list.highlighted = self.aggs.index((cur_op, cur_val)) if (cur_op, cur_val) in self.aggs else 0
+        op_labels = [op for _label, op in self.ops]
+        op_idx = op_labels.index(cur_op) if cur_op in op_labels else 0
+        op_list.highlighted = op_idx
+        value_list.highlighted = self.values.index(cur_val) if cur_val in self.values else 0
         key_list.focus()
 
     def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
-        # Enter on the key list advances to the aggregation list; Enter there
-        # applies, reading the key list's current highlight.
-        if event.option_list.id == "groupby-key":
-            self.query_one("#groupby-agg", OptionList).focus()
+        # Enter advances key -> operation -> value; "count rows" applies straight
+        # from the operation list (no value column needed).
+        list_id = event.option_list.id
+        if list_id == "groupby-key":
+            self.query_one("#groupby-op", OptionList).focus()
             return
+        if list_id == "groupby-op":
+            op = self.ops[int(event.option.id)][1]
+            if op == "size":
+                self._apply(op, None)
+            else:
+                self.query_one("#groupby-value", OptionList).focus()
+            return
+        op = self.ops[self.query_one("#groupby-op", OptionList).highlighted or 0][1]
+        self._apply(op, self.values[int(event.option.id)])
+
+    def _apply(self, op: str, value_col: str | None) -> None:
         key_idx = self.query_one("#groupby-key", OptionList).highlighted
         if key_idx is None:
             return
-        op, value_col = self.aggs[int(event.option.id)]
         self.dismiss((self.keys[key_idx], op, value_col))
 
     def action_cancel(self) -> None:

--- a/src/blosc2/b2view/model.py
+++ b/src/blosc2/b2view/model.py
@@ -1020,24 +1020,91 @@ class StoreBrowser:
         return "size" if op == "size" else f"{value_col}_{op}"
 
     def group_bars(self, path: str, top_n: int = 50) -> dict[str, Any]:
-        """Top-*top_n* groups (by aggregate value) as bar-chart labels + values."""
+        """Grouped result as plot data, chosen by key dtype.
+
+        Follows the grid's active sort on the grouped result (so the plot matches
+        what the user sees — Pareto when sorted by the aggregate, key-order when
+        sorted by the key); with no sort, ranks by the aggregate descending.
+
+        A **categorical** key (dictionary/string) yields a *bar* chart: the first
+        ``top_n`` groups as ``labels`` + ``values``.  A **numeric** key yields a
+        *line* curve over **all** groups (``x`` + ``values``): ``x`` is the key
+        value when sorted by the key (a spacing-honest distribution), else the
+        rank index (a Pareto curve).  ``numeric`` says which.
+        """
         path = self.normalize_path(path)
         result = self._group_views.get(path)
         group = self._groups.get(path)
+        empty = {
+            "numeric": False,
+            "labels": [],
+            "x": [],
+            "values": [],
+            "total": 0,
+            "key": "",
+            "agg": "",
+            "xlabel": "",
+        }
         if result is None or group is None:
-            return {"labels": [], "values": [], "total": 0, "key": "", "agg": ""}
+            return empty
         key = group[0]
         agg = self.group_agg_column(path)
-        keys = safe_asarray(result[key][:])
-        vals = np.asarray(result[agg][:], dtype=float)
-        order = np.argsort(vals)[::-1][:top_n]
+        total = len(result)
+        sorted_result = self._group_sort_views.get(path)
+        sort = self._group_sorts.get(path)
+        source = sorted_result if sorted_result is not None else result
+
+        if self._is_numeric_key(result, key):
+            # Full curve, no top-N cap.  Honour the active sort; default to
+            # aggregate-descending (a Pareto curve) when none is set.
+            keys = np.asarray(source[key][:], dtype=float)
+            vals = np.asarray(source[agg][:], dtype=float)
+            if sorted_result is None:
+                order = np.argsort(vals)[::-1]
+                keys, vals = keys[order], vals[order]
+            if sort is not None and sort[0] == key:  # sorted by the key → key on X
+                x, xlabel = keys.tolist(), key
+            else:  # ranked by the aggregate → rank on X (Pareto)
+                x, xlabel = list(range(len(vals))), f"rank (by {agg})"
+            return {
+                "numeric": True,
+                "labels": [],
+                "x": [float(v) for v in x],
+                "values": [float(v) for v in vals],
+                "total": total,
+                "key": key,
+                "agg": agg,
+                "xlabel": xlabel,
+            }
+
+        # Categorical key → top-N bars.
+        if sorted_result is not None:
+            keys = safe_asarray(sorted_result[key][:top_n])
+            vals = np.asarray(sorted_result[agg][:top_n], dtype=float)
+            order = range(len(vals))
+        else:
+            keys = safe_asarray(result[key][:])
+            vals = np.asarray(result[agg][:], dtype=float)
+            order = np.argsort(vals)[::-1][:top_n]
         return {
+            "numeric": False,
+            "x": [],
             "labels": [str(keys[i]) for i in order],
             "values": [float(vals[i]) for i in order],
-            "total": len(vals),
+            "total": total,
             "key": key,
             "agg": agg,
+            "xlabel": key,
         }
+
+    @staticmethod
+    def _is_numeric_key(result: Any, key: str) -> bool:
+        """True when the grouped key column is numeric (not a decoded dictionary)."""
+        col = result[key]
+        if getattr(col, "is_dictionary", False):
+            return False
+        dt = getattr(col, "dtype", None)
+        return dt is not None and dt.kind in "iuf"
 
     def base_nrows(self, path: str) -> int:
         """Return the unfiltered row count of the CTable at *path*."""

--- a/src/blosc2/b2view/model.py
+++ b/src/blosc2/b2view/model.py
@@ -835,7 +835,9 @@ class StoreBrowser:
             self._filters.pop(path, None)
             self._filter_views.pop(path, None)
             return len(self._get_object(path))
-        self.clear_sort(path)  # filter and sort are mutually exclusive
+        # A filter redefines the row set, so any existing sort over the old rows
+        # is dropped; the user re-sorts the filtered rows on top if they want.
+        self.clear_sort(path)
         view = self._get_object(path).where(expr)
         self._filters[path] = expr
         self._filter_views[path] = view
@@ -850,17 +852,22 @@ class StoreBrowser:
         obj = self._get_object(path)
         return [ix.col_name for ix in getattr(obj, "indexes", []) if getattr(ix, "kind", None) == "full"]
 
-    def set_sort(self, path: str, column: str, reverse: bool) -> None:
-        """Order the CTable at *path* by *column* using its FULL index (zero-copy view).
+    def _row_source(self, path: str) -> Any:
+        """Base rows that sort/group build on: the active row filter view if any,
+        else the underlying table.  This is what makes a filter compose — sort
+        and group operate on the filtered rows, not the whole table."""
+        return self._filter_views.get(path, self._get_object(path))
 
-        The view streams from the sorted index, so the full table is never
-        materialised.  Sorting replaces any active row filter/window for *path*.
+    def set_sort(self, path: str, column: str, reverse: bool) -> None:
+        """Order the CTable at *path* by *column* as a zero-copy sorted view.
+
+        Composes over any active row filter (sorts the filtered rows); replaces
+        any locked window.  With no filter and a FULL index on *column*, the view
+        streams from the index, so the full table is never materialised.
         """
         path = self.normalize_path(path)
         self._window_views.pop(path, None)
-        self._filters.pop(path, None)
-        self._filter_views.pop(path, None)
-        view = self._get_object(path).sort_by(column, ascending=not reverse, view=True)
+        view = self._row_source(path).sort_by(column, ascending=not reverse, view=True)
         self._sorts[path] = (column, reverse)
         self._sort_views[path] = view
 
@@ -875,10 +882,11 @@ class StoreBrowser:
         return self._sorts.get(self.normalize_path(path))
 
     def _ordered_object(self, path: str, obj: Any) -> Any:
-        """CTable read precedence for *path*: group > window > filter > sort > base.
+        """CTable read precedence for *path*: group > window > sort > filter > base.
 
-        A group-by is exclusive (it clears the others), so when present it is the
-        whole story; the remaining tiers compose as before.
+        Sort and group build on the filtered rows (see :meth:`_row_source`), so a
+        sort view already incorporates the filter and ranks above the bare filter
+        view; the bare filter view is read only when no sort is active.
         """
         if path in self._group_sort_views:
             return self._group_sort_views[path]
@@ -886,9 +894,9 @@ class StoreBrowser:
             return self._group_views[path]
         if path in self._window_views:
             return self._window_views[path]
-        if path in self._filter_views:
-            return self._filter_views[path]
-        return self._sort_views.get(path, obj)
+        if path in self._sort_views:
+            return self._sort_views[path]
+        return self._filter_views.get(path, obj)
 
     def set_row_window(self, path: str, start: int, stop: int) -> int:
         """Lock the CTable at *path* to live rows ``[start:stop]``; return its length.
@@ -898,10 +906,14 @@ class StoreBrowser:
         then cannot leave the range because the view reports only its own rows.
         """
         path = self.normalize_path(path)
-        if path in self._filter_views:
+        # The sort view already incorporates any filter, so prefer it; fall back
+        # to the bare filter view, then the base table.
+        if path in self._sort_views:
+            base = self._sort_views[path]
+        elif path in self._filter_views:
             base = self._filter_views[path]
         else:
-            base = self._sort_views.get(path, self._get_object(path))
+            base = self._get_object(path)
         view = base.slice(start, stop, copy=False)
         self._window_views[path] = view
         return len(view)
@@ -948,23 +960,24 @@ class StoreBrowser:
         """Group the CTable at *path* by *key*, aggregating with *op*; return group count.
 
         Builds a materialized result CTable (one row per group, columns = key +
-        aggregate).  Group-by is exclusive: it drops any active filter, window,
-        sort, and column selection for *path*.  Errors from ``group_by`` propagate.
+        aggregate).  Composes over any active row filter (groups the filtered
+        rows); drops any window, sort, and column selection.  Errors from
+        ``group_by`` propagate.
         """
         path = self.normalize_path(path)
         # Memoize the materialized result: the store is read-only, so a given
-        # (path, key, op, value_col) always aggregates to the same tiny CTable.
+        # (path, filter, key, op, value_col) always aggregates to the same tiny
+        # CTable.  The active filter expr is part of the key so a filtered group
+        # never collides with the unfiltered one.
         # ponytail: unbounded dict, but results are one-row-per-group and a
         # session tries only a handful of configs — add an LRU cap if that ever
         # stops being true.
-        cache_key = (path, key, op, value_col)
+        cache_key = (path, self._filters.get(path), key, op, value_col)
         result = self._group_result_cache.get(cache_key)
         if result is None:
-            gb = self._get_object(path).group_by(key)
+            gb = self._row_source(path).group_by(key)
             result = gb.size() if op == "size" else gb.agg({value_col: op})
             self._group_result_cache[cache_key] = result
-        self._filters.pop(path, None)
-        self._filter_views.pop(path, None)
         self._window_views.pop(path, None)
         self._sorts.pop(path, None)
         self._sort_views.pop(path, None)

--- a/src/blosc2/b2view/model.py
+++ b/src/blosc2/b2view/model.py
@@ -915,13 +915,19 @@ class StoreBrowser:
         return self.normalize_path(path) in self._window_views
 
     def group_key_columns(self, path: str) -> list[str]:
-        """CTable columns at *path* usable as group-by keys (dictionary or integer)."""
+        """CTable columns at *path* usable as group-by keys (dictionary or numeric).
+
+        Includes floats: grouping by a numeric column (e.g. trip duration/distance
+        or a timestamp) buckets rows by exact value — handy for spotting rush
+        hours or best-profit windows.  Cardinality is the user's call; we don't
+        bin.  Non-dictionary text and nested/ndarray columns are excluded.
+        """
         obj = self._get_object(path)
         out = []
         for name in getattr(obj, "col_names", []) or []:
             col = obj[name]
             dt = getattr(col, "dtype", None)
-            if getattr(col, "is_dictionary", False) or (dt is not None and dt.kind in "iu"):
+            if getattr(col, "is_dictionary", False) or (dt is not None and dt.kind in "iuf"):
                 out.append(name)
         return out
 

--- a/src/blosc2/b2view/model.py
+++ b/src/blosc2/b2view/model.py
@@ -263,6 +263,10 @@ class StoreBrowser:
         # Per-path sort order for CTable nodes (path -> (column, reverse) / view)
         self._sorts: dict[str, tuple[str, bool]] = {}
         self._sort_views: dict[str, Any] = {}
+        # Per-path group-by for CTable nodes (path -> (key, op, value_col|None) /
+        # materialized result CTable).  Exclusive with filter/window/column-sel.
+        self._groups: dict[str, tuple[str, str, str | None]] = {}
+        self._group_views: dict[str, Any] = {}
         # Per-path column filters (path -> substring pattern / matched names)
         self._column_filters: dict[str, str] = {}
         self._column_selections: dict[str, list[str]] = {}
@@ -390,8 +394,9 @@ class StoreBrowser:
                     return preview_array_1d(obj, start=start, stop=stop)
             return preview_array(obj, slices=slices, max_rows=max_rows, max_cols=max_cols)
         if kind == "ctable":
-            # Read precedence: a locked row window (set by 'v') wins, then a row
-            # filter, then a sort view; all already fold in their predecessors.
+            # Read precedence: a group-by (smaller aggregated result) wins, then
+            # a locked row window (set by 'v'), then a row filter, then a sort
+            # view; all already fold in their predecessors.
             obj = self._ordered_object(path, obj)
             if columns is None:
                 columns = self._column_selections.get(path)
@@ -803,6 +808,8 @@ class StoreBrowser:
         (navigation operates on the filtered universe).
         """
         path = self.normalize_path(path)
+        if path in self._group_views:
+            return list(getattr(self._group_views[path], "col_names", []) or []) or None
         selection = self._column_selections.get(path)
         if selection is not None:
             return list(selection)
@@ -861,7 +868,13 @@ class StoreBrowser:
         return self._sorts.get(self.normalize_path(path))
 
     def _ordered_object(self, path: str, obj: Any) -> Any:
-        """CTable read precedence for *path*: window > filter > sort > base *obj*."""
+        """CTable read precedence for *path*: group > window > filter > sort > base.
+
+        A group-by is exclusive (it clears the others), so when present it is the
+        whole story; the remaining tiers compose as before.
+        """
+        if path in self._group_views:
+            return self._group_views[path]
         if path in self._window_views:
             return self._window_views[path]
         if path in self._filter_views:
@@ -891,6 +904,89 @@ class StoreBrowser:
     def get_row_window(self, path: str) -> bool:
         """Return whether *path* currently has a locked row window."""
         return self.normalize_path(path) in self._window_views
+
+    def group_key_columns(self, path: str) -> list[str]:
+        """CTable columns at *path* usable as group-by keys (dictionary or integer)."""
+        obj = self._get_object(path)
+        out = []
+        for name in getattr(obj, "col_names", []) or []:
+            col = obj[name]
+            dt = getattr(col, "dtype", None)
+            if getattr(col, "is_dictionary", False) or (dt is not None and dt.kind in "iu"):
+                out.append(name)
+        return out
+
+    def group_value_columns(self, path: str) -> list[str]:
+        """CTable columns at *path* usable as aggregation value columns (numeric scalar)."""
+        obj = self._get_object(path)
+        out = []
+        for name in getattr(obj, "col_names", []) or []:
+            col = obj[name]
+            if getattr(col, "is_dictionary", False) or getattr(col, "is_ndarray", False):
+                continue
+            dt = getattr(col, "dtype", None)
+            if dt is not None and dt.kind in "iuf":
+                out.append(name)
+        return out
+
+    def set_group(self, path: str, key: str, op: str, value_col: str | None) -> int:
+        """Group the CTable at *path* by *key*, aggregating with *op*; return group count.
+
+        Builds a materialized result CTable (one row per group, columns = key +
+        aggregate).  Group-by is exclusive: it drops any active filter, window,
+        sort, and column selection for *path*.  Errors from ``group_by`` propagate.
+        """
+        path = self.normalize_path(path)
+        gb = self._get_object(path).group_by(key)
+        result = gb.size() if op == "size" else gb.agg({value_col: op})
+        self._filters.pop(path, None)
+        self._filter_views.pop(path, None)
+        self._window_views.pop(path, None)
+        self._sorts.pop(path, None)
+        self._sort_views.pop(path, None)
+        self._column_filters.pop(path, None)
+        self._column_selections.pop(path, None)
+        self._groups[path] = (key, op, value_col)
+        self._group_views[path] = result
+        return len(result)
+
+    def get_group(self, path: str) -> tuple[str, str, str | None] | None:
+        """Return the active ``(key, op, value_col)`` group-by for *path*, if any."""
+        return self._groups.get(self.normalize_path(path))
+
+    def clear_group(self, path: str) -> None:
+        """Drop any group-by from *path*, restoring the base table."""
+        path = self.normalize_path(path)
+        self._groups.pop(path, None)
+        self._group_views.pop(path, None)
+
+    def group_agg_column(self, path: str) -> str | None:
+        """Name of the aggregate column in the grouped result for *path*, if grouped."""
+        group = self._groups.get(self.normalize_path(path))
+        if group is None:
+            return None
+        key, op, value_col = group
+        return "size" if op == "size" else f"{value_col}_{op}"
+
+    def group_bars(self, path: str, top_n: int = 50) -> dict[str, Any]:
+        """Top-*top_n* groups (by aggregate value) as bar-chart labels + values."""
+        path = self.normalize_path(path)
+        result = self._group_views.get(path)
+        group = self._groups.get(path)
+        if result is None or group is None:
+            return {"labels": [], "values": [], "total": 0, "key": "", "agg": ""}
+        key = group[0]
+        agg = self.group_agg_column(path)
+        keys = safe_asarray(result[key][:])
+        vals = np.asarray(result[agg][:], dtype=float)
+        order = np.argsort(vals)[::-1][:top_n]
+        return {
+            "labels": [str(keys[i]) for i in order],
+            "values": [float(vals[i]) for i in order],
+            "total": len(vals),
+            "key": key,
+            "agg": agg,
+        }
 
     def base_nrows(self, path: str) -> int:
         """Return the unfiltered row count of the CTable at *path*."""

--- a/src/blosc2/b2view/model.py
+++ b/src/blosc2/b2view/model.py
@@ -271,6 +271,9 @@ class StoreBrowser:
         # / sorted view of the small result).  Lives only while grouped.
         self._group_sorts: dict[str, tuple[str, bool]] = {}
         self._group_sort_views: dict[str, Any] = {}
+        # Memoized grouped results, keyed by (path, key, op, value_col).  Survives
+        # ungrouping so re-running a prior group-by is instant (store is read-only).
+        self._group_result_cache: dict[tuple[str, str, str, str | None], Any] = {}
         # Per-path column filters (path -> substring pattern / matched names)
         self._column_filters: dict[str, str] = {}
         self._column_selections: dict[str, list[str]] = {}
@@ -943,8 +946,17 @@ class StoreBrowser:
         sort, and column selection for *path*.  Errors from ``group_by`` propagate.
         """
         path = self.normalize_path(path)
-        gb = self._get_object(path).group_by(key)
-        result = gb.size() if op == "size" else gb.agg({value_col: op})
+        # Memoize the materialized result: the store is read-only, so a given
+        # (path, key, op, value_col) always aggregates to the same tiny CTable.
+        # ponytail: unbounded dict, but results are one-row-per-group and a
+        # session tries only a handful of configs — add an LRU cap if that ever
+        # stops being true.
+        cache_key = (path, key, op, value_col)
+        result = self._group_result_cache.get(cache_key)
+        if result is None:
+            gb = self._get_object(path).group_by(key)
+            result = gb.size() if op == "size" else gb.agg({value_col: op})
+            self._group_result_cache[cache_key] = result
         self._filters.pop(path, None)
         self._filter_views.pop(path, None)
         self._window_views.pop(path, None)

--- a/src/blosc2/b2view/model.py
+++ b/src/blosc2/b2view/model.py
@@ -267,6 +267,10 @@ class StoreBrowser:
         # materialized result CTable).  Exclusive with filter/window/column-sel.
         self._groups: dict[str, tuple[str, str, str | None]] = {}
         self._group_views: dict[str, Any] = {}
+        # Optional sort applied on top of a grouped result (path -> (col, reverse)
+        # / sorted view of the small result).  Lives only while grouped.
+        self._group_sorts: dict[str, tuple[str, bool]] = {}
+        self._group_sort_views: dict[str, Any] = {}
         # Per-path column filters (path -> substring pattern / matched names)
         self._column_filters: dict[str, str] = {}
         self._column_selections: dict[str, list[str]] = {}
@@ -873,6 +877,8 @@ class StoreBrowser:
         A group-by is exclusive (it clears the others), so when present it is the
         whole story; the remaining tiers compose as before.
         """
+        if path in self._group_sort_views:
+            return self._group_sort_views[path]
         if path in self._group_views:
             return self._group_views[path]
         if path in self._window_views:
@@ -946,6 +952,8 @@ class StoreBrowser:
         self._sort_views.pop(path, None)
         self._column_filters.pop(path, None)
         self._column_selections.pop(path, None)
+        self._group_sorts.pop(path, None)  # a fresh result invalidates any group sort
+        self._group_sort_views.pop(path, None)
         self._groups[path] = (key, op, value_col)
         self._group_views[path] = result
         return len(result)
@@ -955,10 +963,35 @@ class StoreBrowser:
         return self._groups.get(self.normalize_path(path))
 
     def clear_group(self, path: str) -> None:
-        """Drop any group-by from *path*, restoring the base table."""
+        """Drop any group-by (and its sort) from *path*, restoring the base table."""
         path = self.normalize_path(path)
         self._groups.pop(path, None)
         self._group_views.pop(path, None)
+        self._group_sorts.pop(path, None)
+        self._group_sort_views.pop(path, None)
+
+    def set_group_sort(self, path: str, column: str, reverse: bool) -> None:
+        """Sort the (already grouped) result at *path* by one of its columns.
+
+        The grouped result is tiny and carries no index, so this lexsorts it as a
+        zero-copy view.  No-op if *path* is not grouped.
+        """
+        path = self.normalize_path(path)
+        result = self._group_views.get(path)
+        if result is None:
+            return
+        self._group_sorts[path] = (column, reverse)
+        self._group_sort_views[path] = result.sort_by(column, ascending=not reverse, view=True)
+
+    def get_group_sort(self, path: str) -> tuple[str, bool] | None:
+        """Return the active ``(column, reverse)`` sort on the grouped result, if any."""
+        return self._group_sorts.get(self.normalize_path(path))
+
+    def clear_group_sort(self, path: str) -> None:
+        """Drop any sort on the grouped result, keeping the group itself."""
+        path = self.normalize_path(path)
+        self._group_sorts.pop(path, None)
+        self._group_sort_views.pop(path, None)
 
     def group_agg_column(self, path: str) -> str | None:
         """Name of the aggregate column in the grouped result for *path*, if grouped."""

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+import ast
 import contextlib
 import contextvars
 import copy
@@ -11455,6 +11456,67 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
                 operands[name] = self._build_computed_lazy(cc)
         return operands
 
+    def _rewrite_dictionary_equalities(
+        self, expr: str, operands: dict[str, blosc2.NDArray | blosc2.LazyExpr]
+    ) -> tuple[str, dict[str, blosc2.NDArray | blosc2.LazyExpr]]:
+        """Rewrite ``dictcol == "literal"`` / ``!=`` into integer-code comparisons.
+
+        Dictionary columns are excluded from the plain operand namespace because
+        the expression engine would compare raw int32 codes against the string
+        literal (never matching).  Here each equality/inequality against a string
+        literal is resolved to that value's dictionary code, the literal is
+        replaced by the code, and the column's codes array is supplied as the
+        operand -- so the comparison becomes an ordinary numeric one that combines
+        with the rest of the expression (``and``/``or``, precedence) natively.  A
+        literal absent from the dictionary maps to a sentinel code no row carries,
+        so ``==`` matches nothing and ``!=`` matches everything.  Other uses of a
+        dictionary column are left untouched and still raise ``Unknown symbol``.
+        """
+        absent_code = int(np.iinfo(np.int32).min)  # a code no live row carries
+        rewritten = expr
+        new_operands = dict(operands)
+        for col in self._schema.columns:
+            if not self._is_dictionary_column(col) or not self._expression_references_name(expr, col.name):
+                continue
+            dc = self._cols[col.name]  # DictionaryColumn
+            # name (==|!=) "..."/'...'  (quoted literal may contain commas/spaces).
+            pattern = (
+                r"(?<![\w.])"
+                + re.escape(col.name)
+                + r"\s*(==|!=)\s*"
+                + r"""(\"(?:[^"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')"""
+            )
+
+            def repl(match: re.Match, _dc=dc, _name=col.name) -> str:
+                value = ast.literal_eval(match.group(2))
+                try:
+                    code = int(_dc.value_to_code(value))
+                except KeyError:
+                    code = absent_code
+                return f"{_name} {match.group(1)} {code}"
+
+            new_expr = re.sub(pattern, repl, rewritten)
+            if new_expr != rewritten:
+                # numexpr needs all operands chunked alike; the codes array uses a
+                # different chunkshape than the regular columns, so when mixed with
+                # one (e.g. ``dictcol == "x" and other > y``) re-chunk it to match.
+                codes = dc.codes
+                target = next(
+                    (
+                        v
+                        for v in operands.values()
+                        if isinstance(v, blosc2.NDArray)
+                        and v.shape == codes.shape
+                        and v.chunks != codes.chunks
+                    ),
+                    None,
+                )
+                if target is not None:
+                    codes = blosc2.asarray(codes[:], chunks=target.chunks, blocks=target.blocks)
+                new_operands[col.name] = codes
+                rewritten = new_expr
+        return rewritten, new_operands
+
     def _rewrite_nested_expression(
         self, expr: str, operands: dict[str, blosc2.NDArray | blosc2.LazyExpr]
     ) -> tuple[str, dict[str, blosc2.NDArray | blosc2.LazyExpr]]:
@@ -11601,6 +11663,7 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         if isinstance(expr_result, str):
             self._guard_varlen_scalar_expression(expr_result)
             operands = self._where_expression_operands(expr_result)
+            expr_result, operands = self._rewrite_dictionary_equalities(expr_result, operands)
             expr_result, operands = self._rewrite_nested_expression(expr_result, operands)
             expr_result = blosc2.lazyexpr(expr_result, operands)
         if isinstance(expr_result, np.ndarray) and expr_result.dtype == np.bool_:

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -11456,21 +11456,29 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
                 operands[name] = self._build_computed_lazy(cc)
         return operands
 
-    def _rewrite_dictionary_equalities(
+    # Quoted string literal (may contain commas/spaces/escapes), single or double.
+    _STR_LITERAL = r"""(\"(?:[^"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')"""
+
+    def _rewrite_dictionary_predicates(
         self, expr: str, operands: dict[str, blosc2.NDArray | blosc2.LazyExpr]
     ) -> tuple[str, dict[str, blosc2.NDArray | blosc2.LazyExpr]]:
-        """Rewrite ``dictcol == "literal"`` / ``!=`` into integer-code comparisons.
+        """Rewrite dictionary-column string predicates into integer-code comparisons.
 
         Dictionary columns are excluded from the plain operand namespace because
         the expression engine would compare raw int32 codes against the string
-        literal (never matching).  Here each equality/inequality against a string
-        literal is resolved to that value's dictionary code, the literal is
-        replaced by the code, and the column's codes array is supplied as the
-        operand -- so the comparison becomes an ordinary numeric one that combines
-        with the rest of the expression (``and``/``or``, precedence) natively.  A
-        literal absent from the dictionary maps to a sentinel code no row carries,
-        so ``==`` matches nothing and ``!=`` matches everything.  Other uses of a
-        dictionary column are left untouched and still raise ``Unknown symbol``.
+        literal (never matching).  Two predicate forms are resolved here, against
+        the dictionary's codes:
+
+        - ``dictcol == "literal"`` / ``!=`` -> ``dictcol ==/!= <code>``; an absent
+          literal maps to a sentinel code no row carries (``==`` matches nothing,
+          ``!=`` everything).
+        - ``"literal" in dictcol`` -> substring search: an ``OR`` of ``==`` over
+          every dictionary value containing *literal* (none -> matches nothing).
+
+        The column's codes array is then supplied as the operand, so the result is
+        an ordinary numeric expression that combines with the rest (``and``/``or``,
+        precedence) natively.  Other uses of a dictionary column are left untouched
+        and still raise ``Unknown symbol``.
         """
         absent_code = int(np.iinfo(np.int32).min)  # a code no live row carries
         rewritten = expr
@@ -11479,15 +11487,9 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
             if not self._is_dictionary_column(col) or not self._expression_references_name(expr, col.name):
                 continue
             dc = self._cols[col.name]  # DictionaryColumn
-            # name (==|!=) "..."/'...'  (quoted literal may contain commas/spaces).
-            pattern = (
-                r"(?<![\w.])"
-                + re.escape(col.name)
-                + r"\s*(==|!=)\s*"
-                + r"""(\"(?:[^"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')"""
-            )
+            name = col.name
 
-            def repl(match: re.Match, _dc=dc, _name=col.name) -> str:
+            def eq_repl(match: re.Match, _dc=dc, _name=name) -> str:
                 value = ast.literal_eval(match.group(2))
                 try:
                     code = int(_dc.value_to_code(value))
@@ -11495,7 +11497,18 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
                     code = absent_code
                 return f"{_name} {match.group(1)} {code}"
 
-            new_expr = re.sub(pattern, repl, rewritten)
+            def in_repl(match: re.Match, _dc=dc, _name=name) -> str:
+                needle = ast.literal_eval(match.group(1))
+                codes = [c for c, value in enumerate(_dc.dictionary) if needle in value]
+                if not codes:
+                    return f"({_name} == {absent_code})"
+                # Per-term parens: bitwise ``|`` binds tighter than ``==``.
+                return "(" + " | ".join(f"({_name} == {c})" for c in codes) + ")"
+
+            eq_pattern = r"(?<![\w.])" + re.escape(name) + r"\s*(==|!=)\s*" + self._STR_LITERAL
+            in_pattern = self._STR_LITERAL + r"\s+in\s+(?<![\w.])" + re.escape(name) + r"(?![\w.])"
+            new_expr = re.sub(eq_pattern, eq_repl, rewritten)
+            new_expr = re.sub(in_pattern, in_repl, new_expr)
             if new_expr != rewritten:
                 # numexpr needs all operands chunked alike; the codes array uses a
                 # different chunkshape than the regular columns, so when mixed with
@@ -11513,7 +11526,7 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
                 )
                 if target is not None:
                     codes = blosc2.asarray(codes[:], chunks=target.chunks, blocks=target.blocks)
-                new_operands[col.name] = codes
+                new_operands[name] = codes
                 rewritten = new_expr
         return rewritten, new_operands
 
@@ -11663,7 +11676,7 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         if isinstance(expr_result, str):
             self._guard_varlen_scalar_expression(expr_result)
             operands = self._where_expression_operands(expr_result)
-            expr_result, operands = self._rewrite_dictionary_equalities(expr_result, operands)
+            expr_result, operands = self._rewrite_dictionary_predicates(expr_result, operands)
             expr_result, operands = self._rewrite_nested_expression(expr_result, operands)
             expr_result = blosc2.lazyexpr(expr_result, operands)
         if isinstance(expr_result, np.ndarray) and expr_result.dtype == np.bool_:

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -1232,8 +1232,17 @@ class Column:
         root._mark_all_indexes_stale()
 
     def __iter__(self):
-        """Iterate over live column values in insertion order, skipping deleted rows."""
+        """Iterate over live column values in row order, skipping deleted rows.
+
+        For an ordered view (sorted view, position view, or a reordering slice
+        such as ``t[::-1]``), rows are yielded in the view's order rather than
+        physical-ascending order.  Physical-order iteration below stays chunked.
+        """
         self._ensure_not_stale()
+        slp = getattr(self._table, "_cached_live_positions", None)
+        if slp is not None and self._table.base is not None:
+            yield from self._values_from_key(slice(None), check_stale=False)
+            return
         if self.is_computed:
             yield from self._iter_chunks_computed(size=None)
             return
@@ -1276,7 +1285,13 @@ class Column:
             )
             preview_values = [f"<{label}>"] * min(len(self), preview_len)
         else:
-            preview_pos = np.where(self._valid_rows[:])[0][:preview_len]
+            # Honor an ordered view (sorted/position view, reordering slice) so
+            # the preview shows the view's leading rows, not physical-first ones.
+            slp = getattr(self._table, "_cached_live_positions", None)
+            if slp is not None and self._table.base is not None:
+                preview_pos = np.asarray(slp[:preview_len])
+            else:
+                preview_pos = np.where(self._valid_rows[:])[0][:preview_len]
             if self.is_dictionary or self.is_varlen_scalar:
                 preview_values = self._raw_col[preview_pos]
             elif len(preview_pos) == 0:
@@ -5602,7 +5617,7 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         self,
         keys: str | Sequence[str],
         *,
-        sort: bool = False,
+        sort: bool | None = None,
         dropna: bool = True,
         engine: str = "auto",
         chunk_size: int | None = None,
@@ -5614,9 +5629,55 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         keys:
             Column name or sequence of column names to group by.
         sort:
-            If ``True``, sort the result by the group keys.  The default
-            ``False`` preserves the hash aggregation order and is usually
-            faster.
+            Controls the ordering of the output groups:
+
+            * ``True`` -- always return groups sorted by key.
+            * ``False`` -- do not sort; groups come out in a deterministic but
+              unspecified order (integer/dense keys are still ascending, as that
+              order is free).
+            * ``None`` (default) -- *auto*: sort only when the path can do so
+              cheaply.  Integer and dictionary (string) keys are sorted (free or
+              vectorized); float and multi-key results, whose only ordering is a
+              Python sort over every distinct group, are left unsorted.  This
+              avoids paying an O(G log G) Python sort that can rival the grouping
+              cost itself on high-cardinality data.
+
+            .. list-table::
+               :header-rows: 1
+
+               * - key kind
+                 - ``sort=False``
+                 - ``sort=None`` (auto)
+                 - ``sort=True``
+               * - int / dense
+                 - ascending\\ :sup:`*`
+                 - ascending
+                 - ascending
+               * - dictionary / string
+                 - first-seen code order
+                 - sorted by string
+                 - sorted by string
+               * - float
+                 - unspecified\\ :sup:`**`
+                 - unspecified\\ :sup:`**`
+                 - sorted
+               * - multi-key / generic
+                 - unspecified\\ :sup:`**`
+                 - unspecified\\ :sup:`**`
+                 - sorted
+
+            :sup:`*` integer dense is always ascending, so ``False`` means "no
+            ordering promise", not "guaranteed unsorted".
+
+            :sup:`**` deterministic for a given table, but order is an
+            implementation detail (hash-bucket or first-appearance depending on
+            the path); do not rely on it -- pass ``sort=True`` if you need order.
+
+            .. note::
+               This differs from pandas, whose ``groupby`` defaults to
+               ``sort=True``.  blosc2 targets large, potentially on-disk data
+               where an unconditional group sort is not always cheap relative to
+               the scan, hence the ``None`` auto-default.
         dropna:
             If ``True`` (default), rows with null/NaN group keys are skipped.
             If ``False``, null/NaN keys form their own group.
@@ -11759,16 +11820,24 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
     def _run_row_logic(self, ind: int | slice | str | Iterable) -> CTable:
         true_pos = self._live_positions_from_valid_rows_chunks()
 
+        # A boolean mask is set-like: it selects rows in physical-ascending order
+        # and cannot represent duplicates.  Every other selector — a slice (incl.
+        # negative-step reverse), an integer array, or a list of positions —
+        # carries an explicit order and may repeat rows.  Detect the mask before
+        # any list() coercion so we keep its dtype.
+        is_bool_mask = isinstance(ind, np.ndarray) and ind.dtype == np.bool_
+
         if isinstance(ind, Iterable) and not isinstance(ind, (str, bytes)):
             ind = list(ind)
 
-        mant_pos = true_pos[ind]
+        mant_pos = np.asarray(true_pos[ind])
 
-        # For an ordered view (sorted view or position view), preserve the row
-        # order and any duplicates by carrying the positions forward.  A boolean
-        # mask is physical-order and set-like, so it would silently drop both.
-        if getattr(self, "_cached_live_positions", None) is not None:
-            return self._view_from_positions(np.asarray(mant_pos))
+        # Carry the positions forward whenever order matters: for an ordered view
+        # (sorted view or position view), or for any order-carrying selector.  A
+        # boolean mask is physical-order and set-like, so going through it would
+        # silently drop both the requested order and any duplicates.
+        if getattr(self, "_cached_live_positions", None) is not None or not is_bool_mask:
+            return self._view_from_positions(mant_pos)
 
         new_mask_np = np.zeros(len(self._valid_rows), dtype=bool)
         new_mask_np[mant_pos] = True

--- a/src/blosc2/dictionary_column.py
+++ b/src/blosc2/dictionary_column.py
@@ -110,6 +110,26 @@ class DictionaryColumn:
         self._ensure_cache()
         return self._dict_store[int(code)]
 
+    def decode_batch(self, codes) -> list[str | None]:
+        """Decode an array of int32 *codes* to a list of strings (``None`` for null codes).
+
+        Reads the whole dictionary store once (cardinality ``D``, not the ``N``
+        rows) instead of indexing the backing var-length array per code, which
+        decompresses a whole msgpack batch on every call.  For many codes this
+        is dramatically cheaper than looping over :meth:`decode`.
+        """
+        codes = np.asarray(codes)
+        self._dict_store.flush()
+        all_strings = np.asarray(self._dict_store[:])  # D unique values, no nulls
+        null_code = int(self._spec.null_code)
+        result: list[str | None] = [None] * len(codes)
+        non_null_idx = np.nonzero(codes != null_code)[0]
+        if non_null_idx.size:
+            picked = all_strings[codes[non_null_idx].astype(np.intp)].tolist()
+            for pos, value in zip(non_null_idx.tolist(), picked, strict=True):
+                result[pos] = value
+        return result
+
     def encode_batch(self, values) -> np.ndarray:
         """Encode a sequence of str/None to a numpy ``int32`` array of codes."""
         result = np.empty(len(values), dtype=np.int32)

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -249,30 +249,39 @@ class CTableGroupBy:
         finally:
             self._result_urlpath = old_result_urlpath
 
+    def _try_fast_paths(self, specs: list[_AggSpec], use_arg_positions: bool):
+        """Dispatch to the available fast paths; return a result CTable or None.
+
+        argmin/argmax can only use the dense single-key path (it tracks row
+        positions); the Cython kernels do not, so they are skipped for them.
+        """
+        if not use_arg_positions:
+            for attempt in (
+                self._try_execute_cython_dense_int_key,
+                self._try_execute_cython_two_int_key_hash,
+                self._try_execute_cython_i32_f64_sum,
+                self._try_execute_cython_float_integral_key_f64_sum,
+            ):
+                fast = attempt(specs)
+                if fast is not None:
+                    return fast
+        # Dense single-key path also covers integral-valued float keys with a
+        # compact non-negative range (e.g. float32 second/id columns), so try it
+        # before the generic float hash path, which is markedly slower.  Unlike
+        # the Cython kernels above, it tracks row positions, so it also serves
+        # argmin/argmax — keeping them off the slow generic hash+merge path.
+        fast = self._try_execute_dense_single_int_key(specs)
+        if fast is not None:
+            return fast
+        if not use_arg_positions:
+            return self._try_execute_cython_float_hash(specs)
+        return None
+
     def _execute_with_result_target(self, specs: list[_AggSpec]):
         use_arg_positions = any(s.op in {"argmin", "argmax"} for s in specs)
-        if not use_arg_positions:
-            fast = self._try_execute_cython_dense_int_key(specs)
-            if fast is not None:
-                return fast
-            fast = self._try_execute_cython_two_int_key_hash(specs)
-            if fast is not None:
-                return fast
-            fast = self._try_execute_cython_i32_f64_sum(specs)
-            if fast is not None:
-                return fast
-            fast = self._try_execute_cython_float_integral_key_f64_sum(specs)
-            if fast is not None:
-                return fast
-            # Dense single-key path also covers integral-valued float keys with a
-            # compact non-negative range (e.g. float32 second/id columns), so try
-            # it before the generic float hash path, which is markedly slower.
-            fast = self._try_execute_dense_single_int_key(specs)
-            if fast is not None:
-                return fast
-            fast = self._try_execute_cython_float_hash(specs)
-            if fast is not None:
-                return fast
+        fast = self._try_fast_paths(specs, use_arg_positions)
+        if fast is not None:
+            return fast
 
         acc: dict[Any, dict[str, _AggState]] = {}
         key_values: dict[Any, tuple[Any, ...]] = {}
@@ -1042,12 +1051,14 @@ class CTableGroupBy:
         # compact non-negative range; per-chunk casting verifies integrality and
         # bails (falling back to the hash path) on the first fractional value.
         key_is_integral_float = (not key_is_dict) and key_dtype.kind == "f"
-        if any(spec.op in {"min", "max"} and spec.input_col is not None for spec in specs):
+        extreme_ops = {"min", "max", "argmin", "argmax"}
+        if any(spec.op in extreme_ops and spec.input_col is not None for spec in specs):
             for spec in specs:
-                if spec.op in {"min", "max"} and spec.input_col is not None:
+                if spec.op in extreme_ops and spec.input_col is not None:
                     dtype = getattr(self.table._schema.columns_by_name[spec.input_col].spec, "dtype", None)
                     if dtype is None or np.dtype(dtype).kind not in "biufmM":
                         return None
+        need_positions = any(spec.op in {"argmin", "argmax"} for spec in specs)
 
         compact_limit = 10_000_000
         present = np.zeros(0, dtype=bool)
@@ -1068,6 +1079,15 @@ class CTableGroupBy:
                 dtype = np.dtype(self.table._schema.columns_by_name[spec.input_col].spec.dtype)
                 identity = _max_identity(dtype) if spec.op == "min" else _min_identity(dtype)
                 states[spec.output_col] = (np.full(0, identity, dtype=dtype), np.zeros(0, dtype=bool))
+            elif spec.op in {"argmin", "argmax"}:
+                assert spec.input_col is not None
+                dtype = np.dtype(self.table._schema.columns_by_name[spec.input_col].spec.dtype)
+                identity = _max_identity(dtype) if spec.op == "argmin" else _min_identity(dtype)
+                states[spec.output_col] = (
+                    np.full(0, identity, dtype=dtype),  # best value seen per group
+                    np.full(0, -1, dtype=np.int64),  # first row position attaining it
+                    np.zeros(0, dtype=bool),  # group has any non-null value
+                )
 
         def ensure_size(size: int) -> bool:
             nonlocal present, states
@@ -1095,14 +1115,27 @@ class CTableGroupBy:
                         np.pad(values, (0, size - old), constant_values=identity),
                         np.pad(has, (0, size - old), constant_values=False),
                     )
+                elif spec.op in {"argmin", "argmax"}:
+                    values, positions, has = state
+                    dtype = values.dtype
+                    identity = _max_identity(dtype) if spec.op == "argmin" else _min_identity(dtype)
+                    states[spec.output_col] = (
+                        np.pad(values, (0, size - old), constant_values=identity),
+                        np.pad(positions, (0, size - old), constant_values=-1),
+                        np.pad(has, (0, size - old), constant_values=False),
+                    )
             return True
 
         phys_len = len(self.table._valid_rows)
         chunk_size = self._chunk_size()
         value_cols = sorted({s.input_col for s in specs if s.input_col is not None})
+        logical_seen = 0  # running count of live rows, for argmin/argmax positions
         for start in range(0, phys_len, chunk_size):
             stop = min(start + chunk_size, phys_len)
             valid = np.asarray(self.table._valid_rows[start:stop], dtype=bool)
+            if need_positions:
+                logical_chunk = logical_seen + np.cumsum(valid, dtype=np.int64) - 1
+                logical_seen += int(np.count_nonzero(valid))
             if not np.any(valid):
                 continue
             raw_keys = self._read_key_chunk(key_name, start, stop)
@@ -1136,6 +1169,7 @@ class CTableGroupBy:
             value_chunks = {
                 name: np.asarray(self.table._cols[name][start:stop])[live_mask] for name in value_cols
             }
+            row_positions = logical_chunk[live_mask] if need_positions else None
 
             for spec in specs:
                 if spec.op == "size":
@@ -1172,6 +1206,37 @@ class CTableGroupBy:
                     else:
                         np.maximum.at(values_state, keys[non_null], values[non_null])
                     has_state[keys[non_null]] = True
+                elif spec.op in {"argmin", "argmax"}:
+                    best_state, pos_state, has_state = states[spec.output_col]
+                    nstates = len(present)
+                    k_nn = keys[non_null]
+                    v_nn = values[non_null]
+                    p_nn = row_positions[non_null]
+                    # This chunk's per-group extreme and the first position attaining it.
+                    if spec.op == "argmin":
+                        chunk_best = np.full(
+                            nstates, _max_identity(best_state.dtype), dtype=best_state.dtype
+                        )
+                        np.minimum.at(chunk_best, k_nn, v_nn)
+                    else:
+                        chunk_best = np.full(
+                            nstates, _min_identity(best_state.dtype), dtype=best_state.dtype
+                        )
+                        np.maximum.at(chunk_best, k_nn, v_nn)
+                    chunk_has = np.zeros(nstates, dtype=bool)
+                    chunk_has[k_nn] = True
+                    attains = v_nn == chunk_best[k_nn]
+                    chunk_pos = np.full(nstates, np.iinfo(np.int64).max, dtype=np.int64)
+                    np.minimum.at(chunk_pos, k_nn[attains], p_nn[attains])
+                    # Merge: a strictly better value replaces the position; an equal
+                    # value keeps the earlier (lower) position, so ties keep the first row.
+                    if spec.op == "argmin":
+                        better = chunk_has & (~has_state | (chunk_best < best_state))
+                    else:
+                        better = chunk_has & (~has_state | (chunk_best > best_state))
+                    best_state[better] = chunk_best[better]
+                    pos_state[better] = chunk_pos[better]
+                    has_state |= chunk_has
 
         group_codes = np.nonzero(present)[0]
         rows = []
@@ -1201,6 +1266,13 @@ class CTableGroupBy:
                     values_state, has_state = state
                     row[spec.output_col] = (
                         _python_scalar(values_state[code])
+                        if has_state[code]
+                        else _null_output_value(self._result_spec_for_agg(spec))
+                    )
+                elif spec.op in {"argmin", "argmax"}:
+                    _best_state, pos_state, has_state = state
+                    row[spec.output_col] = (
+                        int(pos_state[code])
                         if has_state[code]
                         else _null_output_value(self._result_spec_for_agg(spec))
                     )
@@ -1350,17 +1422,20 @@ class CTableGroupBy:
         row_positions: np.ndarray,
         n_groups: int,
     ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        best_values = np.empty(n_groups, dtype=values.dtype)
+        # Reduce the per-group extreme value with the (vectorized) min/max path,
+        # then pick the *first* row position that attains it — vectorized, instead
+        # of the former per-row Python loop (~30x faster on millions of rows).
+        mm_op = "min" if op == "argmin" else "max"
+        best_values, has_value = self._minmax_partials(mm_op, inverse, values, non_null, n_groups)
         best_positions = np.full(n_groups, -1, dtype=np.int64)
-        has_value = np.zeros(n_groups, dtype=bool)
-        for group, value, ok, pos in zip(inverse, values, non_null, row_positions, strict=True):
-            if not ok:
-                continue
-            better = value < best_values[group] if op == "argmin" else value > best_values[group]
-            if not has_value[group] or better:
-                best_values[group] = value
-                best_positions[group] = int(pos)
-                has_value[group] = True
+        # Rows in a value-bearing group whose value equals their group's extreme.
+        # On ties np.minimum.at keeps the smallest position, matching "first row".
+        attains = non_null & has_value[inverse] & (values == best_values[inverse])
+        if np.any(attains):
+            int_max = np.iinfo(np.int64).max
+            pos_best = np.full(n_groups, int_max, dtype=np.int64)
+            np.minimum.at(pos_best, inverse[attains], np.asarray(row_positions)[attains])
+            best_positions = np.where(pos_best != int_max, pos_best, -1)
         return best_values, best_positions, has_value
 
     def _merge_partials(

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -75,7 +75,7 @@ class CTableGroupBy:
         table: CTable,
         keys: str | Sequence[str],
         *,
-        sort: bool = False,
+        sort: bool | None = None,
         dropna: bool = True,
         engine: str = "auto",
         chunk_size: int | None = None,
@@ -89,7 +89,10 @@ class CTableGroupBy:
 
         self.table = table
         self.keys = [table._logical_to_physical_name(k) for k in keys]
-        self.sort = bool(sort)
+        # Tri-state ordering request resolved per execution path by
+        # _resolve_sort(): True forces a key sort, False emits first-appearance
+        # order, None (the default) sorts only when the path can do so cheaply.
+        self.sort = sort
         self.dropna = bool(dropna)
         self.engine = engine
         self.chunk_size = chunk_size
@@ -713,19 +716,21 @@ class CTableGroupBy:
                     if not call_checked(desc["kernel"], *args):
                         return None
 
+        # For integer keys np.nonzero already yields ascending key order.  When
+        # sorting is requested (sort=True, or sort=None since the dict lexsort is
+        # cheap) dictionary keys are reordered by decoded string; otherwise they
+        # stay in first-appearance (code-assignment) order.
         group_codes = np.nonzero(keys_present)[0]
-        if self.sort and key_is_dict:
-            group_codes = np.array(
-                sorted(
-                    group_codes,
-                    key=lambda code: _sortable_key_part(self.table._cols[key_name].decode(int(code))),
-                ),
-                dtype=group_codes.dtype,
-            )
+        if key_is_dict and self._resolve_sort(cheap=True):
+            group_codes = self._sort_dict_group_codes(key_name, group_codes)
 
+        key_values = (
+            self.table._cols[key_name].decode_batch(group_codes)
+            if key_is_dict
+            else [_python_scalar(code) for code in group_codes]
+        )
         rows = []
-        for code in group_codes:
-            key_value = self.table._cols[key_name].decode(int(code)) if key_is_dict else _python_scalar(code)
+        for code, key_value in zip(group_codes, key_values, strict=True):
             row = {key_name: key_value}
             for desc in descriptors:
                 spec = desc["spec"]
@@ -756,7 +761,7 @@ class CTableGroupBy:
 
     def _try_execute_cython_i32_f64_sum(self, specs: list[_AggSpec]):  # noqa: C901
         """Cython fast path for one int32 key and one non-null float64 sum."""
-        if len(self.keys) != 1 or len(specs) != 1 or specs[0].op != "sum" or self.sort:
+        if len(self.keys) != 1 or len(specs) != 1 or specs[0].op != "sum":
             return None
         spec = specs[0]
         if spec.input_col is None:
@@ -823,10 +828,22 @@ class CTableGroupBy:
                 if status != 0:
                     return None
 
-        rows = []
-        for code in np.nonzero(present)[0]:
-            key_value = self.table._cols[key_name].decode(int(code)) if key_is_dict else int(code)
-            rows.append({key_name: key_value, spec.output_col: float(sums[code])})
+        # np.nonzero gives ascending integer-key order; dict keys (which can
+        # reach this path when the broader dense_int_key path declined) are
+        # reordered by decoded string when a cheap sort is requested, matching
+        # the other dense paths.
+        present_codes = np.nonzero(present)[0]
+        if key_is_dict and self._resolve_sort(cheap=True):
+            present_codes = self._sort_dict_group_codes(key_name, present_codes)
+        key_values = (
+            self.table._cols[key_name].decode_batch(present_codes)
+            if key_is_dict
+            else [int(code) for code in present_codes]
+        )
+        rows = [
+            {key_name: key_value, spec.output_col: float(sums[code])}
+            for code, key_value in zip(present_codes, key_values, strict=True)
+        ]
         return self._build_result(rows, specs)
 
     def _try_execute_cython_float_hash(self, specs: list[_AggSpec]):  # noqa: C901
@@ -934,15 +951,18 @@ class CTableGroupBy:
                             state.value = value
                         state.count += 1
 
-        # Hash-table iteration order is intentionally not exposed.  Emit float
-        # hash groups in key order for deterministic results and compatibility
-        # with the previous NumPy fallback behavior for these cases.
+        # list(acc) follows the Cython kernel's emission order (hash-bucket
+        # order) -- deterministic for a given table but unspecified.  Key-sorting
+        # it is a Python list.sort over all groups, so it only runs when
+        # requested (sort=True; sort=None leaves it unsorted since this path is
+        # not cheap to sort).
         ordered_keys = list(acc)
-        ordered_keys.sort(
-            key=lambda k: tuple(
-                (1, "") if isinstance(v, float) and math.isnan(v) else (0, v) for v in key_values[k]
+        if self._resolve_sort(cheap=False):
+            ordered_keys.sort(
+                key=lambda k: tuple(
+                    (1, "") if isinstance(v, float) and math.isnan(v) else (0, v) for v in key_values[k]
+                )
             )
-        )
         rows = []
         for norm_key in ordered_keys:
             row = dict(zip(self.keys, key_values[norm_key], strict=True))
@@ -960,7 +980,7 @@ class CTableGroupBy:
 
     def _try_execute_cython_float_integral_key_f64_sum(self, specs: list[_AggSpec]):  # noqa: C901
         """Cython fast path for integral float32/float64 keys and one non-null float64 sum."""
-        if len(self.keys) != 1 or len(specs) != 1 or specs[0].op != "sum" or self.sort:
+        if len(self.keys) != 1 or len(specs) != 1 or specs[0].op != "sum":
             return None
         spec = specs[0]
         if spec.input_col is None:
@@ -1238,15 +1258,21 @@ class CTableGroupBy:
                     pos_state[better] = chunk_pos[better]
                     has_state |= chunk_has
 
+        # np.nonzero gives ascending integer-key order.  When sorting is
+        # requested (sort=True, or sort=None since the dict lexsort is cheap)
+        # dictionary keys are reordered by decoded string; otherwise they stay in
+        # first-appearance (code-assignment) order.
         group_codes = np.nonzero(present)[0]
+        if key_is_dict and self._resolve_sort(cheap=True):
+            group_codes = self._sort_dict_group_codes(key_name, group_codes)
+        if key_is_dict:
+            key_values = self.table._cols[key_name].decode_batch(group_codes)
+        elif key_is_integral_float:
+            key_values = [float(code) for code in group_codes]
+        else:
+            key_values = [_python_scalar(code) for code in group_codes]
         rows = []
-        for code in group_codes:
-            if key_is_dict:
-                key_value = self.table._cols[key_name].decode(int(code))
-            elif key_is_integral_float:
-                key_value = float(code)
-            else:
-                key_value = _python_scalar(code)
+        for code, key_value in zip(group_codes, key_values, strict=True):
             row = {key_name: key_value}
             for spec in specs:
                 state = states[spec.output_col]
@@ -1311,17 +1337,47 @@ class CTableGroupBy:
         unique, inverse = np.unique(packed, return_inverse=True)
         return unique, inverse
 
+    def _resolve_sort(self, *, cheap: bool) -> bool:
+        """Resolve the tri-state ``self.sort`` request for the current path.
+
+        ``cheap`` is declared by the call site: ``True`` for vectorized/free
+        ordering (``np.nonzero`` ascending or the vectorized
+        :meth:`_sort_dict_group_codes` lexsort), ``False`` for a Python
+        ``list.sort`` over all groups.  ``None`` (auto) sorts only cheap paths.
+        """
+        return _resolve_sort(self.sort, cheap=cheap)
+
+    def _sort_dict_group_codes(self, key_name: str, group_codes: np.ndarray) -> np.ndarray:
+        """Reorder dictionary *group_codes* so groups come out sorted by string.
+
+        Vectorized: the dictionary store holds only the unique category values
+        (cardinality ``D``, not the ``N`` rows), so decompressing it whole into a
+        NumPy array and ``np.lexsort``-ing the present codes is cheap — far
+        cheaper than a Python ``sorted`` with a per-code ``decode`` call.  Null
+        groups (``null_code``) sort first, matching ``_sortable_key_part``'s
+        ordering of ``None`` before real values.
+        """
+        col = self.table._cols[key_name]
+        null_code = int(col._spec.null_code)
+        all_strings = np.asarray(col._dict_store[:])  # D unique values, no nulls
+        is_non_null = group_codes != null_code
+        decoded = np.empty(len(group_codes), dtype=all_strings.dtype if all_strings.size else "<U1")
+        # Null groups keep a placeholder; the primary lexsort key sorts them
+        # first regardless, so their string value is never compared.
+        decoded[is_non_null] = all_strings[group_codes[is_non_null]]
+        decoded[~is_non_null] = ""
+        order = np.lexsort((decoded, is_non_null.astype(np.int8)))
+        return group_codes[order]
+
     def _display_keys(self, unique_keys: np.ndarray | list[np.ndarray]) -> list[tuple[Any, ...]]:
         if len(self.keys) == 1:
             name = self.keys[0]
             col_info = self.table._schema.columns_by_name[name]
-            values = []
-            for value in np.asarray(unique_keys):
-                if self.table._is_dictionary_column(col_info):
-                    values.append((self.table._cols[name].decode(int(value)),))
-                else:
-                    values.append((_python_scalar(value),))
-            return values
+            unique_arr = np.asarray(unique_keys)
+            if self.table._is_dictionary_column(col_info):
+                decoded = self.table._cols[name].decode_batch(unique_arr)
+                return [(value,) for value in decoded]
+            return [(_python_scalar(value),) for value in unique_arr]
 
         result = []
         assert isinstance(unique_keys, np.ndarray)
@@ -1494,8 +1550,13 @@ class CTableGroupBy:
         key_values: dict[Any, tuple[Any, ...]],
         specs: list[_AggSpec],
     ) -> list[dict[str, Any]]:
+        # This path handles keys that miss the vectorized fast paths (fixed-width
+        # strings, multi-key, exotic dtypes); ordering is a Python list.sort over
+        # all groups, so it only runs when requested.  list(acc) is deterministic
+        # first-appearance order (sort=False, or sort=None since this path is not
+        # cheap to sort).
         keys = list(acc)
-        if self.sort:
+        if self._resolve_sort(cheap=False):
             keys.sort(key=lambda k: tuple(_sortable_key_part(v) for v in key_values[k]))
 
         rows = []
@@ -1689,7 +1750,7 @@ def _null_output_value(spec: SchemaSpec):
 # ----------------------------------------------------------------------
 
 
-def group_reduce(keys, values=None, op: AggName = "size", *, sort: bool = False, dropna: bool = True):
+def group_reduce(keys, values=None, op: AggName = "size", *, sort: bool | None = None, dropna: bool = True):
     """Group *keys* and reduce *values* with *op*.
 
     This is a lower-level, array-oriented grouped reduction primitive.  It exposes
@@ -1707,9 +1768,13 @@ def group_reduce(keys, values=None, op: AggName = "size", *, sort: bool = False,
     op : {"size", "count", "sum", "mean", "min", "max"}, default: "size"
         Reduction operation.  ``"size"`` counts rows per group, while
         ``"count"`` counts non-NaN values per group.
-    sort : bool, default: False
-        If true, sort output groups by key.  With ``sort=False`` output order is
-        implementation dependent.
+    sort : bool or None, default: None
+        Output group ordering.  ``True`` always sorts groups by key; ``False``
+        never sorts (order is implementation dependent but deterministic for a
+        given input); ``None`` (the default) sorts only when cheap -- the
+        vectorized integer and float kernels sort (``np.argsort``), while the
+        generic Python fallback is left unsorted to avoid an O(G log G) Python
+        sort that can rival the grouping cost on high-cardinality keys.
     dropna : bool, default: True
         If true, skip NaN float keys.  If false, all NaN keys form one group.
 
@@ -1750,15 +1815,20 @@ def group_reduce(keys, values=None, op: AggName = "size", *, sort: bool = False,
     if len(keys_arr) == 0:
         return keys_arr.copy(), np.empty(0, dtype=_result_dtype(values_arr, op))
 
-    fast = _try_dense_integer(keys_arr, values_arr, op, sort=sort)
+    # The dense integer and float-hash kernels sort via vectorized np.argsort
+    # (cheap); the generic Python fallback sorts via list.sort (expensive).
+    # Resolve the tri-state per path's cost so None auto-sorts only the cheap ones.
+    fast = _try_dense_integer(keys_arr, values_arr, op, sort=_resolve_sort(sort, cheap=True))
     if fast is not None:
         return fast
 
-    fast = _try_float_hash(keys_arr, values_arr, op, sort=sort, dropna=dropna)
+    fast = _try_float_hash(keys_arr, values_arr, op, sort=_resolve_sort(sort, cheap=True), dropna=dropna)
     if fast is not None:
         return fast
 
-    return _group_reduce_numpy(keys_arr, values_arr, op, sort=sort, dropna=dropna)
+    return _group_reduce_numpy(
+        keys_arr, values_arr, op, sort=_resolve_sort(sort, cheap=False), dropna=dropna
+    )
 
 
 def _try_dense_integer(keys: np.ndarray, values: np.ndarray | None, op: str, *, sort: bool):  # noqa: C901
@@ -1968,6 +2038,20 @@ def _group_reduce_sort_key(value: Any) -> tuple[int, Any]:
     if isinstance(value, float) and math.isnan(value):
         return (2, "")
     return (1, value)
+
+
+def _resolve_sort(sort: bool | None, *, cheap: bool) -> bool:
+    """Resolve a tri-state ``sort`` request for a given execution path.
+
+    ``sort`` is ``True`` (always sort), ``False`` (never sort), or ``None``
+    (auto: sort only when this path can do so cheaply).  ``cheap`` is declared
+    by the call site: ``True`` for vectorized/free ordering (``np.nonzero``
+    ascending or a vectorized lexsort/argsort), ``False`` for a Python
+    ``list.sort`` over all groups.
+    """
+    if sort is None:
+        return cheap
+    return sort
 
 
 def _maybe_sort(groups: np.ndarray, result: np.ndarray, sort: bool):

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -61,6 +61,30 @@ def _column_name(value: Any) -> str:
     return name
 
 
+_OP_ALIAS_CACHE: dict | None = None
+
+
+def _op_alias_map() -> dict:
+    """Map blosc2 reduction *function objects* to group-by op names, by identity.
+
+    Built lazily (and cached) to avoid importing the top-level package at module
+    load time.  Only the functions that have a matching group-by op are included;
+    matching is by object identity, so a user function merely named ``sum`` does
+    not collide with :func:`blosc2.sum`.
+    """
+    global _OP_ALIAS_CACHE
+    if _OP_ALIAS_CACHE is None:
+        import blosc2
+
+        mapping = {}
+        for op in ("sum", "mean", "min", "max", "argmin", "argmax"):
+            fn = getattr(blosc2, op, None)
+            if fn is not None:
+                mapping[fn] = op
+        _OP_ALIAS_CACHE = mapping
+    return _OP_ALIAS_CACHE
+
+
 class CTableGroupBy:
     """Deferred group-by operation returned by :meth:`CTable.group_by`.
 
@@ -174,46 +198,164 @@ class CTableGroupBy:
         """
         return self.agg({_column_name(column): "argmax"}, urlpath=urlpath)
 
-    def agg(self, aggregations: Mapping[str, str | Sequence[str]], *, urlpath: str | None = None):
+    def agg(
+        self,
+        aggregations: Mapping[str, str | Sequence[str]]
+        | Sequence[tuple[Any, str | Sequence[str]]]
+        | None = None,
+        *,
+        urlpath: str | None = None,
+        **named: tuple[str, str],
+    ):
         """Aggregate value columns per group.
+
+        Three ways to specify aggregations and name the output columns, which may
+        be combined:
+
+        * **Auto-named mapping** -- pass *aggregations* as a mapping from input
+          column name to an aggregation name (or list of names).  Each result
+          column is named ``"<column>_<op>"`` (e.g. ``price_sum``).  Compact and
+          collision-safe when a column is aggregated several ways.
+        * **Auto-named list of pairs** -- pass *aggregations* as a list of
+          ``(column, op-or-ops)`` pairs.  Same ``"<column>_<op>"`` naming, but
+          unlike the mapping form it accepts :class:`~blosc2.ctable.Column`
+          objects (e.g. ``t.price``), which cannot be dict keys.
+        * **Explicitly named** -- pass ``output_name=(column, op)`` keyword
+          arguments (pandas-style named aggregation), giving the result column
+          exactly the name you want.
 
         Parameters
         ----------
         aggregations:
-            Mapping from input column name to an aggregation name or list of
-            names.  Supported operations in Phase 1 are ``"count"``, ``"sum"``,
-            ``"mean"``, ``"min"``, ``"max"``, ``"argmin"``, ``"argmax"`` and
-            the special row-count spelling ``{"*": "size"``}.
+            Either a mapping ``{column: op-or-ops}`` or a list of
+            ``(column, op-or-ops)`` pairs.  Columns may be name strings or
+            :class:`~blosc2.ctable.Column` objects (list/named forms only).
+            Supported operations are ``"count"``, ``"sum"``, ``"mean"``,
+            ``"min"``, ``"max"``, ``"argmin"``, ``"argmax"`` and the special
+            row-count spelling ``"*": "size"``.  An op may also be given as the
+            corresponding blosc2 reduction *function* (``blosc2.sum``, ``mean``,
+            ``min``, ``max``, ``argmin``, ``argmax``), matched by identity; this
+            is a naming shorthand, not a UDF mechanism (custom functions are
+            rejected).  Result columns are named ``"<column>_<op>"``.
+        urlpath:
+            If given, write the result as a persistent CTable at that path.
+        **named:
+            Named aggregations as ``output_name=(column, op)`` pairs.  Use
+            ``("*", "size")`` for a row count.
+
+        Examples
+        --------
+        >>> g = t.group_by("city")  # doctest: +SKIP
+        >>> # Auto-named mapping: columns become sales_sum / sales_mean.
+        >>> g.agg({"sales": ["sum", "mean"]})  # doctest: +SKIP
+        >>> # Auto-named list of pairs: same names, but accepts Column objects
+        >>> # and blosc2 reduction functions as ops.
+        >>> g.agg([(t.sales, [blosc2.sum, "mean"])])  # doctest: +SKIP
+        >>> # Explicitly named: columns become revenue / avg_sale.
+        >>> g.agg(revenue=("sales", "sum"), avg_sale=("sales", "mean"))  # doctest: +SKIP
+        >>> # Forms combine, e.g. a list of pairs plus a named row count.
+        >>> g.agg([(t.sales, "sum")], n=("*", "size"))  # doctest: +SKIP
         """
-        specs = self._normalize_aggs(aggregations)
+        specs = self._normalize_aggs(aggregations, named)
         return self._execute(specs, urlpath=urlpath)
 
-    def _normalize_aggs(self, aggregations: Mapping[str, str | Sequence[str]]) -> list[_AggSpec]:
-        if not isinstance(aggregations, Mapping) or not aggregations:
-            raise ValueError("agg() requires a non-empty mapping")
+    def _resolve_op(self, op):
+        """Resolve an aggregation *op* to its name string.
+
+        Accepts a name string, or one of blosc2's own reduction *functions*
+        (:func:`blosc2.sum`, ``mean``, ``min``, ``max``, ``argmin``, ``argmax``)
+        matched **by identity** -- so a user function that merely shares a name
+        (e.g. a UDF called ``sum``) is *not* silently accepted, and custom UDF
+        aggregations are rejected rather than misinterpreted.
+        """
+        if isinstance(op, str):
+            return op
+        if callable(op):
+            alias = _op_alias_map().get(op)
+            if alias is not None:
+                return alias
+            raise ValueError(
+                f"Unsupported aggregation function {getattr(op, '__name__', op)!r}.  Pass a "
+                f"string op name (e.g. 'sum') or a blosc2 reduction function "
+                f"(blosc2.sum/mean/min/max/argmin/argmax).  Custom UDF aggregations are "
+                f"not supported."
+            )
+        raise ValueError(f"Aggregation op must be a string or a blosc2 reduction function, got {op!r}")
+
+    def _build_agg_spec(self, col_name, op, output_col: str | None = None) -> _AggSpec:
+        """Validate a single (column, op) pair and build its :class:`_AggSpec`.
+
+        ``output_col`` overrides the default ``"<column>_<op>"`` name; ``"*"`` as
+        *col_name* (only with ``op="size"``) yields a row count.  *col_name* may
+        be a column name string or a :class:`~blosc2.ctable.Column` object; *op*
+        may be an op name string or a blosc2 reduction function (see
+        :meth:`_resolve_op`).
+        """
+        op = self._resolve_op(op)
+        # Guard the "*" check with isinstance: a Column object overloads __eq__
+        # to build an expression, so a bare ``col_name == "*"`` would not return
+        # a bool.  Only the literal string "*" is the row-count sentinel.
+        if isinstance(col_name, str) and col_name == "*":
+            if op != "size":
+                raise ValueError("Only the 'size' aggregation is supported for '*' input")
+            return _AggSpec(None, "size", output_col or "size")
+        physical = self.table._logical_to_physical_name(_column_name(col_name))
+        self._validate_value_column(physical)
+        if op not in {"count", "sum", "mean", "min", "max", "argmin", "argmax"}:
+            raise ValueError(f"Unsupported aggregation {op!r}")
+        self._validate_agg_for_column(physical, op)
+        return _AggSpec(physical, op, output_col or f"{physical}_{op}")
+
+    def _expand_ops(self, col_name, ops) -> list[_AggSpec]:
+        """Expand a (column, op-or-ops) entry into one auto-named spec per op."""
+        # A single op may be a string or a reduction function (both non-iterable
+        # in the sense we want); only a real sequence of ops is expanded.
+        op_list = [ops] if isinstance(ops, str) or callable(ops) else list(ops)
+        if not op_list:
+            raise ValueError(f"No aggregations specified for column {col_name!r}")
+        return [self._build_agg_spec(col_name, op) for op in op_list]
+
+    def _normalize_aggs(
+        self,
+        aggregations: Mapping[str, str | Sequence[str]] | Sequence[tuple[Any, str | Sequence[str]]] | None,
+        named: Mapping[str, tuple[str, str]] | None = None,
+    ) -> list[_AggSpec]:
+        if not aggregations and not named:
+            raise ValueError("agg() requires a mapping/list of pairs and/or named aggregations")
         specs: list[_AggSpec] = []
-        for col_name, ops in aggregations.items():
-            if isinstance(ops, str):
-                op_list = [ops]
+        if aggregations:
+            if isinstance(aggregations, Mapping):
+                entries = list(aggregations.items())
+            elif isinstance(aggregations, Sequence) and not isinstance(aggregations, (str, bytes)):
+                # List of (column, ops) pairs -- lets you use Column objects,
+                # which cannot be dict keys (Column is unhashable).
+                entries = []
+                for pair in aggregations:
+                    if not (isinstance(pair, (tuple, list)) and len(pair) == 2):
+                        raise ValueError(
+                            f"agg() positional list must contain (column, ops) pairs, got {pair!r}"
+                        )
+                    entries.append(pair)
             else:
-                op_list = list(ops)
-            if not op_list:
-                raise ValueError(f"No aggregations specified for column {col_name!r}")
-
-            if col_name == "*":
-                for op in op_list:
-                    if op != "size":
-                        raise ValueError("Only the 'size' aggregation is supported for '*' input")
-                    specs.append(_AggSpec(None, "size", "size"))
-                continue
-
-            physical = self.table._logical_to_physical_name(_column_name(col_name))
-            self._validate_value_column(physical)
-            for op in op_list:
-                if op not in {"count", "sum", "mean", "min", "max", "argmin", "argmax"}:
-                    raise ValueError(f"Unsupported aggregation {op!r}")
-                self._validate_agg_for_column(physical, op)
-                specs.append(_AggSpec(physical, op, f"{physical}_{op}"))
+                raise ValueError(
+                    "agg() positional argument must be a mapping or a list of (column, ops) pairs"
+                )
+            for col_name, ops in entries:
+                specs.extend(self._expand_ops(col_name, ops))
+        for out_name, value in (named or {}).items():
+            if not (isinstance(value, (tuple, list)) and len(value) == 2):
+                raise ValueError(
+                    f"Named aggregation {out_name!r} must be a (column, op) pair, got {value!r}"
+                )
+            col_name, op = value
+            if isinstance(op, (tuple, list, set)):
+                raise ValueError(
+                    f"Named aggregation {out_name!r} takes a single op, got {op!r}.  "
+                    f"Each named output maps to one (column, op); use the mapping "
+                    f"form agg({{column: [...]}}) for several ops, or give each its "
+                    f"own name (e.g. {out_name}_sum=(col, 'sum'))."
+                )
+            specs.append(self._build_agg_spec(col_name, op, output_col=out_name))
         output_names = [s.output_col for s in specs]
         if len(output_names) != len(set(output_names)):
             raise ValueError("Aggregation output column names must be unique")

--- a/src/blosc2/indexing.py
+++ b/src/blosc2/indexing.py
@@ -114,6 +114,10 @@ _HOT_CACHE_BYTES: int = 0
 _QUERY_CACHE_STORE_HANDLES: dict[str, object] = {}
 # Cached mmap handles for data arrays used in full-query gather: urlpath -> NDArray.
 _GATHER_MMAP_HANDLES: dict[str, object] = {}
+# Last-seen on-disk fingerprint (mtime_ns, size) for persistent paths whose query
+# handles/coordinates are cached above. Lets an in-place overwrite (same path, new
+# contents) be detected and invalidated, not just an outright deletion.
+_PERSISTENT_FINGERPRINTS: dict[str, tuple[int, int]] = {}
 # Registry for index sidecar files stored inside a .b2z bundle.
 # Maps absolute sidecar path -> (b2z_path, data_offset_in_zip).
 # Populated by the storage layer so indexing code can open sidecars without
@@ -195,8 +199,63 @@ def _purge_stale_persistent_caches() -> None:
     for path in stale_gather_paths:
         _GATHER_MMAP_HANDLES.pop(path, None)
 
+    stale_fingerprints = [path for path in tuple(_PERSISTENT_FINGERPRINTS) if not Path(path).exists()]
+    for path in stale_fingerprints:
+        _PERSISTENT_FINGERPRINTS.pop(path, None)
+
     for scope in stale_scopes:
         _hot_cache_clear(scope=scope)
+
+
+def _file_fingerprint(path: str) -> tuple[int, int] | None:
+    """Return a cheap change-detection fingerprint ``(mtime_ns, size)`` for *path*."""
+    try:
+        st = os.stat(path)
+    except OSError:
+        return None
+    return (st.st_mtime_ns, st.st_size)
+
+
+def _drop_persistent_path_caches(raw_path: str, resolved: str) -> None:
+    """Drop every process-global cache entry keyed by the persistent file *path*."""
+    scope = ("persistent", resolved)
+    _PERSISTENT_INDEXES.pop(scope, None)
+    for cache in (_DATA_CACHE, _SIDECAR_HANDLE_CACHE):
+        for key in [k for k in tuple(cache) if k[0] == scope]:
+            cache.pop(key, None)
+    _hot_cache_clear(scope=scope)
+    for handles in (_QUERY_CACHE_STORE_HANDLES, _GATHER_MMAP_HANDLES):
+        handles.pop(raw_path, None)
+        handles.pop(resolved, None)
+
+
+def _refresh_persistent_caches(path: str | None) -> None:
+    """Invalidate cached handles/coordinates for *path* if its file changed on disk.
+
+    Reuse of the process-global query caches is keyed by urlpath, and the entries are
+    otherwise only dropped once their file is *deleted* (see
+    :func:`_purge_stale_persistent_caches`).  A file that is overwritten in place (for
+    instance re-uploaded with new contents at the same path) would therefore still be
+    served from the stale mmap handle and coordinate cache of the previous file.
+
+    Comparing the current ``(mtime_ns, size)`` against the fingerprint recorded when the
+    caches were populated lets us detect that and drop the affected entries; they simply
+    repopulate on the next query.
+    """
+    if not path:
+        return
+    raw_path = str(path)
+    try:
+        resolved = str(Path(raw_path).resolve())
+    except OSError:
+        return
+    fingerprint = _file_fingerprint(resolved)
+    if fingerprint is None:
+        return
+    previous = _PERSISTENT_FINGERPRINTS.get(resolved)
+    if previous is not None and previous != fingerprint:
+        _drop_persistent_path_caches(raw_path, resolved)
+    _PERSISTENT_FINGERPRINTS[resolved] = fingerprint
 
 
 def evict_cached_index_handles(root: str | None) -> None:
@@ -776,6 +835,9 @@ def get_cached_coords(
     """Return cached coordinates for *expression*/*tokens*/*order*, or ``None``."""
     owner = _query_cache_owner(array)
     scope = _query_cache_scope(owner)
+    # Drop stale coordinates if the underlying file was overwritten in place.
+    if _is_persistent_array(owner):
+        _refresh_persistent_caches(getattr(owner, "urlpath", None))
     descriptor = _normalize_query_descriptor(expression, tokens, order)
     digest = _query_cache_digest(descriptor)
     return _hot_cache_get(digest, scope=scope)
@@ -6139,6 +6201,8 @@ def _gather_mmap_source(where_x):
         return where_x
     _purge_stale_persistent_caches()
     urlpath = str(urlpath)
+    # Drop the cached mapping if the file was overwritten in place since we mapped it.
+    _refresh_persistent_caches(urlpath)
     handle = _GATHER_MMAP_HANDLES.get(urlpath)
     if handle is None:
         handle = blosc2.open(urlpath, mode="r", mmap_mode=_INDEX_MMAP_MODE)

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -4073,8 +4073,9 @@ class LazyExpr(LazyArray):
                     return out
                 arr = lazy_expr[key]
                 if builtins.sum(mask) > 0:
-                    # Correct shape to adjust to NumPy convention
-                    arr.shape = tuple(arr.shape[i] for i in range(len(mask)) if not mask[i])
+                    # Correct shape to adjust to NumPy convention.
+                    new_shape = tuple(arr.shape[i] for i in range(len(mask)) if not mask[i])
+                    arr = np.reshape(arr, new_shape)
                 return arr
 
             return chunked_eval(lazy_expr.expression, lazy_expr.operands, item, **kwargs)

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -61,11 +61,11 @@ def group_store(tmp_path_factory):
 from blosc2.b2view.model import StoreBrowser  # noqa: E402
 
 
-def test_group_key_columns_are_dict_and_int(group_store):
+def test_group_key_columns_are_dict_and_numeric(group_store):
     path, _ = group_store
     with StoreBrowser(path) as browser:
         keys = browser.group_key_columns("/ctable")
-    assert set(keys) == {"vendor", "region"}  # float 'amount' excluded
+    assert set(keys) == {"vendor", "region", "amount"}  # dict + int + float
 
 
 def test_group_value_columns_are_numeric_scalars(group_store):

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -111,12 +111,18 @@ def test_get_and_clear_group_roundtrip(group_store):
     assert page["nrows"] == NROWS  # base table restored
 
 
-def test_group_clears_active_filter(group_store):
-    path, _ = group_store
+def test_group_composes_over_active_filter(group_store):
+    """Group-by aggregates the filtered rows and keeps the filter active."""
+    path, cols = group_store
+    region = np.asarray(cols["region"])
     with StoreBrowser(path) as browser:
         browser.set_filter("/ctable", "region == 0")
-        browser.set_group("/ctable", "vendor", "size", None)
-        assert browser.get_filter("/ctable") is None  # filter dropped (exclusive)
+        ngroups = browser.set_group("/ctable", "vendor", "size", None)
+        assert browser.get_filter("/ctable") == "region == 0"  # filter persists
+        page = browser.preview("/ctable", max_rows=100)
+    # Counts cover only the filtered rows, not the whole table.
+    assert int(np.asarray(page["data"]["size"]).sum()) == int((region == 0).sum())
+    assert ngroups == len(page["data"]["size"])
 
 
 def test_group_sort_orders_result_by_column(group_store):

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -428,8 +428,8 @@ async def test_group_numeric_key_plots_as_line(group_store):
         assert isinstance(pilot.app.screen, GroupBarScreen)
         assert pilot.app.screen.numeric is True
 
-        await pilot.press("h")  # hi-res is a line, not a bar
+        await pilot.press("h")  # hi-res is a stem/impulse plot, not bars
         await pilot.pause()
         await pilot.pause()
         assert isinstance(pilot.app.screen, HiResPlotScreen)
-        assert pilot.app.screen._mode == "line"
+        assert pilot.app.screen._mode == "stem"

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -163,16 +163,42 @@ def test_group_sort_noop_when_not_grouped(group_store):
         assert browser.get_group_sort("/ctable") is None
 
 
-def test_group_bars_sorted_desc_and_capped(group_store):
+def test_group_bars_categorical_is_bar_sorted_desc_and_capped(group_store):
+    """A dictionary key yields capped bars ranked by the aggregate descending."""
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group("/ctable", "vendor", "mean", "amount")
+        bars = browser.group_bars("/ctable", top_n=2)
+    assert bars["numeric"] is False
+    assert len(bars["values"]) == 2  # capped to top_n
+    assert bars["values"][0] >= bars["values"][1]  # descending
+    assert bars["agg"] == "amount_mean"
+    assert bars["key"] == "vendor"
+
+
+def test_group_bars_numeric_is_line_pareto_by_default(group_store):
+    """A numeric key with no sort yields a full line curve ranked by value (Pareto)."""
     path, _ = group_store
     with StoreBrowser(path) as browser:
         browser.set_group("/ctable", "region", "mean", "amount")
         bars = browser.group_bars("/ctable", top_n=2)
-    assert bars["total"] == 4
-    assert len(bars["values"]) == 2
-    assert bars["values"][0] >= bars["values"][1]  # descending
-    assert bars["agg"] == "amount_mean"
-    assert bars["key"] == "region"
+    assert bars["numeric"] is True
+    assert len(bars["values"]) == 4  # no top-N cap on the curve
+    assert bars["values"] == sorted(bars["values"], reverse=True)  # Pareto
+    assert bars["x"] == [0, 1, 2, 3]  # rank index on X
+    assert "rank" in bars["xlabel"]
+
+
+def test_group_bars_numeric_sorted_by_key_uses_key_on_x(group_store):
+    """Sorting a numeric-key result by the key puts key values on X in that order."""
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group("/ctable", "region", "mean", "amount")
+        browser.set_group_sort("/ctable", "region", reverse=False)
+        bars = browser.group_bars("/ctable")
+    assert bars["numeric"] is True
+    assert bars["x"] == [0.0, 1.0, 2.0, 3.0]  # actual key values, ascending
+    assert bars["xlabel"] == "region"
 
 
 # ── TUI journey ────────────────────────────────────────────────────────────
@@ -348,16 +374,17 @@ async def test_group_bar_chart_and_hires(group_store):
         pilot.app.query_one("#data-table", DataTable).focus()
         await pilot.pause()
 
-        # Group region -> mean(amount), then plot it as a bar chart.
+        # Group vendor (categorical) -> mean(amount), then plot it as a bar chart.
         await pilot.press("G")
         await pilot.pause()
-        await pilot.press("down", "enter")  # key: region -> operation list
+        await pilot.press("enter")  # key: vendor (first) -> operation list
         await pilot.press("down", "down", "down", "enter")  # mean -> value list
         await pilot.press("down", "enter")  # value: amount -> apply
         await _wait_table(pilot)
         await pilot.press("p")
         await pilot.pause()
         assert isinstance(pilot.app.screen, GroupBarScreen)
+        assert pilot.app.screen.numeric is False
 
         # 'h' opens the hi-res matplotlib bar chart; esc returns to the plotext bars.
         await pilot.press("h")
@@ -368,3 +395,35 @@ async def test_group_bar_chart_and_hires(group_store):
         await pilot.press("escape")
         await pilot.pause()
         assert isinstance(pilot.app.screen, GroupBarScreen)
+
+
+@pytest.mark.asyncio
+@pytest.mark.tui
+async def test_group_numeric_key_plots_as_line(group_store):
+    if TextualImage is None or not _matplotlib_available():
+        pytest.skip("hi-res line view needs textual-image + matplotlib")
+    path, _ = group_store
+    app = B2ViewApp(path)
+    async with app.run_test(size=TERM_SIZE) as pilot:
+        await pilot.press("down", "enter")  # select + show the /ctable node
+        await _wait_table(pilot)
+        pilot.app.query_one("#data-table", DataTable).focus()
+        await pilot.pause()
+
+        # Group region (numeric) -> mean(amount): plots as a line curve, not bars.
+        await pilot.press("G")
+        await pilot.pause()
+        await pilot.press("down", "enter")  # key: region -> operation list
+        await pilot.press("down", "down", "down", "enter")  # mean -> value list
+        await pilot.press("down", "enter")  # value: amount -> apply
+        await _wait_table(pilot)
+        await pilot.press("p")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, GroupBarScreen)
+        assert pilot.app.screen.numeric is True
+
+        await pilot.press("h")  # hi-res is a line, not a bar
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, HiResPlotScreen)
+        assert pilot.app.screen._mode == "line"

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -201,14 +201,27 @@ async def test_group_key_applies_and_escape_clears(group_store):
         await pilot.press("G")
         await pilot.pause()
         assert isinstance(pilot.app.screen, GroupByScreen)
-        await pilot.press("enter")  # key list -> aggregation list
-        await pilot.press("enter")  # apply first aggregation (count rows / size)
+        await pilot.press("enter")  # key list -> operation list
+        await pilot.press("enter")  # "count rows" (first op) applies, no value col
         await _wait_table(pilot)
 
         assert pilot.app.browser.get_group("/ctable") is not None
         table = pilot.app.query_one("#data-table", DataTable)
         cols = [str(c.label) for c in table.columns.values()]
         assert any("size" in c for c in cols)
+
+        # Re-group via the operation + value-column path: pick a numeric op.
+        await pilot.press("G")
+        await pilot.pause()
+        await pilot.press("enter")  # key list -> operation list
+        await pilot.press("down", "down", "enter")  # -> "sum" -> value list
+        await pilot.press("enter")  # apply sum(<first value column>)
+        await _wait_table(pilot)
+        key, op, value_col = pilot.app.browser.get_group("/ctable")
+        assert op == "sum"
+        assert value_col is not None
+        cols = [str(c.label) for c in pilot.app.query_one("#data-table", DataTable).columns.values()]
+        assert any(f"{value_col}_sum" == c for c in cols)
 
         # Sort the grouped result by one of its columns via 'S'.
         await pilot.press("S")

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -185,7 +185,15 @@ if blosc2.IS_WASM:
 
 from textual.widgets import DataTable  # noqa: E402
 
-from blosc2.b2view.app import B2ViewApp, GroupByScreen, SortByScreen  # noqa: E402
+from blosc2.b2view.app import (  # noqa: E402
+    B2ViewApp,
+    GroupBarScreen,
+    GroupByScreen,
+    HiResPlotScreen,
+    SortByScreen,
+    TextualImage,
+    _matplotlib_available,
+)
 
 TERM_SIZE = (120, 40)
 
@@ -325,3 +333,38 @@ async def test_group_config_cached_and_reused(group_store):
         await pilot.pause()
         assert isinstance(pilot.app.screen, GroupByScreen)
         assert pilot.app.screen._current == ("region", "mean", "amount")
+
+
+@pytest.mark.asyncio
+@pytest.mark.tui
+async def test_group_bar_chart_and_hires(group_store):
+    if TextualImage is None or not _matplotlib_available():
+        pytest.skip("hi-res bar view needs textual-image + matplotlib")
+    path, _ = group_store
+    app = B2ViewApp(path)
+    async with app.run_test(size=TERM_SIZE) as pilot:
+        await pilot.press("down", "enter")  # select + show the /ctable node
+        await _wait_table(pilot)
+        pilot.app.query_one("#data-table", DataTable).focus()
+        await pilot.pause()
+
+        # Group region -> mean(amount), then plot it as a bar chart.
+        await pilot.press("G")
+        await pilot.pause()
+        await pilot.press("down", "enter")  # key: region -> operation list
+        await pilot.press("down", "down", "down", "enter")  # mean -> value list
+        await pilot.press("down", "enter")  # value: amount -> apply
+        await _wait_table(pilot)
+        await pilot.press("p")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, GroupBarScreen)
+
+        # 'h' opens the hi-res matplotlib bar chart; esc returns to the plotext bars.
+        await pilot.press("h")
+        await pilot.pause()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, HiResPlotScreen)
+        assert pilot.app.screen._mode == "bar"
+        await pilot.press("escape")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, GroupBarScreen)

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -1,0 +1,183 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#######################################################################
+
+"""Tests for b2view's CTable group-by ('G'): model layer + one TUI journey.
+
+Group-by replaces the table with a small materialised result (one row per
+group, columns = key + aggregate).  The model tests drive ``StoreBrowser``
+directly (no Textual); the TUI test drives the real app through a ``Pilot``.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+import blosc2
+
+NROWS = 240
+VENDORS = ["acme", "globex", "initech"]
+
+
+@dataclasses.dataclass
+class _Row:
+    vendor: str = blosc2.field(blosc2.dictionary())  # dictionary key
+    region: int = blosc2.field(blosc2.int64())  # low-cardinality int key
+    amount: float = blosc2.field(blosc2.float64())  # numeric value column
+
+
+def _columns():
+    i = np.arange(NROWS)
+    return {
+        "vendor": [VENDORS[j % len(VENDORS)] for j in range(NROWS)],  # plain str for dictionary
+        "region": (i % 4).astype(np.int64),
+        "amount": (i * 1.5).astype(np.float64),
+    }
+
+
+@pytest.fixture(scope="module")
+def group_store(tmp_path_factory):
+    """A TreeStore with one CTable carrying a dictionary + int + float column."""
+    path = str(tmp_path_factory.mktemp("group") / "group.b2z")
+    cols = _columns()
+    tstore = blosc2.TreeStore(path, mode="w")
+    try:
+        t = blosc2.CTable(_Row, expected_size=NROWS, validate=False)
+        t.extend(cols, validate=False)
+        tstore["/ctable"] = t
+    finally:
+        tstore.close()
+    return path, cols
+
+
+# ── Model layer ────────────────────────────────────────────────────────────
+
+from blosc2.b2view.model import StoreBrowser  # noqa: E402
+
+
+def test_group_key_columns_are_dict_and_int(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        keys = browser.group_key_columns("/ctable")
+    assert set(keys) == {"vendor", "region"}  # float 'amount' excluded
+
+
+def test_group_value_columns_are_numeric_scalars(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        values = browser.group_value_columns("/ctable")
+    assert "amount" in values
+    assert "region" in values
+    assert "vendor" not in values  # dictionary excluded
+
+
+def test_size_counts_rows_per_group(group_store):
+    path, cols = group_store
+    with StoreBrowser(path) as browser:
+        ngroups = browser.set_group("/ctable", "vendor", "size", None)
+        assert ngroups == len(VENDORS)
+        page = browser.preview("/ctable", max_rows=100)
+    assert "size" in page["columns"]
+    assert int(np.asarray(page["data"]["size"]).sum()) == NROWS
+
+
+def test_mean_matches_numpy(group_store):
+    path, cols = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group("/ctable", "region", "mean", "amount")
+        page = browser.preview("/ctable", max_rows=100)
+    got = dict(
+        zip(np.asarray(page["data"]["region"]), np.asarray(page["data"]["amount_mean"]), strict=False)
+    )
+    region, amount = cols["region"], cols["amount"]
+    for r in np.unique(region):
+        assert got[r] == pytest.approx(amount[region == r].mean())
+
+
+def test_get_and_clear_group_roundtrip(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group("/ctable", "vendor", "size", None)
+        assert browser.get_group("/ctable") == ("vendor", "size", None)
+        browser.clear_group("/ctable")
+        assert browser.get_group("/ctable") is None
+        page = browser.preview("/ctable", max_rows=5)
+    assert page["nrows"] == NROWS  # base table restored
+
+
+def test_group_clears_active_filter(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_filter("/ctable", "region == 0")
+        browser.set_group("/ctable", "vendor", "size", None)
+        assert browser.get_filter("/ctable") is None  # filter dropped (exclusive)
+
+
+def test_group_bars_sorted_desc_and_capped(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group("/ctable", "region", "mean", "amount")
+        bars = browser.group_bars("/ctable", top_n=2)
+    assert bars["total"] == 4
+    assert len(bars["values"]) == 2
+    assert bars["values"][0] >= bars["values"][1]  # descending
+    assert bars["agg"] == "amount_mean"
+    assert bars["key"] == "region"
+
+
+# ── TUI journey ────────────────────────────────────────────────────────────
+
+pytest.importorskip("textual")
+pytest.importorskip("pytest_asyncio")
+
+if blosc2.IS_WASM:
+    pytest.skip("Textual apps need a terminal driver (termios)", allow_module_level=True)
+
+from textual.widgets import DataTable  # noqa: E402
+
+from blosc2.b2view.app import B2ViewApp, GroupByScreen  # noqa: E402
+
+TERM_SIZE = (120, 40)
+
+
+async def _wait_table(pilot):
+    for _ in range(50):
+        await pilot.pause()
+        page = getattr(pilot.app, "table_page", None)
+        if page and page.get("source_kind") == "ctable":
+            return page
+    raise AssertionError("data grid never loaded")
+
+
+@pytest.mark.asyncio
+@pytest.mark.tui
+async def test_group_key_applies_and_escape_clears(group_store):
+    path, _ = group_store
+    app = B2ViewApp(path)
+    async with app.run_test(size=TERM_SIZE) as pilot:
+        await pilot.press("down", "enter")  # select + show the /ctable node
+        await _wait_table(pilot)
+        pilot.app.query_one("#data-table", DataTable).focus()
+        await pilot.pause()
+
+        await pilot.press("G")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, GroupByScreen)
+        await pilot.press("enter")  # key list -> aggregation list
+        await pilot.press("enter")  # apply first aggregation (count rows / size)
+        await _wait_table(pilot)
+
+        assert pilot.app.browser.get_group("/ctable") is not None
+        table = pilot.app.query_one("#data-table", DataTable)
+        cols = [str(c.label) for c in table.columns.values()]
+        assert any("size" in c for c in cols)
+
+        await pilot.press("escape")  # ungroup
+        await _wait_table(pilot)
+        assert pilot.app.browser.get_group("/ctable") is None

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -119,6 +119,38 @@ def test_group_clears_active_filter(group_store):
         assert browser.get_filter("/ctable") is None  # filter dropped (exclusive)
 
 
+def test_group_sort_orders_result_by_column(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group("/ctable", "region", "mean", "amount")
+        browser.set_group_sort("/ctable", "amount_mean", reverse=True)
+        assert browser.get_group_sort("/ctable") == ("amount_mean", True)
+        page = browser.preview("/ctable", max_rows=100)
+    vals = np.asarray(page["data"]["amount_mean"])
+    assert list(vals) == sorted(vals, reverse=True)  # descending
+
+
+def test_group_sort_cleared_by_regroup_and_clear(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group("/ctable", "region", "mean", "amount")
+        browser.set_group_sort("/ctable", "amount_mean", reverse=False)
+        # Re-grouping drops the stale sort...
+        browser.set_group("/ctable", "vendor", "size", None)
+        assert browser.get_group_sort("/ctable") is None
+        # ...as does clearing the group.
+        browser.set_group_sort("/ctable", "size", reverse=True)
+        browser.clear_group("/ctable")
+        assert browser.get_group_sort("/ctable") is None
+
+
+def test_group_sort_noop_when_not_grouped(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group_sort("/ctable", "region", reverse=True)  # no group active
+        assert browser.get_group_sort("/ctable") is None
+
+
 def test_group_bars_sorted_desc_and_capped(group_store):
     path, _ = group_store
     with StoreBrowser(path) as browser:
@@ -141,7 +173,7 @@ if blosc2.IS_WASM:
 
 from textual.widgets import DataTable  # noqa: E402
 
-from blosc2.b2view.app import B2ViewApp, GroupByScreen  # noqa: E402
+from blosc2.b2view.app import B2ViewApp, GroupByScreen, SortByScreen  # noqa: E402
 
 TERM_SIZE = (120, 40)
 
@@ -177,6 +209,19 @@ async def test_group_key_applies_and_escape_clears(group_store):
         table = pilot.app.query_one("#data-table", DataTable)
         cols = [str(c.label) for c in table.columns.values()]
         assert any("size" in c for c in cols)
+
+        # Sort the grouped result by one of its columns via 'S'.
+        await pilot.press("S")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, SortByScreen)
+        await pilot.press("enter")  # apply the highlighted column
+        await _wait_table(pilot)
+        assert pilot.app.browser.get_group_sort("/ctable") is not None
+
+        await pilot.press("escape")  # clear the group sort, keep the group
+        await _wait_table(pilot)
+        assert pilot.app.browser.get_group_sort("/ctable") is None
+        assert pilot.app.browser.get_group("/ctable") is not None
 
         await pilot.press("escape")  # ungroup
         await _wait_table(pilot)

--- a/tests/b2view/test_group.py
+++ b/tests/b2view/test_group.py
@@ -144,6 +144,18 @@ def test_group_sort_cleared_by_regroup_and_clear(group_store):
         assert browser.get_group_sort("/ctable") is None
 
 
+def test_group_result_is_cached(group_store):
+    path, _ = group_store
+    with StoreBrowser(path) as browser:
+        browser.set_group("/ctable", "region", "mean", "amount")
+        first = browser._group_views["/ctable"]
+        browser.clear_group("/ctable")  # cache must survive ungrouping
+        browser.set_group("/ctable", "region", "mean", "amount")
+        assert browser._group_views["/ctable"] is first  # reused, not recomputed
+        browser.set_group("/ctable", "region", "max", "amount")  # different config
+        assert browser._group_views["/ctable"] is not first
+
+
 def test_group_sort_noop_when_not_grouped(group_store):
     path, _ = group_store
     with StoreBrowser(path) as browser:
@@ -239,3 +251,77 @@ async def test_group_key_applies_and_escape_clears(group_store):
         await pilot.press("escape")  # ungroup
         await _wait_table(pilot)
         assert pilot.app.browser.get_group("/ctable") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.tui
+async def test_argmin_cell_jumps_to_base_row(group_store):
+    path, _ = group_store
+    app = B2ViewApp(path)
+    async with app.run_test(size=TERM_SIZE) as pilot:
+        await pilot.press("down", "enter")  # select + show the /ctable node
+        await _wait_table(pilot)
+        pilot.app.query_one("#data-table", DataTable).focus()
+        await pilot.pause()
+
+        # Group region -> argmin(amount).  Ops: count rows, count, sum, mean,
+        # min, max, argmin(6), argmax.  Values: region(0), amount(1).
+        await pilot.press("G")
+        await pilot.pause()
+        await pilot.press("down", "enter")  # key: region -> operation list
+        await pilot.press("down", "down", "down", "down", "down", "down", "enter")  # argmin -> value
+        await pilot.press("down", "enter")  # value: amount -> apply
+        await _wait_table(pilot)
+        assert pilot.app.browser.get_group("/ctable") == ("region", "argmin", "amount")
+
+        # The cursor parks on the amount_argmin column; its cell is a row position.
+        table = pilot.app.query_one("#data-table", DataTable)
+        agg_col = pilot.app.table_page["columns"][table.cursor_column]
+        assert agg_col == "amount_argmin"
+        pos = int(pilot.app.table_page["data"]["amount_argmin"][table.cursor_row])
+
+        await pilot.press("enter")  # drill down to that base row
+        await _wait_table(pilot)
+        assert pilot.app.browser.get_group("/ctable") is None  # ungrouped
+        table = pilot.app.query_one("#data-table", DataTable)
+        landed_row = pilot.app.table_page["start"] + table.cursor_row
+        landed_col = pilot.app.table_page["columns"][table.cursor_column]
+        assert landed_row == pos
+        assert landed_col == "amount"
+
+
+@pytest.mark.asyncio
+@pytest.mark.tui
+async def test_group_config_cached_and_reused(group_store):
+    path, _ = group_store
+    app = B2ViewApp(path)
+    async with app.run_test(size=TERM_SIZE) as pilot:
+        await pilot.press("down", "enter")  # select + show the /ctable node
+        await _wait_table(pilot)
+        pilot.app.query_one("#data-table", DataTable).focus()
+        await pilot.pause()
+
+        # Group region -> mean(amount).
+        await pilot.press("G")
+        await pilot.pause()
+        await pilot.press("down", "enter")  # key: region -> operation list
+        await pilot.press("down", "down", "down", "enter")  # mean -> value list
+        await pilot.press("down", "enter")  # value: amount -> apply
+        await _wait_table(pilot)
+        assert pilot.app._last_group == ("region", "mean", "amount")
+
+        # Ungroup, then reselect the node (mimics navigating away and back).
+        await pilot.press("escape")
+        await _wait_table(pilot)
+        assert pilot.app.browser.get_group("/ctable") is None
+        pilot.app.update_panels("/ctable")
+        await _wait_table(pilot)
+        assert pilot.app._last_group == ("region", "mean", "amount")  # cache survives
+
+        # 'G' now pre-fills the modal from the cached config.
+        pilot.app.query_one("#data-table", DataTable).focus()
+        await pilot.pause()
+        await pilot.press("G")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, GroupByScreen)
+        assert pilot.app.screen._current == ("region", "mean", "amount")

--- a/tests/b2view/test_sort.py
+++ b/tests/b2view/test_sort.py
@@ -107,6 +107,26 @@ def test_indexed_column_plots_from_summary(tmp_path, kind):
         assert np.nanmax(env["ymax"]) == pytest.approx(vals.max())
 
 
+def test_sort_non_indexed_column(tmp_path):
+    """A column with no FULL index still sorts (materialise key + lexsort)."""
+
+    @dataclasses.dataclass
+    class Row:
+        v: int = blosc2.field(blosc2.int64())
+
+    path = str(tmp_path / "noidx.b2z")
+    rng = np.random.default_rng(0)
+    vals = rng.integers(0, 1000, N).astype(np.int64)
+    t = blosc2.CTable(Row, urlpath=path, mode="w", expected_size=N)
+    t.extend([(int(x),) for x in vals])
+    t.close()  # no create_index
+
+    with StoreBrowser(path) as browser:
+        assert browser.full_index_columns("/") == []  # nothing indexed
+        browser.set_sort("/", "v", reverse=False)
+        assert _head(browser, "v", 5) == sorted(vals.tolist())[:5]
+
+
 def test_sort_dictionary_by_decoded_string(sort_store):
     path, _, labels = sort_store
     with StoreBrowser(path) as browser:
@@ -216,7 +236,9 @@ async def test_sort_last_column_keeps_full_window(wide_store):
 
         await pilot.press("S")
         await pilot.pause()
-        await pilot.press("enter")  # only indexed column is the last one
+        # Every column is now offered; jump to the last one (the indexed one).
+        app.screen.query_one("#sortby-list").highlighted = len(cols) - 1
+        await pilot.press("enter")
         await pilot.pause()
         assert app.browser.get_sort("/") == (last, False)
 
@@ -246,6 +268,31 @@ async def test_sort_last_column_keeps_full_window(wide_store):
         cur_row, cur_col = app.query_one("#data-table").cursor_coordinate
         assert page["columns"][cur_col] == last
         assert page["data"][last][0] == max(page["data"][last])
+
+
+@pytest.mark.asyncio
+@pytest.mark.tui
+async def test_sort_non_indexed_column_async(wide_store):
+    """Sorting a non-indexed column runs in the background and still applies."""
+    path, cols = wide_store
+    app = B2ViewApp(path, start_panel="data")
+    async with app.run_test(size=TERM_SIZE) as pilot:
+        await _wait_for_table(pilot)
+        app.query_one("#data-table").focus()
+        await pilot.pause()
+
+        await pilot.press("S")
+        await pilot.pause()
+        app.screen.query_one("#sortby-list").highlighted = 0  # c00 — not indexed
+        await pilot.press("enter")
+        # Wait for the background sort worker to finish and repaint.
+        for _ in range(100):
+            await pilot.pause()
+            if app.browser.get_sort("/") == (cols[0], False):
+                break
+        assert app.browser.get_sort("/") == (cols[0], False)
+        col = cols[0]
+        assert app.table_page["data"][col][0] == min(app.table_page["data"][col])
 
 
 @pytest.mark.asyncio

--- a/tests/b2view/test_sort.py
+++ b/tests/b2view/test_sort.py
@@ -157,7 +157,19 @@ def test_filter_clears_sort(sort_store):
     with StoreBrowser(path) as browser:
         browser.set_sort("/", "b", reverse=False)
         browser.set_filter("/", "b > 500")
-        assert browser.get_sort("/") is None  # mutually exclusive
+        assert browser.get_sort("/") is None  # re-filtering drops the old sort
+
+
+def test_sort_composes_over_active_filter(sort_store):
+    """Sort applied after a filter orders only the filtered rows, keeping both."""
+    path, bvals, _ = sort_store
+    expected = sorted(int(v) for v in bvals if v > 500)
+    with StoreBrowser(path) as browser:
+        browser.set_filter("/", "b > 500")
+        browser.set_sort("/", "b", reverse=False)
+        assert browser.get_filter("/") == "b > 500"  # filter persists under the sort
+        assert browser.get_sort("/") == ("b", False)
+        assert _head(browser, "b", 5) == expected[:5]  # sorted, and all > 500
 
 
 # ── End-to-end TUI flow (Pilot) ───────────────────────────────────────────

--- a/tests/ctable/test_dictionary_column.py
+++ b/tests/ctable/test_dictionary_column.py
@@ -184,6 +184,33 @@ class TestCTableBehavior:
         mask = ct["vendor"] == None  # noqa: E711
         assert _logical_mask_values(ct, mask) == [False, False, False, False, True]
 
+    def test_string_where_expression_on_dictionary_column(self):
+        # A string where() referencing a dictionary column must resolve the
+        # literal to its code instead of failing with "Unknown symbol".
+        ct = CTable(TripRow)
+        ct.extend(DATA_TUPLES)
+
+        assert ct.where('vendor == "Uber"')["fare"][:].tolist() == [10.5, 15.0]
+        assert ct.where('vendor != "Uber"')["fare"][:].tolist() == [7.2, 5.0]
+        # Combined with a regular-column predicate.
+        assert ct.where('vendor == "Uber" and fare > 12')["fare"][:].tolist() == [15.0]
+        # Absent literal -> no match (no crash).
+        assert ct.where('vendor == "Waymo"').nrows == 0
+
+    def test_string_where_dictionary_literal_with_special_chars(self):
+        # Literals with commas/spaces/dashes (e.g. chicago-taxi company names).
+        @dataclass
+        class Row:
+            company: str = blosc2.field(blosc2.dictionary())
+            n: int = blosc2.field(blosc2.int64())
+
+        name = "3721 - Santamaria Express, Alvaro Santamaria"
+        ct = CTable(Row)
+        ct.extend([(name, 1), ("Acme", 2), (name, 3)])
+
+        assert ct.where(f'company == "{name}"')["n"][:].tolist() == [1, 3]
+        assert ct.where(f"company == '{name}'")["n"][:].tolist() == [1, 3]  # single quotes too
+
     def test_dictionary_predicate_combines_with_regular_predicate_in_aggregate(self):
         ct = CTable(TripRow)
         ct.extend(DATA_TUPLES)

--- a/tests/ctable/test_dictionary_column.py
+++ b/tests/ctable/test_dictionary_column.py
@@ -197,6 +197,23 @@ class TestCTableBehavior:
         # Absent literal -> no match (no crash).
         assert ct.where('vendor == "Waymo"').nrows == 0
 
+    def test_string_where_substring_in_dictionary_column(self):
+        # '"needle" in dictcol' is a substring filter over the dictionary values.
+        @dataclass
+        class Row:
+            company: str = blosc2.field(blosc2.dictionary())
+            amount: float = blosc2.field(blosc2.float64())
+
+        ct = CTable(Row)
+        ct.extend([("Acme Inc", 7.0), ("Santamaria Cabs", 15.0), ("Beta", 5.0), ("Acme LLC", 9.0)])
+
+        assert ct.where('"Acme" in company')["amount"][:].tolist() == [7.0, 9.0]
+        assert ct.where('"acme" in company').nrows == 0  # case-sensitive
+        assert ct.where('"zzz" in company').nrows == 0  # no match -> empty
+        # Combines with other predicates and operators.
+        assert ct.where('"Acme" in company and amount > 8')["amount"][:].tolist() == [9.0]
+        assert ct.where('"Acme" in company or "Beta" in company').nrows == 3
+
     def test_string_where_dictionary_literal_with_special_chars(self):
         # Literals with commas/spaces/dashes (e.g. chicago-taxi company names).
         @dataclass

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -666,3 +666,142 @@ def test_group_reduce_tristate_sort():
     assert list(g_auto) == [1, 2, 3]
     g_false, _ = blosc2.group_reduce(keys, values, op="sum", sort=False)
     assert sorted(g_false) == [1, 2, 3]  # order unspecified, same groups
+
+
+# ----------------------------------------------------------------------
+# agg() output column naming: auto suffix vs explicit named aggregation
+# ----------------------------------------------------------------------
+
+
+def test_agg_auto_suffix_names():
+    t = CTable(SalesRow, new_data=DATA)
+    out = t.group_by("city", sort=True).agg({"sales": ["sum", "mean"]})
+    assert out.col_names == ["city", "sales_sum", "sales_mean"]
+
+
+def test_agg_explicit_named_kwargs():
+    t = CTable(SalesRow, new_data=DATA)
+    out = t.group_by("city", sort=True).agg(revenue=("sales", "sum"), avg_sale=("sales", "mean"))
+    assert out.col_names == ["city", "revenue", "avg_sale"]
+    got = rows(out)
+    assert got[1][0] == "Paris"
+    assert got[1][1] == 40.0  # revenue == sales_sum
+    assert got[1][2] == 20.0  # avg_sale == sales_mean
+
+
+def test_agg_combines_mapping_and_named():
+    t = CTable(SalesRow, new_data=DATA)
+    out = t.group_by("city", sort=True).agg({"sales": "sum"}, n=("*", "size"))
+    assert out.col_names == ["city", "sales_sum", "n"]
+    got = rows(out)
+    assert got[0][0] == "Berlin"
+    assert np.isnan(got[0][1])
+    assert got[0][2] == 1
+    assert got[1] == ("Paris", 40.0, 3)
+    assert got[2] == ("Rome", 60.0, 2)
+
+
+def test_agg_list_of_pairs_auto_named():
+    t = CTable(SalesRow, new_data=DATA)
+    out = t.group_by("city", sort=True).agg([("sales", ["sum", "mean"])])
+    assert out.col_names == ["city", "sales_sum", "sales_mean"]
+
+
+def test_agg_list_of_pairs_accepts_column_objects():
+    # The list form's whole point: use Column objects, which can't be dict keys.
+    t = CTable(SalesRow, new_data=DATA)
+    out = t.group_by("city", sort=True).agg([(t.sales, ["sum", "mean"])])
+    assert out.col_names == ["city", "sales_sum", "sales_mean"]
+    got = rows(out)
+    assert got[1] == ("Paris", 40.0, 20.0)
+
+
+def test_agg_list_of_pairs_combines_with_named():
+    t = CTable(SalesRow, new_data=DATA)
+    out = t.group_by("city", sort=True).agg([(t.sales, "sum")], n=("*", "size"))
+    assert out.col_names == ["city", "sales_sum", "n"]
+
+
+def test_agg_positional_must_be_mapping_or_pairs():
+    t = CTable(SalesRow, new_data=DATA)
+    with pytest.raises(ValueError, match="mapping or a list of"):
+        t.group_by("city").agg("sales")
+    with pytest.raises(ValueError, match=r"must contain \(column, ops\) pairs"):
+        t.group_by("city").agg([("sales",)])
+
+
+def test_agg_named_accepts_column_objects():
+    # A Column object can't be a dict key (unhashable: __eq__ is overloaded for
+    # expressions), but it works as a named-agg value, like group_by() args.
+    t = CTable(SalesRow, new_data=DATA)
+    g = t.group_by("city", sort=True)
+    with pytest.raises(TypeError, match="unhashable"):
+        _ = {t.sales: ["sum"]}  # fails at dict construction, before agg() runs
+    out = g.agg(total=(t.sales, "sum"), avg=(t.sales, "mean"))
+    assert out.col_names == ["city", "total", "avg"]
+
+
+def test_agg_accepts_blosc2_reduction_functions():
+    # blosc2 reduction functions are accepted as ops (matched by identity),
+    # interchangeably with strings, in both the list and named forms.
+    t = CTable(SalesRow, new_data=DATA)
+    g = t.group_by("city", sort=True)
+    by_func = g.agg([(t.sales, [blosc2.sum, blosc2.mean])])
+    by_str = g.agg([(t.sales, ["sum", "mean"])])
+    assert by_func.col_names == by_str.col_names == ["city", "sales_sum", "sales_mean"]
+    assert col(by_func, "city") == col(by_str, "city")
+    np.testing.assert_array_equal(  # NaN-safe (Berlin has no non-null sales)
+        col(by_func, "sales_sum"), col(by_str, "sales_sum")
+    )
+    named = g.agg(revenue=(t.sales, blosc2.sum))
+    assert named.col_names == ["city", "revenue"]
+
+
+def test_agg_rejects_non_blosc2_callables_by_identity():
+    # A UDF that merely shares a builtin op name must NOT be silently accepted;
+    # np.sum / builtin sum are likewise rejected (only blosc2.* by identity).
+    t = CTable(SalesRow, new_data=DATA)
+    g = t.group_by("city")
+
+    def sum(values):
+        return -1
+
+    for fn in (sum, np.sum):
+        with pytest.raises(ValueError, match="Unsupported aggregation function"):
+            g.agg([(t.sales, fn)])
+    # blosc2.std is a real function but not a supported group-by op.
+    with pytest.raises(ValueError, match="Unsupported aggregation function"):
+        g.agg([(t.sales, blosc2.std)])
+
+
+def test_agg_named_star_size():
+    t = CTable(SalesRow, new_data=DATA)
+    out = t.group_by("city", sort=True).agg(total=("*", "size"))
+    assert out.col_names == ["city", "total"]
+    assert rows(out) == [("Berlin", 1), ("Paris", 3), ("Rome", 2)]
+
+
+def test_agg_requires_some_aggregation():
+    t = CTable(SalesRow, new_data=DATA)
+    with pytest.raises(ValueError, match="requires a mapping"):
+        t.group_by("city").agg()
+
+
+def test_agg_named_must_be_column_op_pair():
+    t = CTable(SalesRow, new_data=DATA)
+    with pytest.raises(ValueError, match=r"must be a \(column, op\) pair"):
+        t.group_by("city").agg(x=("sales",))
+
+
+def test_agg_named_rejects_multiple_ops_with_guidance():
+    # A named output maps to a single op; multiple ops need the mapping form or
+    # one name each. The error should say so, not "unsupported aggregation".
+    t = CTable(SalesRow, new_data=DATA)
+    with pytest.raises(ValueError, match="takes a single op"):
+        t.group_by("city").agg(total=("sales", ("sum", "mean")))
+
+
+def test_agg_duplicate_output_names_rejected():
+    t = CTable(SalesRow, new_data=DATA)
+    with pytest.raises(ValueError, match="must be unique"):
+        t.group_by("city").agg({"sales": "sum"}, sales_sum=("sales", "sum"))

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -169,6 +169,42 @@ def test_groupby_dictionary_key_groups_by_decoded_value():
     assert rows(out) == [("Paris", 40), ("Rome", 20)]
 
 
+def test_groupby_dictionary_key_sorted_by_string_not_code_order():
+    """Dict groups come out alphabetical even when codes are assigned otherwise.
+
+    Regression for the always-sorted contract: with "Rome" seen before "Paris"
+    (codes Rome=0, Paris=1), the result must still be Paris-then-Rome.  The old
+    code emitted code-assignment order unless ``sort=True``, and even then only
+    happened to look right when first-seen order matched alphabetical.
+    """
+    t = CTable(DictRow, new_data=[("Rome", 20), ("Paris", 10), ("Rome", 5), ("Paris", 30)])
+
+    # No sort= argument: ordering is now guaranteed.
+    assert rows(t.group_by("city").agg({"sales": "sum"})) == [("Paris", 40), ("Rome", 25)]
+    # argmin/argmax drive the dense-position path; it must sort the same way.
+    out = t.group_by("city").agg({"sales": ["argmin", "argmax"]})
+    # Paris rows 1,3 (10,30) -> argmin 1, argmax 3; Rome rows 0,2 (20,5).
+    assert rows(out) == [("Paris", 1, 3), ("Rome", 2, 0)]
+
+
+def test_groupby_dictionary_key_sorted_matches_python_sorted():
+    """Vectorized dict-key ordering matches a Python sorted() reference."""
+    rng = np.random.default_rng(0)
+    labels = [f"city_{i:03d}" for i in range(200)]
+    data = [(labels[int(rng.integers(len(labels)))], int(rng.integers(100))) for _ in range(5000)]
+    t = CTable(DictRow, new_data=data)
+
+    got = [r[0] for r in rows(t.group_by("city").size())]
+    assert got == sorted({label for label, _ in data})
+
+
+def test_groupby_string_key_sorted_without_sort_flag():
+    """Fixed-width string keys (generic path) are also always sorted by key."""
+    t = CTable(SalesRow, new_data=DATA)
+    out = t.group_by("city").size()
+    assert [r[0] for r in rows(out)] == ["Berlin", "Paris", "Rome"]
+
+
 def test_groupby_dictionary_key_argmin_argmax_positions():
     # Dictionary key drives the dense-position fast path; verify it returns the
     # logical row positions of the extremes (chicago-taxi "company" shape).
@@ -262,7 +298,9 @@ class DictFloatRow:
         (
             DictFloatRow,
             [("a", 1.5), ("c", 10.0), ("b", 2.5), ("c", 3.0), ("a", 4.0)],
-            [("a", 5.5), ("c", 13.0), ("b", 2.5)],
+            # Groups come out sorted by decoded string, not code-assignment order
+            # ("c" was seen before "b").
+            [("a", 5.5), ("b", 2.5), ("c", 13.0)],
         ),
     ],
 )
@@ -277,7 +315,9 @@ def test_groupby_fast_path_sum_variants(row_type, data, expected):
 def test_groupby_float_integral_fast_path_falls_back_for_non_integral_keys():
     t = CTable(Float64KeyRow, new_data=[(0.5, 1.0), (1.5, 2.0), (0.5, 3.0)])
 
-    out = t.group_by("key").agg({"value": "sum"})
+    # Float keys are not key-sorted by default (sort=None); request sort=True to
+    # assert a specific order.
+    out = t.group_by("key", sort=True).agg({"value": "sum"})
 
     assert rows(out) == [(0.5, 4.0), (1.5, 2.0)]
 
@@ -448,7 +488,9 @@ def test_groupby_cython_arbitrary_float_key_aggs():
         new_data=[(0.5, 1.0), (1.25, 10.0), (0.5, 3.0), (-2.5, 4.0), (1.25, 2.0)],
     )
 
-    out = t.group_by("key").agg({"value": ["count", "sum", "mean", "min", "max"]})
+    # Float keys are not key-sorted by default (sort=None); request sort=True to
+    # assert a specific order.
+    out = t.group_by("key", sort=True).agg({"value": ["count", "sum", "mean", "min", "max"]})
 
     assert rows(out) == [
         (-2.5, 1, 4.0, 4.0, 4.0, 4.0),
@@ -547,3 +589,80 @@ def test_groupby_persistent_output_urlpath_on_convenience_method(tmp_path):
 
     reopened = CTable.open(str(path), mode="r")
     assert rows(reopened) == [("Berlin", 6.0), ("Paris", 7 / 3), ("Rome", 4.0)]
+
+
+# ----------------------------------------------------------------------
+# Tri-state sort= (True / False / None-auto)
+# ----------------------------------------------------------------------
+
+# First-seen order is deliberately non-alphabetical / non-ascending so that a
+# real reorder is observable.
+_DICT_SORT_DATA = [("zeta", 1.0), ("alpha", 2.0), ("mike", 3.0), ("alpha", 4.0), ("zeta", 5.0)]
+_INT_SORT_DATA = [(30, 1.0), (10, 2.0), (20, 3.0), (10, 4.0)]
+_FLOAT_SORT_DATA = [(3.5, 1.0), (1.5, 2.0), (2.5, 3.0), (1.5, 4.0)]
+
+
+def _keys(out):
+    return [out._cols[out.col_names[0]][i] for i in range(out.nrows)]
+
+
+def test_groupby_int_key_always_ascending_regardless_of_sort():
+    # Integer/dense keys come out ascending under every sort= value -- nonzero
+    # ordering is free and unavoidable.
+    t = CTable(Int32FloatRow, new_data=_INT_SORT_DATA)
+    for sort in (None, True, False):
+        assert _keys(t.group_by("key", sort=sort).sum("value")) == [10, 20, 30]
+
+
+def test_groupby_dict_key_sorted_under_auto_and_true():
+    # Dictionary keys are cheap to sort, so None (auto) and True both sort by
+    # string; False keeps first-seen code order.
+    t = CTable(DictFloatRow, new_data=_DICT_SORT_DATA)
+    assert _keys(t.group_by("key").sum("value")) == ["alpha", "mike", "zeta"]  # default None
+    assert _keys(t.group_by("key", sort=True).sum("value")) == ["alpha", "mike", "zeta"]
+    assert _keys(t.group_by("key", sort=False).sum("value")) == ["zeta", "alpha", "mike"]
+
+
+def test_groupby_float_key_unsorted_under_auto_sorted_under_true():
+    # Float keys only sort via a Python list.sort, so None (auto) leaves them
+    # unsorted; True sorts. The unsorted order must be deterministic across runs.
+    t = CTable(Float64KeyRow, new_data=_FLOAT_SORT_DATA)
+    assert _keys(t.group_by("key", sort=True).sum("value")) == [1.5, 2.5, 3.5]
+    auto1 = _keys(t.group_by("key").sum("value"))
+    auto2 = _keys(t.group_by("key").sum("value"))
+    assert auto1 == auto2  # deterministic
+    assert sorted(auto1) == [1.5, 2.5, 3.5]  # same groups, order unspecified
+
+
+def test_groupby_multikey_unsorted_under_auto_sorted_under_true():
+    # Multi-key results only sort via a Python list.sort, so None (auto) leaves
+    # them unsorted (deterministic but unspecified order); True sorts.
+    data = [("z", 2, 1.0), ("a", 1, 2.0), ("z", 1, 3.0), ("a", 1, 4.0)]
+    t = CTable(DictIntKeyFloatRow, new_data=data)
+
+    def keypairs(out):
+        return [(str(r[0]), int(r[1])) for r in rows(out)]
+
+    expected = {("a", 1), ("z", 1), ("z", 2)}
+    assert keypairs(t.group_by(["key0", "key1"], sort=True).sum("value")) == [
+        ("a", 1),
+        ("z", 1),
+        ("z", 2),
+    ]
+    auto1 = keypairs(t.group_by(["key0", "key1"]).sum("value"))
+    auto2 = keypairs(t.group_by(["key0", "key1"]).sum("value"))
+    assert auto1 == auto2  # deterministic
+    assert set(auto1) == expected  # same groups, order unspecified
+
+
+def test_group_reduce_tristate_sort():
+    # group_reduce mirrors the tri-state. Its float path is vectorized
+    # (np.argsort), so unlike CTable's float-hash it *does* sort under None.
+    keys = blosc2.array([3, 1, 2, 1])
+    values = blosc2.array([1.0, 2.0, 3.0, 4.0])
+    g_true, _ = blosc2.group_reduce(keys, values, op="sum", sort=True)
+    assert list(g_true) == [1, 2, 3]
+    g_auto, _ = blosc2.group_reduce(keys, values, op="sum")  # default None, cheap -> sorted
+    assert list(g_auto) == [1, 2, 3]
+    g_false, _ = blosc2.group_reduce(keys, values, op="sum", sort=False)
+    assert sorted(g_false) == [1, 2, 3]  # order unspecified, same groups

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -96,6 +96,22 @@ def test_groupby_argmin_argmax_convenience_methods_and_view_positions():
     assert rows(argmin) == [("Berlin", -1), ("Paris", 1), ("Rome", 0)]
 
 
+def test_groupby_argmin_argmax_ties_keep_first_row():
+    # Two rows tie for the group's extreme; the earliest logical row wins, even
+    # when the tie straddles a chunk boundary (locks the vectorized path).
+    TieRow = make_dataclass(
+        "TieRow",
+        [("g", int, blosc2.field(blosc2.int32())), ("v", float, blosc2.field(blosc2.float64()))],
+    )
+    data = [(0, 5.0), (0, 9.0), (0, 9.0), (0, 5.0)]  # rows 0..3
+    t = CTable(TieRow, new_data=data)
+
+    out = t.group_by("g", sort=True, chunk_size=2).agg({"v": ["argmin", "argmax"]})
+
+    # min 5.0 first at row 0; max 9.0 first at row 1 (tie with row 2 ignored).
+    assert rows(out) == [(0, 0, 1)]
+
+
 def test_groupby_multi_key_size():
     t = CTable(SalesRow, new_data=DATA)
 
@@ -151,6 +167,18 @@ def test_groupby_dictionary_key_groups_by_decoded_value():
 
     assert out.col_names == ["city", "sales_sum"]
     assert rows(out) == [("Paris", 40), ("Rome", 20)]
+
+
+def test_groupby_dictionary_key_argmin_argmax_positions():
+    # Dictionary key drives the dense-position fast path; verify it returns the
+    # logical row positions of the extremes (chicago-taxi "company" shape).
+    t = CTable(DictRow, new_data=[("Paris", 10), ("Rome", 50), ("Paris", 30), ("Rome", 20)])
+
+    out = t.group_by("city", sort=True).agg({"sales": ["argmin", "argmax"]})
+
+    assert out.col_names == ["city", "sales_argmin", "sales_argmax"]
+    # Paris rows 0,2 (10,30) -> argmin row0, argmax row2; Rome rows 1,3 (50,20).
+    assert rows(out) == [("Paris", 0, 2), ("Rome", 3, 1)]
 
 
 def test_groupby_dictionary_key_beyond_default_code_capacity():

--- a/tests/ctable/test_row_logic.py
+++ b/tests/ctable/test_row_logic.py
@@ -103,30 +103,31 @@ def test_row_list_indexing():
     """List indexing: no holes, with holes, out-of-range, edge cases."""
     data = generate_test_data(20)
 
-    # No holes
+    # No holes: a list gather is order-carrying -> rows come back in the
+    # requested order (not physical-ascending).
     t = CTable(Row, new_data=data)
     r = t[[0, 5, 10, 15]]
     assert isinstance(r, CTable)
     assert len(r) == 4
-    assert set(r.id) == {0, 5, 10, 15}
-    assert set(t[[19, 0, 10]].id) == {0, 10, 19}
+    assert list(r.id) == [0, 5, 10, 15]
+    assert list(t[[19, 0, 10]].id) == [19, 0, 10]
 
     # With holes: delete [1,3,5,7,9] -> logical 0->id0, 1->id2, 2->id4...
     t.delete([1, 3, 5, 7, 9])
-    assert set(t[[0, 2, 4]].id) == {0, 4, 8}
-    assert set(t[[5, 3, 1]].id) == {2, 6, 10}
+    assert list(t[[0, 2, 4]].id) == [0, 4, 8]
+    assert list(t[[5, 3, 1]].id) == [10, 6, 2]
 
     # Negative indices in list
     t2 = CTable(Row, new_data=generate_test_data(10))
-    assert set(t2[[0, -1, 5]].id) == {0, 5, 9}
+    assert list(t2[[0, -1, 5]].id) == [0, 9, 5]
 
     # Single element
     assert t2[[5]].id[0] == 5
 
-    # Duplicate indices -> deduplicated
+    # Duplicate indices -> preserved (a gather can repeat rows)
     r_dup = t2[[5, 5, 5]]
-    assert len(r_dup) == 1
-    assert r_dup.id[0] == 5
+    assert len(r_dup) == 3
+    assert list(r_dup.id) == [5, 5, 5]
 
     # Empty list
     assert len(t2[[]]) == 0
@@ -135,6 +136,47 @@ def test_row_list_indexing():
     for bad in [[0, 5, 100], [0, 1, -11]]:
         with pytest.raises(IndexError):
             _ = t2[bad]
+
+
+def test_row_selector_preserves_order_and_duplicates():
+    """Order-carrying selectors on a plain (unordered) table keep order + dups.
+
+    Regression: a negative-step slice and an integer/list gather used to be
+    collapsed into a set-like boolean mask, which silently returned rows in
+    physical-ascending order and dropped duplicates.  This is exactly the shape
+    of a freshly built group-by result, where ``res[::-1]`` looked like a no-op.
+    """
+    t = CTable(Row, new_data=generate_test_data(10))
+
+    # Reverse via negative-step slice.
+    assert list(t[::-1].id) == list(range(9, -1, -1))
+    assert list(t[::-1].score) == [float(i * 10) for i in range(9, -1, -1)]
+
+    # Strided negative slice.
+    assert list(t[8:2:-2].id) == [8, 6, 4]
+
+    # Integer-array reorder (NumPy fancy index).
+    order = np.array([3, 1, 2, 0])
+    assert list(t[order].id) == [3, 1, 2, 0]
+
+    # Duplicate positions are preserved, in order.
+    assert list(t[[7, 7, 1]].id) == [7, 7, 1]
+
+    # A boolean mask stays set-like: physical-ascending order, no duplicates.
+    mask = np.zeros(10, dtype=bool)
+    mask[[5, 1, 8]] = True
+    assert list(t[mask].id) == [1, 5, 8]
+
+
+def test_reverse_slice_roundtrip_matches_numpy():
+    """``t[::-1]`` matches reversing the materialized structured array."""
+    t = CTable(Row, new_data=generate_test_data(25))
+    arr = np.asarray(t)
+    rev = t[::-1]
+    assert list(rev.id) == list(arr["id"][::-1])
+    assert list(rev.score) == list(arr["score"][::-1])
+    # Reversing twice is the identity.
+    assert list(t[::-1][::-1].id) == list(range(25))
 
 
 def test_row_view_properties():

--- a/tests/ndarray/test_lazyexpr_fields.py
+++ b/tests/ndarray/test_lazyexpr_fields.py
@@ -681,3 +681,41 @@ def test_fields_indexing():
 
     # Remove file
     blosc2.remove_urlpath("sa-1M.b2nd")
+
+
+@pytest.mark.parametrize("same_filter", [True, False])
+def test_query_cache_overwrite(tmp_path, same_filter):
+    # Query-result handles (gather mmaps, cached coordinates) are keyed by urlpath and
+    # were historically only dropped when the file was *deleted*. A file overwritten in
+    # place (same path, new contents) must not be served from the stale caches of the
+    # previous file -- the cached handles have to be validated against the file's
+    # mtime/size, not just its existence. See the Caterva2 lazyexpr-cache regression.
+    urlpath = str(tmp_path / "sa.b2nd")
+    dtype = [("A", np.int32), ("B", np.float32)]
+
+    # First version: 1000 rows, A = 0..999
+    na = np.empty(1000, dtype=dtype)
+    na["A"] = np.arange(1000)
+    na["B"] = np.arange(1000, dtype=np.float32)
+    blosc2.asarray(na, urlpath=urlpath, mode="w")
+
+    flt1 = "A < 100"
+    arr = blosc2.open(urlpath)
+    res = arr[flt1].sort(None).compute()[:]
+    np.testing.assert_array_equal(np.sort(res["A"].copy()), np.arange(100))
+    del arr  # drop the Python handle; the process-global caches survive
+
+    # Overwrite in place with different size *and* contents: 5000 rows, A = 5000..9999
+    nb = np.empty(5000, dtype=dtype)
+    nb["A"] = np.arange(5000, 10000)
+    nb["B"] = np.arange(5000, dtype=np.float32)
+    blosc2.asarray(nb, urlpath=urlpath, mode="w")
+
+    arr = blosc2.open(urlpath)
+    # Reuse the same filter (same query digest -> exercises the coordinate cache) or a
+    # new one (exercises the gather-mmap handle); both must read the *new* file.
+    flt2 = flt1 if same_filter else "A < 6000"
+    res = arr[flt2].sort(None).compute()[:]
+
+    expected = nb[nb["A"] < (100 if same_filter else 6000)]
+    np.testing.assert_array_equal(np.sort(res["A"].copy()), np.sort(expected["A"].copy()))

--- a/tests/test_python_blosc.py
+++ b/tests/test_python_blosc.py
@@ -7,7 +7,6 @@
 
 # Test the python-blosc API
 
-import ctypes
 import gc
 import os
 import unittest
@@ -199,9 +198,11 @@ class TestCodec(unittest.TestCase):
     def test_no_leaks(self):
         num_elements = 10000000
         typesize = 8
-        data = [float(i) for i in range(num_elements)]  # ~76MB
-        Array = ctypes.c_double * num_elements
-        array = Array(*data)
+        # ~76MB ctypes buffer, big enough that a per-call leak dwarfs RSS noise.
+        # Build it from a numpy buffer (O(1) view) instead of Array(*data),
+        # whose 10M-arg unpack dominated the test's runtime.
+        np_data = np.arange(num_elements, dtype=np.float64)
+        array = np.ctypeslib.as_ctypes(np_data)
 
         def leaks(operation, repeats=3):
             gc.collect()
@@ -220,6 +221,12 @@ class TestCodec(unittest.TestCase):
         def decompress():
             cx = blosc2.compress(array, typesize, clevel=1)
             blosc2.decompress(cx)
+
+        # Warm up the allocator: the first compress grows the heap arena by
+        # one output buffer (a one-time cost, not a leak).  The old test paid
+        # this implicitly while building its ~360MB input list; with the cheap
+        # numpy buffer we must prime it so the RSS baseline is stable.
+        decompress()
 
         assert not leaks(compress), "compress leaks memory"
         assert not leaks(decompress), "decompress leaks memory"


### PR DESCRIPTION
This adds first-class grouping to both the core library and the `b2view` TUI, plus a test-runtime cut.

## Core: `group_by` / `group_reduce`

- **Flexible aggregation specs & naming** — `CTable.group_by(...).agg()` now
  accepts a list of `(column, ops)` pairs and pandas-style explicit output
  names alongside the existing auto-suffixed mapping; forms combine:
  ```python
  g.agg({"sales": ["sum", "mean"]})        # auto: sales_sum, sales_mean
  g.agg([(t.sales, ["sum", "mean"])])      # accepts Column objects
  g.agg(revenue=("sales", "sum"))          # explicit name
  g.agg({"sales": "sum"}, n=("*", "size")) # combined + named row count
  Ops may be blosc2 reduction functions (blosc2.sum, mean, …), matched by
  identity; arbitrary/UDF look-alikes (np.sum, user sum) are rejected, not
  silently misread.
- Tri-state sort= (None/True/False) on CTable.group_by() and
blosc2.group_reduce(). New default None = auto: sort only when cheap
(integer/dictionary keys), skip the O(G log G) Python sort for float/multi-key
results.
  - ⚠️ Behavior change: CTable.group_by() float-key and multi-key results
are no longer key-sorted by default (sort=True restores it).
group_reduce() cheap kernels now sort by default (sort=False opts out).
- Vectorized dictionary group ordering — batch-decodes string keys in one
decode_batch pass instead of per-group decode(); high-cardinality string
group_by().size() drops from seconds to milliseconds (~100k groups).
- Accelerated argmin/argmax in groupby.
- where expressions on dictionary (string) columns, including
'"Acme" in company'-style membership.

b2view TUI

- G group-by over dictionary, integer, and float key columns, with the
last group operation memoized and reused.
- While grouped, S/R operate on the grouped result; row filters are
preserved across subsequent sort/group ops.
- Sort by non-indexed columns (builds the permutation off-thread).
- Plots: bars for categorical keys, lines for numeric keys, stem/impulse
for numeric-key groups (no misleading connected lines), each with an hi-res
counterpart.
- Data-panel border_subtitle shows G(roup); group menu reorganized.

Fixes & maintenance

- Open-file cache validates cached entries against the file fingerprint
(st_mtime_ns, st_size).
- Adjust for NumPy 2.5 deprecations.
