### PR TITLE
Enhancing CTable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ project(python-blosc2)
 
 # blosc2_ext.pyx calls blosc2_schunk_lock()/unlock(), added in c-blosc2 3.2.x
 set(BLOSC2_MIN_VERSION 3.2.1)
-set(BLOSC2_BUNDLED_VERSION v3.2.2)
+set(BLOSC2_BUNDLED_VERSION v3.2.3)
 
 if(WIN32 AND NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
     message(FATAL_ERROR "Windows builds require clang-cl. Set CC/CXX to clang-cl or configure CMake with -T ClangCL.")

--- a/bench/ctable/bench_groupby_keys.py
+++ b/bench/ctable/bench_groupby_keys.py
@@ -1,0 +1,71 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#######################################################################
+
+"""Group-by aggregation speed by key type (the Gap D1 gate case: 1e7 rows,
+low-cardinality keys).  String keys are the case to watch: they miss every
+Cython fast path and go through hash-based factorization in
+``_factorize_fixed_width_str``."""
+
+import time
+from dataclasses import dataclass
+
+import numpy as np
+
+import blosc2
+from blosc2 import CTable
+
+N = 10_000_000
+rng = np.random.default_rng(42)
+
+int_keys = rng.integers(0, 20, N)
+float_vals = rng.random(N) * 100
+cities = np.array(["Paris", "Rome", "Berlin", "Madrid", "Lisbon"])
+str_keys = cities[rng.integers(0, 5, N)]
+
+
+@dataclass
+class Row:
+    ikey: int = blosc2.field(blosc2.int64())
+    skey: str = blosc2.field(blosc2.string(max_length=8))
+    dkey: str = blosc2.field(blosc2.dictionary())
+    val: float = blosc2.field(blosc2.float64())
+
+
+print(f"building table ({N:.0e} rows)...", flush=True)
+t = CTable(Row)
+t.extend(
+    {"ikey": int_keys, "skey": str_keys, "dkey": [str(s) for s in str_keys], "val": float_vals},
+    validate=False,
+)
+
+
+def bench(label, fn, reps=3):
+    times = []
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    print(f"{label:45s} {min(times) * 1000:8.1f} ms", flush=True)
+
+
+bench("int key, sum", lambda: t.group_by("ikey").sum("val"))
+bench("int key, mean", lambda: t.group_by("ikey").agg({"val": "mean"}))
+bench("string key, sum", lambda: t.group_by("skey").sum("val"))
+bench("dict key, sum", lambda: t.group_by("dkey").sum("val"))
+bench("two keys (int+dict), sum", lambda: t.group_by(["ikey", "dkey"]).sum("val"))
+
+try:
+    import pandas as pd
+except ImportError:
+    pass
+else:
+    df = pd.DataFrame({"ikey": int_keys, "skey": str_keys, "val": float_vals})
+    bench("pandas int key, sum", lambda: df.groupby("ikey")["val"].sum())
+    bench("pandas string key, sum", lambda: df.groupby("skey")["val"].sum())
+
+# rough speed-of-light reference for the int-key case
+bench("numpy bincount int key, sum", lambda: np.bincount(int_keys, weights=float_vals))

--- a/bench/ctable/bench_groupby_keys.py
+++ b/bench/ctable/bench_groupby_keys.py
@@ -5,8 +5,8 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #######################################################################
 
-"""Group-by aggregation speed by key type (the Gap D1 gate case: 1e7 rows,
-low-cardinality keys).  String keys are the case to watch: they miss every
+"""Group-by aggregation speed by key type (1e7 rows, low-cardinality keys).
+String keys are the case to watch: they miss every
 Cython fast path and go through hash-based factorization in
 ``_factorize_fixed_width_str``."""
 

--- a/doc/guides/optimization_tips.md
+++ b/doc/guides/optimization_tips.md
@@ -1,7 +1,6 @@
 # Optimization tips
 
-This page collects small idioms that make a measurable difference in speed or memory (often both). Each one is backed by a small benchmark in [`bench/optim_tips/`](https://github.com/Blosc/python-blosc2/tree/main/bench/optim_tips), which you can run yourself — see the
-[bench/optim_tips README](https://github.com/Blosc/python-blosc2/tree/main/bench/optim_tips/README.md).
+This page collects small idioms that make a measurable difference in speed or memory (often both). Each one is backed by a small benchmark in [`bench/optim_tips/`](https://github.com/Blosc/python-blosc2/tree/main/bench/optim_tips), which you can run yourself — see the [bench/optim_tips README](https://github.com/Blosc/python-blosc2/tree/main/bench/optim_tips/README.md).
 
 Numbers below were measured on an Apple M4 Pro Mac Mini (macOS, Python 3.14); absolute values will differ on your machine, but the direction and rough magnitude of each effect should not.
 

--- a/doc/reference/ctable.rst
+++ b/doc/reference/ctable.rst
@@ -193,7 +193,9 @@ expression:
 
 - **Boolean combinators** (``& | ~``) need no special handling: their
   inputs are already-resolved comparison results with null-ness folded to
-  ``False``.
+  ``False``. Mind the consequence for negation: since a null compares
+  ``False``, ``~(t.price > 0)`` *selects* null rows (they are "not > 0").
+  Add ``& t.price.notnull()`` to exclude them.
 
 Kleene three-valued logic (where ``null > 0`` evaluates to null rather than
 ``False``) is intentionally out of scope — it needs a validity channel on

--- a/doc/reference/ctable.rst
+++ b/doc/reference/ctable.rst
@@ -373,6 +373,32 @@ several ways; the list-of-pairs form additionally lets you pass ``Column``
 objects (``t.sales``) instead of name strings; use explicit names when you want a
 specific (and easily addressable) output column name.
 
+**Custom UDF aggregations** are accepted only via the named form --
+``output_name=(column, callable)``, optionally with an explicit output dtype as
+a third element::
+
+    by_city.agg(sales_range=(t.sales, lambda a: a.max() - a.min()))
+    # explicit dtype instead of inferring it from the callable's results:
+    by_city.agg(sales_range=(t.sales, lambda a: a.max() - a.min(), blosc2.float32()))
+
+The callable receives a 1-D NumPy array of the group's live, non-null values
+(same null semantics as the built-in aggregations) and returns a scalar; it is
+called once per group with a plain Python loop -- there is no JIT
+acceleration for arbitrary UDFs yet.  A group with no non-null values for that
+column never calls the callable, producing a null result instead (the same
+convention ``sum``/``min``/``max`` already use).  The mapping and
+list-of-pairs auto-named forms cannot derive an output column name for an
+arbitrary callable, so they only accept the string/blosc2-reduction-function
+ops described above.
+
+**Execution engine.**  :meth:`CTable.group_by` takes an ``engine=`` parameter
+for the *built-in* aggregations (``size``/``count``/``sum``/``mean``/``min``/
+``max``/``argmin``/``argmax``): ``"auto"`` (default) and ``"numpy"`` both use
+the NumPy/Cython chunked implementation; ``"jit"`` is reserved for a future
+miniexpr-JIT path and currently raises :class:`NotImplementedError`. UDF
+aggregations always run the plain Python per-group loop regardless of
+``engine``.
+
 **Output ordering.**  ``sort`` controls how groups are ordered, and is *always
 by the group key(s), never by the aggregated value*:
 
@@ -466,6 +492,7 @@ in place.
     CTable.drop_computed_column
     CTable.drop_column
     CTable.rename_column
+    CTable.apply
 
 .. automethod:: CTable.delete
 .. automethod:: CTable.compact
@@ -475,6 +502,7 @@ in place.
 .. automethod:: CTable.drop_computed_column
 .. automethod:: CTable.drop_column
 .. automethod:: CTable.rename_column
+.. automethod:: CTable.apply
 
 
 Indexes

--- a/doc/reference/ctable.rst
+++ b/doc/reference/ctable.rst
@@ -195,7 +195,8 @@ expression:
   inputs are already-resolved comparison results with null-ness folded to
   ``False``. Mind the consequence for negation: since a null compares
   ``False``, ``~(t.price > 0)`` *selects* null rows (they are "not > 0").
-  Add ``& t.price.notnull()`` to exclude them.
+  To exclude them, write the complementary comparison instead
+  (``t.price <= 0``), which never matches nulls.
 
 Kleene three-valued logic (where ``null > 0`` evaluates to null rather than
 ``False``) is intentionally out of scope — it needs a validity channel on

--- a/doc/reference/ctable.rst
+++ b/doc/reference/ctable.rst
@@ -202,19 +202,21 @@ Kleene three-valued logic (where ``null > 0`` evaluates to null rather than
 ``False``) is intentionally out of scope — it needs a validity channel on
 boolean intermediates, i.e. masks, which CTable does not use.
 
-One limitation to be aware of: reductions called directly on a *derived*
-expression built from Column arithmetic (e.g. ``(t.price + 1).sum()``) do
-**not** skip the promoted NaNs — that expression is a plain
-:class:`~blosc2.LazyExpr` with no memory of which table column it came from,
-so its own ``.sum()``/``.mean()`` follow ordinary NumPy semantics (a NaN
-poisons the reduction). :meth:`Column.sum`/:meth:`~Column.mean` *do* skip
-nulls, because they always operate on a real, named column. To reduce a
-derived expression while skipping nulls, filter or mask first::
+Reductions on derived expressions skip nulls too: arithmetic involving a
+nullable column returns a ``NullableExpr`` — a thin wrapper that remembers
+which rows are null — so ``sum``/``mean``/``min``/``max``/``std`` on it skip
+nulls (and deleted rows) exactly like the corresponding :meth:`Column.sum`
+etc. do on a real column::
 
-      t.price.sum()                              # skips nulls (real Column)
-      (t.price + 1).sum()                         # NaN if any null present
-      values = t.price[:]
-      (values[t.price.notnull()] + 1).sum()       # skips nulls, via NumPy
+      t.price.sum()          # skips nulls (real Column)
+      (t.price + 1).sum()    # skips nulls too (NullableExpr)
+      ((t.price + 1) * 2).mean()  # chaining keeps the null channel
+
+Only *nulls* are skipped: a NaN produced by the arithmetic itself (e.g.
+``0/0`` on non-null values) is a value, not a null, and poisons the
+reduction as usual. ``min()``/``max()`` raise ``ValueError`` when every
+value is null; ``sum()`` returns ``0.0`` and ``mean()``/``std()`` return
+NaN — the same conventions as the Column reductions.
 
 
 Attributes

--- a/doc/reference/ctable.rst
+++ b/doc/reference/ctable.rst
@@ -164,6 +164,56 @@ Sentinels are resolved in this order: explicit ``null_value`` in the schema,
 .. autofunction:: get_null_policy
 
 
+Nulls in expressions
+---------------------
+
+Arithmetic and comparisons built from :class:`Column` objects (``t.x + 1``,
+``t.x > 0``, ...) propagate nulls on nullable int/timestamp/bool columns
+without touching storage or the on-disk format — a sentinel is a validity
+bitmap encoded in-band, so propagation is purely a rewrite of the lazy
+expression:
+
+- **Arithmetic** (``+ - * / // % **``): the result is null (NaN) wherever
+  any nullable operand is null, promoting integer/timestamp results to
+  ``float64`` — the same promotion pandas' legacy (pre-nullable-dtype)
+  integer-null arithmetic performs. Non-nullable columns are unaffected and
+  pay no overhead::
+
+      (t.price + 1)          # NaN where price is null; float64 either way
+      (t.price + t.tax)      # NaN where either operand is null
+
+- **Comparisons** (``< <= > >= == !=``): SQL ``WHERE`` semantics — a null
+  never satisfies any comparison, including ``==``/``!=`` against the raw
+  sentinel value itself. Only :meth:`Column.is_null` /
+  :meth:`Column.notnull` test for nullness::
+
+      t[t.price < 0]         # excludes rows where price is null
+      t[t.price == -1]       # False for a null row even if -1 is the sentinel
+      t[t.price.is_null()]   # the only way to select null rows
+
+- **Boolean combinators** (``& | ~``) need no special handling: their
+  inputs are already-resolved comparison results with null-ness folded to
+  ``False``.
+
+Kleene three-valued logic (where ``null > 0`` evaluates to null rather than
+``False``) is intentionally out of scope — it needs a validity channel on
+boolean intermediates, i.e. masks, which CTable does not use.
+
+One limitation to be aware of: reductions called directly on a *derived*
+expression built from Column arithmetic (e.g. ``(t.price + 1).sum()``) do
+**not** skip the promoted NaNs — that expression is a plain
+:class:`~blosc2.LazyExpr` with no memory of which table column it came from,
+so its own ``.sum()``/``.mean()`` follow ordinary NumPy semantics (a NaN
+poisons the reduction). :meth:`Column.sum`/:meth:`~Column.mean` *do* skip
+nulls, because they always operate on a real, named column. To reduce a
+derived expression while skipping nulls, filter or mask first::
+
+      t.price.sum()                              # skips nulls (real Column)
+      (t.price + 1).sum()                         # NaN if any null present
+      values = t.price[:]
+      (values[t.price.notnull()] + 1).sum()       # skips nulls, via NumPy
+
+
 Attributes
 ----------
 
@@ -257,6 +307,7 @@ When a NumPy structured array is needed, materialize explicitly::
 .. autosummary::
 
     CTable.where
+    CTable.dropna
     CTable.view
     CTable.take
     CTable.select
@@ -268,6 +319,7 @@ When a NumPy structured array is needed, materialize explicitly::
     CTable.group_by
 
 .. automethod:: CTable.where
+.. automethod:: CTable.dropna
 .. automethod:: CTable.view
 .. automethod:: CTable.take
 .. automethod:: CTable.select
@@ -666,10 +718,12 @@ Nullable helpers
     Column.is_null
     Column.notnull
     Column.null_count
+    Column.fillna
 
 .. automethod:: Column.is_null
 .. automethod:: Column.notnull
 .. automethod:: Column.null_count
+.. automethod:: Column.fillna
 
 
 Unique values

--- a/doc/reference/ctable.rst
+++ b/doc/reference/ctable.rst
@@ -506,11 +506,23 @@ well as import/export paths for CSV, Arrow, and Parquet data.
     CTable.to_cframe
     CTable.to_csv
     CTable.to_arrow
+    CTable.__arrow_c_stream__
     CTable.to_parquet
     CTable.from_arrow
     CTable.from_parquet
     CTable.from_csv
     ctable_from_cframe
+
+CTable also implements the `Arrow PyCapsule interchange protocol
+<https://arrow.apache.org/docs/format/CDataInterface/PyCapsuleInterface.html>`_
+via :meth:`~blosc2.CTable.__arrow_c_stream__`, so pyarrow, DuckDB, Polars, and
+pandas >= 2.2 can consume a CTable directly as a stream of record batches
+(``pa.table(ct)``, ``duckdb.sql("SELECT ... FROM ct")``, ``pl.DataFrame(ct)``),
+and :meth:`~blosc2.CTable.from_arrow` accepts any object implementing that
+protocol on ingest. Strict zero-copy is not possible — the underlying data is
+compressed, so decompression is unavoidably a copy — but there is no
+intermediate materialization: batches are decompressed and handed to the
+consumer one at a time, so memory use stays bounded regardless of table size.
 
 .. automethod:: CTable.load
 .. automethod:: CTable.open
@@ -520,6 +532,7 @@ well as import/export paths for CSV, Arrow, and Parquet data.
 .. automethod:: CTable.to_cframe
 .. automethod:: CTable.to_csv
 .. automethod:: CTable.to_arrow
+.. automethod:: CTable.__arrow_c_stream__
 .. automethod:: CTable.to_parquet
 .. automethod:: CTable.from_arrow
 .. automethod:: CTable.from_parquet

--- a/plans/enhancing-ctable-phase2.md
+++ b/plans/enhancing-ctable-phase2.md
@@ -1,0 +1,639 @@
+# Enhancing CTable, phase 2: finishing the pandas-3 story
+
+**Status:** NOT STARTED (plan written 2026-07-16). Successor to
+`plans/enhancing-ctable.md` (phase 1, fully landed on branch
+`enhancing-ctable`: Arrow PyCapsule interchange, read-only views, the
+sentinel-null story including null propagation and `NullableExpr`
+reductions, UDF aggregations, `CTable.apply()`, and hash-based string-key
+groupby factorization).
+
+**Audience:** an implementing model/developer who has NOT read the discussion
+that produced this plan and has NOT read phase 1. Everything needed is in
+this file. When in doubt, prefer the laziest change that satisfies the
+acceptance criteria — do not add abstractions, protocols, or options this
+plan does not ask for.
+
+**Important practical notes:**
+
+- All line numbers below were verified on 2026-07-16. Lines WILL drift;
+  always locate code by the symbol names given, using grep, and treat line
+  numbers only as hints.
+- Run Python/pytest through the `blosc2` conda env:
+  `conda run -n blosc2 python -m pytest ...`. Never use the repo `.venv`
+  (stale).
+- Editing `.pyx` files does NOT trigger a rebuild in an editable install;
+  prefer pure-Python implementations. Every item in this plan is designed to
+  be pure Python.
+- **Docstrings and code comments must be self-contained.** Never reference
+  this plan, phase 1, or item labels ("P2", "Gap C2b") from source, tests,
+  or bench scripts — state the semantics directly. (Plan→code references,
+  like the symbol names in this file, are fine.) This is an explicit
+  maintainer rule; phase 1 had to be cleaned up retroactively for violating
+  it.
+- CTable tests live under `tests/ctable/`; match the style of neighboring
+  tests. The dev env has pandas 3.0.3, numpy 2.4.6, pyarrow, duckdb, and
+  polars installed, so `importorskip` tests run for real there.
+- The dev machine is an Apple-silicon Mac; benchmark numbers below were
+  measured there.
+
+---
+
+## Background
+
+The "What's new in pandas 3" post
+(https://datapythonista.me/blog/whats-new-in-pandas-3) highlights five
+themes. Verified state of CTable against them after phase 1:
+
+| pandas 3 theme | CTable state (verified 2026-07-16) |
+|---|---|
+| Copy-on-Write | **Done, differently and deliberately**: views are fully read-only; writes raise pointing at `take()`/`copy()`. Do not revisit. |
+| Arrow integration | **Done**: `CTable.__arrow_c_stream__` + capsule ingest in `from_arrow`; streaming, bounded memory. Do not revisit. |
+| `engine=` for UDFs | **Mostly done inside CTable** (`CTable.apply()`, groupby UDF aggs). The *outward* half — blosc2 as a pandas engine — exists (`blosc2.jit.__pandas_udf__`, `src/blosc2/proxy.py:907`) but is **broken against pandas 3.0.3 GA** (see P1, a verified live bug). |
+| NA semantics | **Done for sentinels**: null propagation in expressions, `fillna`/`dropna`, null-skipping reductions even on derived expressions (`NullableExpr` in `ctable.py`). Mask-based nullable dtypes remain (P5). |
+| `pd.col()` expressions / string dtype | **The two real gaps**: no chaining API and no unbound `col()` (P2); variable-length strings are second-class (P3). |
+
+Verified current-state facts the items below build on:
+
+- `blosc2.jit` is defined at `src/blosc2/proxy.py:754`; the pandas engine
+  adapter `class PandasUdfEngine` at `proxy.py:859`; wired via
+  `jit.__pandas_udf__ = PandasUdfEngine` at `proxy.py:907`. Existing tests:
+  `tests/test_pandas_udf_engine.py` (test_map, test_apply_1d,
+  test_apply_1d_with_args, test_apply_2d, test_apply_2d_by_column,
+  test_apply_2d_by_row) — these use mocks/older call conventions and pass,
+  yet the integration is broken against real pandas 3.0.3 (P1).
+- `Column` operator overloads route through `Column._unwrap_operand`,
+  `_null_aware_arith`, `_null_aware_compare` (`src/blosc2/ctable.py`, Column
+  class starts near line 1000; `NullableExpr` sits just above it near line
+  807). All null semantics live there — P2's `col()` must reuse them by
+  binding to `Column`, never reimplement them.
+- Chain-friendly methods that already exist on `CTable`: `head()`
+  (`ctable.py:5846`), `select(cols)` (`ctable.py:5918`), `sort_by()`,
+  `where()`, `__getitem__` (all return views). There is NO `CTable.assign`.
+  NOTE: `Column.assign(data)` exists (`ctable.py:2175`) and means "overwrite
+  values" — a different thing on a different class; do not confuse them.
+- `CTable.add_computed_column(name, expr, *, dtype=None, inputs=None)`
+  (`ctable.py:10014`) adds a virtual column backed by a LazyExpr — but it
+  MUTATES the table. Views share `_computed_cols`, `_schema` and `col_names`
+  with their parent (see `CTable._make_view`, grep for `def _make_view`).
+- Variable-length string columns exist as `blosc2.vlstring()`
+  (`src/blosc2/schema.py:762`, msgpack-serialized cells) but are
+  second-class, verified empirically: `group_by` on a vlstring key raises
+  `TypeError: Cannot group by variable-length/list column ... in Phase 1`
+  (`groupby.py:139`); comparisons raise `NotImplementedError` in
+  `Column._ensure_queryable` (`ctable.py:1715`); `sort_by` raises
+  (`ctable.py:10611`). Function-style ops (`blosc2.startswith(t.col, "x")`)
+  DO work. Fixed-width `blosc2.string(max_length=n)` is `U<n>` = UTF-32,
+  4 bytes/char pre-compression.
+- Groupby UDF aggregations (`groupby.py`: `_AggSpec` with `udf` field,
+  `_udf_value_partials`, the `udf` branches in `_merge_partials` /
+  `_final_rows`, `_infer_udf_spec`) execute a per-group Python loop after
+  concatenating per-chunk value arrays. `_factorize_keys`
+  (`groupby.py:~1520`) has a hash-based fast path for fixed-width string
+  keys (`_factorize_fixed_width_str`).
+- `blosc2.dsl_kernel` (`src/blosc2/dsl_kernel.py`: `class DSLKernel` at 495,
+  `def dsl_kernel` at 616) validates and transpiles a restricted Python
+  subset for *elementwise* kernels (miniexpr). It has NO reduction support
+  today.
+- numpy 2.4.6 provides `np.dtypes.StringDType` (checked
+  `hasattr(np.dtypes, 'StringDType')` → True) and the vectorized
+  `np.strings` module.
+
+## Execution order (by effort/payoff)
+
+1. **P1: fix + harden the pandas `engine=blosc2.jit` integration** — hours;
+   there is a verified crash against pandas 3.0.3 GA; highest
+   visibility-per-line-of-code. Do first.
+2. **P2: `CTable.assign()` chaining + unbound `blosc2.col()`** — days; the
+   last user-visible pandas-3 idiom gap; mostly reuses existing machinery.
+3. **P4: segmented acceleration for `dsl_kernel` UDF aggregations** — days;
+   benchmark-gated like phase 1's engine work was.
+4. **P3: first-class variable-length string columns** — the one real
+   project (multi-week); phased internally.
+5. **P5: mask-based nullable columns** — PARKED with start criteria; the
+   design is decided but nobody has hit the limitation yet.
+
+Each item is independent; land them as separate PRs in the order above.
+After each lands, append an "Implementation notes" subsection to its section
+here recording what actually happened.
+
+---
+
+## P1 — Fix and harden the pandas `engine=blosc2.jit` integration
+
+### Why first
+
+The pandas 3 launch post names Blosc as an example `engine=` provider —
+this is blosc2's shop window in front of every pandas 3 reader — and the
+integration is currently **broken against pandas 3.0.3**, verified in the
+dev env on 2026-07-16:
+
+```python
+import pandas as pd, blosc2  # pandas 3.0.3
+
+df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+df.apply(lambda x: x + 1, engine=blosc2.jit)
+# AttributeError: 'numpy.ndarray' object has no attribute 'values'
+```
+
+Also verified: `Series.apply` in pandas 3.0.3 does **not** accept `engine=`
+at all (it forwards unknown kwargs to the UDF — `engine='python'` fails the
+same way), so the engine surface is `DataFrame.apply` and `.map`;
+`Series.map`/`DataFrame.map` DO reach the engine (our `map` raises
+`NotImplementedError` by design today).
+
+### P1.1 Fix the crash
+
+The engine adapter is `PandasUdfEngine` (`src/blosc2/proxy.py:859`).
+`_ensure_numpy_data` handles the "maybe it is a Series/DataFrame" case with
+a `.values` fallback, but some path in `apply()` (around `proxy.py:883-907`,
+the axis-0/axis-1 branches with comments "pandas apply(axis=0) column-wise"
+etc.) accesses `.values` unconditionally on what pandas 3.0.3 now passes as
+a plain `numpy.ndarray`. Reproduce with the snippet above, read the
+traceback, and route every data access through `_ensure_numpy_data` (or an
+`isinstance(data, np.ndarray)` check). Do NOT guess the pandas-side calling
+convention from memory — pin it by running against the installed
+pandas 3.0.3 and reading
+`pandas.core.apply` (grep for `__pandas_udf__` in the installed pandas to
+see exactly what gets passed for each axis).
+
+### P1.2 Decide `map` (decision already made: implement it)
+
+pandas' `map` is elementwise; the blosc2 engine philosophy (see the
+docstring at `proxy.py:873-879`) is "the function is vectorized, call it
+once with the array". Apply the same rule to `map`: call the decorated
+function once with the full NumPy array and require it to be vectorized.
+That is what `engine=blosc2.jit` *means*; document it in the `map`
+docstring. Keep `skip_na` handling minimal: if pandas passes
+`skip_na=True`, raise `NotImplementedError` naming the limitation (do not
+silently ignore it).
+
+### P1.3 Tests
+
+Extend `tests/test_pandas_udf_engine.py`. The existing six tests exercise
+the adapter directly; ADD end-to-end tests that go through real pandas
+(guard with `pytest.importorskip("pandas")` and skip when
+`pd.__version__ < "3"`):
+
+1. `df.apply(f, engine=blosc2.jit)` for axis=0 and axis=1, values equal to
+   `df.apply(f)` without the engine.
+2. `df.apply` with extra `args=`/`**kwargs` forwarded to the UDF.
+3. `series.map(f, engine=blosc2.jit)` and `df.map(...)` equal the
+   engine-less result for a vectorized `f`.
+4. A non-numeric (object-dtype) frame produces the adapter's clear
+   ValueError, not a crash.
+
+### P1.4 Docs + bench
+
+- One documentation page/section "Using blosc2 as a pandas engine" with a
+  runnable example (`@blosc2.jit` on a vectorized function, then
+  `df.apply(f, engine=blosc2.jit)`), stating the vectorized-function
+  contract and the `Series.apply` limitation (pandas-side, not ours).
+- One micro-benchmark script under `bench/` comparing
+  `df.apply(f, engine=blosc2.jit)` vs plain `df.apply(f, axis=1)` on a
+  1e6-row frame — the point of the engine is to skip the per-row Python
+  loop, so the win should be large; record the number in the doc.
+
+Acceptance: the P1.3 tests green against pandas 3.0.3; no pandas version
+pin added to any requirements file.
+
+---
+
+## P2 — `CTable.assign()` chaining + unbound `blosc2.col()`
+
+### Goal
+
+Make the pandas-3 headline idiom work on CTable:
+
+```python
+import blosc2
+from blosc2 import col
+
+result = (
+    t.assign(profit=col("revenue") - col("cost"))[col("profit") > 0]
+    .sort_by("profit", ascending=False)
+    .head(10)
+)
+```
+
+Phase 1 parked unbound `col()` ("Gap E") with an explicit unpark trigger:
+"if CTable grows a chaining/pipeline API". This item IS that trigger —
+build the chaining method and `col()` together, in this order.
+
+### Decisions already made (do not re-litigate)
+
+1. `col()` is a **deferred name + operator replay**, nothing more. It must
+   reuse the `Column`/`NullableExpr` operator machinery by binding to
+   `table[name]` at evaluation time. Do NOT build a second expression
+   engine, an AST, or a query optimizer.
+2. `assign()` is **non-mutating** and returns a table sharing storage with
+   the original (a view with its own computed-column metadata). It must NOT
+   copy column data.
+3. Scope is `assign`, plus `col()` acceptance in the existing filter/index
+   entry points. NO `pipe()`, NO `col()` in `agg()`/groupby contexts, NO
+   `filter()` alias (indexing `t[...]` already is the filter API).
+
+### P2.1 `ColExpr` (the unbound expression)
+
+New class in `src/blosc2/ctable.py` (keep it in this file; it needs nothing
+private from elsewhere) plus a `col(name)` factory exported from the blosc2
+namespace (exports live in `src/blosc2/__init__.py`, the CTable block is at
+line ~635 — add `col` there).
+
+The laziest correct implementation is closure composition:
+
+```python
+class ColExpr:
+    """Unbound column expression: a recipe that, given a table, evaluates
+    against that table's columns.
+
+    ``blosc2.col("x") + 1`` builds a deferred computation; passing it to
+    ``CTable.assign()`` or using it to index/filter a table binds it,
+    replaying the operators on ``table["x"]`` — so all Column semantics
+    (null propagation, SQL comparison rules, dictionary/timestamp
+    handling) apply identically to the bound form ``t.x + 1``.
+    """
+
+    def __init__(self, bind, repr_str):
+        self._bind = bind  # callable: CTable -> Column/LazyExpr/NullableExpr
+        self._repr = repr_str
+
+    def __repr__(self):
+        return self._repr
+
+
+def col(name: str) -> ColExpr:
+    return ColExpr(lambda t: t[name], f"col({name!r})")
+```
+
+Operator overloads on `ColExpr` (`+ - * / // % ** & | ~ < <= > >= == !=`,
+plus the reflected variants and `__neg__`) each return a new `ColExpr`
+whose `_bind` binds the operands and applies the Python operator:
+
+```python
+def _binop(op, self, other, sym, reflected=False):
+    def bind(t):
+        left = self._bind(t)
+        right = other._bind(t) if isinstance(other, ColExpr) else other
+        return op(right, left) if reflected else op(left, right)
+
+    ...
+    return ColExpr(bind, ...)
+```
+
+Use the `operator` module; write the overloads mechanically (a small loop
+over `(dunder, operator_func, symbol)` triples installed with `setattr` is
+acceptable and shorter than 30 hand-written methods — but if the codebase
+style reviewer prefers explicit methods, explicit is fine too).
+
+Notes:
+
+- Method calls on col expressions (`col("x").sum()`, `.is_null()`,
+  `.fillna()`) are OUT OF SCOPE for this item. `__getattr__` on `ColExpr`
+  should raise a clear `AttributeError` explaining that only operators are
+  supported unbound and pointing at the bound form (`t.x.sum()`).
+- `col("nonexistent")` must fail at BIND time with the table's normal
+  unknown-column error — that is the documented behavior difference vs the
+  bound form (typo surfaces at evaluation, not construction). State this in
+  the `col()` docstring.
+
+### P2.2 Binding entry points
+
+Teach these `CTable` methods to accept `ColExpr` by binding first (a
+two-line prelude `if isinstance(key, ColExpr): key = key._bind(self)` — put
+it in a tiny helper):
+
+- `CTable.__getitem__` (boolean-filter branch) and `CTable.where()`.
+- `CTable.assign()` (below) — the main consumer.
+
+Grep for the `__getitem__`/`where` isinstance dispatch before editing;
+`where`'s signature already accepts
+`str | np.ndarray | blosc2.NDArray | blosc2.LazyExpr | blosc2.LazyUDF |
+Column` — add `ColExpr` to the annotation and docs.
+
+### P2.3 `CTable.assign(**named_exprs) -> CTable`
+
+Semantics: return a table that shares all storage with `self`, has all of
+`self`'s columns, plus one computed column per keyword argument. Accepted
+values per name: `ColExpr`, `Column`, `NullableExpr`, `blosc2.LazyExpr`,
+or a string expression (same forms `add_computed_column` accepts, plus
+`ColExpr`).
+
+Implementation sketch — study these two functions FIRST, then decide the
+exact mechanics:
+
+- `CTable._make_view(parent, new_valid_rows)` (grep in `ctable.py`): note
+  it shares `_computed_cols`, `_schema`, and `col_names` with the parent by
+  reference.
+- `CTable.add_computed_column` (`ctable.py:10014`): note what it records
+  (a `_computed_cols` entry + schema/col_names updates) and which of those
+  structures views share.
+
+The intended shape: `assign` builds a view over all live rows
+(`CTable._make_view(self, self._valid_rows)`), then gives that view its OWN
+copies of the metadata that `add_computed_column` would touch
+(`_computed_cols` dict copy, `col_names` list copy, and whatever schema
+container records computed columns — copy only what is mutated, keep
+everything else shared), then registers the computed column on the view
+only. Bind `ColExpr` values against **the view** so nested references to
+other assigned columns within one `assign()` call are NOT supported (state
+this; pandas requires chaining two `assign` calls for that too... actually
+pandas does support it — we deliberately do not; document the difference
+and the workaround: chain `.assign()` twice).
+
+**Escape valve:** if per-view metadata copies violate invariants you cannot
+untangle in a day (schema identity assumptions, persistence paths,
+`__arrow_c_stream__` of computed columns on views), fall back to v1
+semantics: `assign()` returns `self.take(<all live rows>)` — an independent
+in-memory table — plus `add_computed_column`. That copies data (document
+it loudly in the docstring) but is correct; record the fallback in the
+implementation notes so a later pass can revisit.
+
+### P2.4 Tests (new file `tests/ctable/test_col_expr.py`)
+
+1. `t.assign(profit=col("rev") - col("cost"))` — new column values correct;
+   original table unchanged (same `col_names`, no new column).
+2. The full chain from the Goal section end-to-end, values checked against
+   the same computation in pandas.
+3. `t[col("x") > 0]` equals `t[t.x > 0]` (row-identical view).
+4. Null semantics ride along: with a nullable column,
+   `t.assign(y=col("x") + 1)` produces nulls where `x` is null, and
+   `t[col("x") < 0]` excludes null rows — assert equality against the bound
+   forms, which are already tested.
+5. Reflected/scalar operands: `t.assign(y=100 - col("x"))`.
+6. `col("nope")` binds → clear unknown-column error; construction does not
+   raise.
+7. `col("x").sum()` raises the clear AttributeError from P2.1.
+8. Reusability: the same `expr = col("x") + 1` object applied to two
+   different tables gives each table's own values.
+9. A view chain: `t[t.x > 0].assign(...)` works (assign on a view).
+10. Writes through the assigned result are rejected like any view (reuse
+    the phase-1 read-only-view error).
+
+Acceptance: all green; `assign` copies no column data (assert via storage
+identity: the assigned table's `_cols` is the parent's `_cols` object —
+skip this assertion if the escape valve was taken).
+
+---
+
+## P3 — First-class variable-length string columns (the real project)
+
+### Goal
+
+pandas 3's headline dtype is an efficient variable-length string with NA
+semantics as the default string story. CTable's equivalent must make this
+work, at full speed, with bounded memory:
+
+```python
+@dataclass
+class Row:
+    name: str = blosc2.field(blosc2.utf8())  # new: varlen, first-class
+    ...
+
+
+t[t.name == "Paris"]  # vectorized comparison
+t.group_by("name").sum("x")  # groupby key
+t.sort_by("name")  # ordering
+```
+
+### Why the existing pieces don't cover it (verified)
+
+- `blosc2.string(max_length=n)` is fixed-width `U<n>` (UTF-32): 4 bytes per
+  character per row before compression, and 32-byte comparisons that made
+  string groupby 8x slower than pandas until phase 1's hash fix. Wrong
+  answer for long/variable text.
+- `blosc2.vlstring()` (`schema.py:762`) stores msgpack-serialized cells —
+  per-cell decode, no vectorized anything: `_ensure_queryable`
+  (`ctable.py:1715`) rejects comparisons, `groupby.py:139` rejects keys,
+  `ctable.py:10611` rejects sort. Retrofitting msgpack cells to be fast is
+  a dead end; do not try.
+- `blosc2.dictionary()` is the right tool for LOW-cardinality strings and
+  is already first-class. P3 is for high-cardinality/free-text columns.
+
+### Decisions already made
+
+1. **Storage layout: Arrow-style offsets + bytes.** Two companion NDArrays
+   per column in the store: `int64` offsets (length `n+1`) and a `uint8`
+   UTF-8 byte blob. Precedent for companion arrays already exists
+   (`valid_rows` in `ctable_storage.py`; the dictionary store; the phase-1
+   decision that companion arrays need no format bump). Chunk-aligned
+   access: reading rows `[a, b)` needs `offsets[a : b+1]` plus
+   `bytes[offsets[a] : offsets[b]]` — both are plain NDArray slice reads.
+2. **In-memory representation: `numpy.dtypes.StringDType`** (numpy ≥ 2.0;
+   the project already requires numpy 2.x in the dev env — verify the
+   package's minimum numpy before relying on it; if the floor is < 2.0,
+   gate the feature on the installed numpy and raise a clear error).
+   StringDType arrays support `==`, ordering, and the vectorized
+   `np.strings` functions.
+3. **Expression routing: chunked numpy, NOT numexpr.** numexpr/miniexpr
+   cannot evaluate StringDType. String comparisons must evaluate chunk by
+   chunk in numpy and produce the same physical-length boolean masks the
+   existing predicates produce. Look at how dictionary columns solved the
+   identical problem (`Column._dictionary_eq`, and grep how its
+   physical-slot predicates flow into `where()`) — mirror that pattern, do
+   not invent a new one.
+4. **Nulls: sentinel-based**, consistent with everything else — the null is
+   a reserved sentinel string (the existing machinery already supports
+   string sentinels; grep `test_null_value_string`). NOT a validity mask
+   (that is P5, and P3 must not depend on it).
+5. **Spec name `blosc2.utf8(nullable=..., null_value=...)`.** Keep
+   `string()` (fixed) and `vlstring()` (msgpack) untouched for backward
+   compatibility. Making `utf8` the default for `str` fields is explicitly
+   NOT part of this item — propose it separately once P3 has soaked.
+
+### Phasing (each lands separately, in order)
+
+**P3.a Storage + roundtrip.** Schema spec `utf8` in `schema.py` (mirror how
+`vlstring` declares itself, `schema.py:762`, but with
+`kind: "utf8"`); read/write paths in `ctable_storage.py` for the two
+companion arrays; `append`/`extend`/`__getitem__` on the column returning
+StringDType arrays; persistence roundtrip (`.b2z` save/open). In-place cell
+UPDATE of a varlen value changes the byte length — decision: rewriting a
+cell rewrites the column's tail (offsets shift). That is O(n) and fine for
+v1; `Column.__setitem__` on a utf8 column should work but the docstring
+must state the cost. Tests: roundtrip (ASCII, non-ASCII, empty strings,
+1-char, multi-KB values), append/extend, setitem, persistence, repr.
+
+**P3.b Arrow interop.** `iter_arrow_batches` exports utf8 columns as
+`pa.string()` (or `pa.large_string()` when offsets exceed int32 — just
+always use `large_string` and be done); `from_arrow` maps incoming
+`string`/`large_string` columns to `utf8` specs (today they land as
+fixed-width or dictionary — check `_auto_null_sentinel` /
+`from_arrow`'s type dispatch before changing it; keep the old mapping
+available via the existing import options if one exists). Null cells map
+sentinel↔validity like every other dtype. Tests: `pa.table(ct)` roundtrip,
+duckdb query on a utf8 column, `from_arrow(pa_table)` ingest.
+
+**P3.c Filters and expressions.** Carve utf8 out of the
+`_ensure_queryable` rejection (`ctable.py:1715`) for comparisons only;
+implement `==`, `!=`, `<`, `<=`, `>`, `>=` against scalars and other utf8
+columns via the chunked-numpy predicate path from decision 3, with the
+phase-1 SQL null rule (a null never satisfies any comparison; grep
+`_null_aware_compare` for the semantics to match). `blosc2.startswith`-
+style function ops already work — add tests pinning them. Tests: filter
+correctness incl. null rows, `t[t.name == "x"]` on views, comparison with
+non-string scalar raises clearly.
+
+**P3.d Groupby keys.** Replace the `groupby.py:139` rejection for utf8
+keys. Factorization: read the chunk as offsets+bytes and hash rows
+vectorized — same trick as phase 1's `_factorize_fixed_width_str`
+(`groupby.py`, study it first) but over variable-length bytes: a vectorized
+loop over the (few) distinct byte-lengths, or `np.frombuffer`-based chunked
+mixing; verify + `np.unique`-on-StringDType fallback for collisions,
+identical output contract. Benchmark against dictionary-key groupby on the
+same data (bench/ctable/bench_groupby_keys.py — extend it); target: within
+3x of the dictionary path for 1e7 rows/low cardinality. If the vectorized
+hash proves hard, the honest fallback is `np.unique` on the StringDType
+chunk (correct, slower) — land correctness first, speed second.
+
+**P3.e Sort.** Lift the `ctable.py:10611` rejection: `sort_by` on utf8 uses
+`np.argsort` on the StringDType array (chunked merge if the existing sort
+machinery is chunked — study `sort_by`'s path first). Null ordering must
+match the existing convention (nulls last; grep `test_sort_nulls_last`).
+
+**Out of scope for P3:** making `utf8` the `str`-field default; `.str`
+accessor namespaces; regex operations beyond what `np.strings` gives;
+string interning/dedup (that's `dictionary()`).
+
+Acceptance for the item overall: the three Goal-section lines work, the
+groupby bench number is recorded, and `vlstring`/`string` behavior is
+byte-for-byte unchanged.
+
+---
+
+## P4 — Segmented acceleration for `dsl_kernel` UDF aggregations
+
+### Goal
+
+`g.agg(rng=("sales", my_udf))` runs a per-group Python loop (correct
+baseline from phase 1). For high cardinality (say 100k groups) that loop
+dominates. When the UDF is a `blosc2.dsl_kernel`-decorated function built
+from whitelisted reductions, execute it for ALL groups at once with
+segmented numpy — no per-group Python.
+
+### Decisions already made
+
+1. **Mechanism: `np.ufunc.reduceat` over group-sorted values.** The groupby
+   UDF path already produces, per output column, the concatenated non-null
+   values of every group in group order (see `_udf_value_partials` and the
+   `udf` branch of `_final_rows` in `groupby.py` — study both first). With
+   `boundaries` = the start index of each group in that concatenation:
+   - `a.sum()`  → `np.add.reduceat(vals, boundaries)`
+   - `a.min()`  → `np.minimum.reduceat(vals, boundaries)`
+   - `a.max()`  → `np.maximum.reduceat(vals, boundaries)`
+   - `a.mean()` → `np.add.reduceat(vals, boundaries) / counts`
+   - `len(a)`   → `counts` (= `np.diff(boundaries, append=len(vals))`)
+   Scalar arithmetic combining these (`a.max() - a.min()`, `a.sum() / len(a)`,
+   constants) is then ordinary vectorized numpy over the groups axis.
+   Empty groups never appear in this path (phase 1 already routes
+   zero-non-null groups to a null result before the UDF is consulted —
+   verify that invariant holds and add `boundaries` handling consistent
+   with it).
+2. **Recognition: AST inspection of the `DSLKernel` only.** A UDF qualifies
+   iff it is `dsl_kernel`-decorated (identity: `isinstance(op, DSLKernel)`,
+   import from `blosc2.dsl_kernel`), takes exactly one array argument, and
+   its body is a single expression tree whose only non-scalar operations
+   are the five whitelisted calls above applied directly to the argument
+   (no chained/nested reductions like `(a - a.mean()).sum()` — that
+   requires broadcasting values against per-group scalars; OUT OF SCOPE,
+   explicitly). `DSLKernel` already retains the function source/AST for
+   transpilation (grep `getsource`/`ast` in `dsl_kernel.py`) — reuse that;
+   do not re-parse from scratch if the parsed form is available.
+3. **Fallback is the law.** Anything unrecognized — plain callables,
+   multi-statement kernels, unsupported calls — silently uses the existing
+   per-group loop. The segmented path must produce results the loop path
+   would produce, bit-for-bit for min/max/len and to float tolerance for
+   sum/mean. NO new user-facing API, NO new parameter: recognition is
+   automatic when the user already passed a `dsl_kernel` UDF.
+4. **Benchmark gate (same rule as phase 1):** 1e6 rows, 100k groups, UDF
+   `a.max() - a.min()`. If the segmented path is not ≥5x faster than the
+   Python loop, do not merge the dispatch (it will be — reduceat vs 100k
+   Python calls — but measure, and record the number in the implementation
+   notes). Extend `bench/ctable/bench_groupby_keys.py` or add a sibling
+   script.
+
+### Implementation pointers
+
+- The place to intercept is `_final_rows`'s `udf` branch (`groupby.py`,
+  grep `spec.op == "udf"`): today it concatenates chunks and calls the UDF
+  per group inside the row loop. Restructure: BEFORE the row loop, for each
+  UDF spec whose callable qualifies, compute all group results in one
+  segmented pass into an array aligned with the (already ordered) group
+  keys; the row loop then just reads `results[i]` instead of calling the
+  UDF. The per-group chunks lists in `_AggState.value` give you the
+  concatenation; keys iterate in a deterministic order there — reuse that
+  order for `boundaries`.
+- dtype inference and the explicit-dtype tuple element must behave
+  identically in both paths (`_infer_udf_spec` runs on the collected
+  results either way).
+- Error semantics: the segmented path cannot raise per-group with the group
+  key named (phase 1's loop does). Acceptable: whitelisted reductions on
+  non-empty float/int arrays cannot raise. Assert the input dtype kind is
+  numeric before taking the segmented path; otherwise fall back.
+
+### Tests
+
+1. For each whitelisted reduction and two composites
+   (`a.max() - a.min()`, `a.sum() / len(a)`): `dsl_kernel` UDF result equals
+   the same UDF passed as a plain lambda (loop path), on data with nulls,
+   multiple chunks (`chunk_size=2`), and ≥3 groups.
+2. A `dsl_kernel` UDF using an unsupported construct falls back to the loop
+   (assert via monkeypatching the segmented entry point with a spy, or by
+   a counter on the loop path — keep it simple).
+3. High-cardinality smoke test: 10k groups, values equal between paths.
+4. The benchmark script, recorded but not part of CI.
+
+---
+
+## P5 — Mask-based nullable columns: PARKED (design recorded, do not build yet)
+
+Sentinels cannot represent: nullable bool with all 256 byte values in use
+(current nullable bool reserves 255), full-range `uint8`/`int8`, and any
+dtype where reserving a value is unacceptable. The agreed design, recorded
+in phase 1 and restated here so it survives:
+
+- A hidden companion boolean validity array per column — just another key
+  in the `.b2z` store, exactly like `valid_rows`
+  (`ctable_storage.py:130-139`) and P3's offsets array. **No .b2z or
+  C-Blosc2 format change.**
+- A per-column schema marker (e.g. `null_mask: true` in the column's
+  metadata dict) — NOT a global `/_meta` `version` bump, so only tables
+  actually using masks are unreadable by old readers, failing cleanly at
+  schema load.
+- Integration points when built: `Column.is_null()` reads the mask;
+  write paths (`append`/`extend`/`__setitem__`/`assign`) maintain it;
+  `_nonnull_chunks` and the lazy reduction masks consult it; groupby null
+  handling; Arrow import/export maps mask↔validity directly (cheaper than
+  sentinel conversion); `fillna`/`dropna`.
+
+**Criteria to unpark** (any one): a user asks for nullable bool without the
+255 reservation; a user needs full-range small ints with nulls; Arrow
+ingest of a type whose sentinel choice is provably lossy. Until then, build
+nothing — every phase-1 and phase-2 feature works on sentinels.
+
+---
+
+## Cross-cutting rules for the implementer
+
+1. **Verify before building.** This codebase has been ahead of every
+   analysis so far (phase 1's notes record it repeatedly). Before
+   implementing any sub-item, grep for it; if it exists, write the test
+   that proves it and move on.
+2. **One PR per item**, in the P1 → P2 → P4 → P3 → P5 order. P5: no PR.
+3. **No new dependencies.** pandas/pyarrow/duckdb/polars appear only in
+   tests via `importorskip`; numpy StringDType is stdlib-of-the-project.
+4. **Benchmark gates are real.** P4 (and P3.d) must not merge a "fast path"
+   that the recorded benchmark shows is not fast. Phase 1 rejected its own
+   JIT engine on exactly this rule and was right to.
+5. **Error messages name the escape hatch** (the view-write error pointing
+   at `take()`/`copy()` is the house style).
+6. **Docstrings are self-contained** — no references to this plan or its
+   item labels anywhere in `src/`, `tests/`, or `bench/`.
+7. **Docstrings in the existing style** (NumPy-doc with Examples sections,
+   as throughout `ctable.py`).
+8. Run the CTable subset with
+   `conda run -n blosc2 python -m pytest tests/ctable -q`; run
+   `tests/ndarray` too when touching anything under `src/blosc2/` outside
+   `ctable.py`/`groupby.py`.
+9. After landing an item, append an "Implementation notes" subsection to
+   its section in THIS file: what landed, what deviated and why, measured
+   numbers, and commit hashes.

--- a/plans/enhancing-ctable.md
+++ b/plans/enhancing-ctable.md
@@ -1,0 +1,686 @@
+# Enhancing CTable: closing the pandas-3-inspired gaps
+
+**Status:** Gaps A, B, C, D implemented and committed on branch
+`enhancing-ctable` (2026-07-15). Gap E remains parked (see its section).
+See "Implementation notes" at the end of each gap's section below for what
+landed, what deviated from the original plan, and why.
+**Audience:** an implementing model/developer who has NOT read the discussion that
+produced this plan. Everything needed is in this file. When in doubt, prefer the
+laziest change that satisfies the acceptance criteria — do not add abstractions,
+protocols, or options this plan does not ask for.
+
+**Important practical notes:**
+
+- All line numbers below were verified against `src/blosc2/ctable.py`,
+  `src/blosc2/groupby.py`, `src/blosc2/ctable_storage.py` and
+  `src/blosc2/lazyexpr.py` on 2026-07-15. Lines WILL drift; always locate code by
+  the symbol names given, using grep, and treat line numbers only as hints.
+- Run Python/pytest through the `blosc2` conda env:
+  `conda run -n blosc2 python -m pytest ...`. Never use the repo `.venv` (stale).
+- Editing `.pyx` files does NOT trigger a rebuild in an editable install; prefer
+  pure-Python implementations (everything in this plan is pure Python).
+- Existing CTable tests live under `tests/`; find them with
+  `grep -rl "CTable" tests/ | head`. Match the style of neighboring tests.
+
+---
+
+## Background
+
+The "What's new in pandas 3" post (https://datapythonista.me/blog/whats-new-in-pandas-3)
+highlights five features: copy-on-write, the `pd.col()` expression API, pluggable
+accelerated UDF engines (`engine=` in `.apply()` — blosc2's `jit` decorator,
+defined in `src/blosc2/proxy.py` as `def jit(...)`, is one such engine for
+pandas), a new string dtype with NA semantics, and pragmatic Arrow integration.
+
+We analyzed which equivalents CTable is missing. The investigation found CTable
+is much further along than expected, which reshaped the plan. Summary of the
+**verified current state**:
+
+| Area | State |
+|---|---|
+| Column expressions | `ct.x` returns `Column` with full operator overloading (`Column.__add__` etc., around `ctable.py:1586`) building lazy expressions. Bound-only; no unbound `col()`. |
+| Groupby | `CTable.group_by()` → `CTableGroupBy` with `size/count/sum/mean/min/max/argmin/argmax/agg`. `agg()` **rejects callables by design** (docstring: "not a UDF mechanism"). `engine=` parameter exists but only `"auto"` is accepted (`ctable.py`, in `group_by()`: `raise ValueError("Only engine='auto' is supported for group_by() in Phase 1")`). |
+| UDF machinery | `blosc2.lazyudf` with `jit_backend` in `{None, "tcc", "cc", "js"}` (see `_apply_jit_backend_pragma` in `lazyexpr.py`). Wired into CTable computed/generated columns, NOT into groupby, and there is no `CTable.apply()`. |
+| Nulls | Sentinel-based and **already deep**: `NullPolicy` (`ctable.py:93`), per-dtype extreme sentinels (`INT64_MIN` for timestamps, NaN for floats), `Column.is_null()/notnull()/null_count()/_nonnull_chunks()`, reductions skip nulls (`sum/mean/min/max/std` docstrings all say "Null sentinel values are skipped"), groupby skips/handles null keys (`dropna=`) and null values (`groupby.py` `_execute`, around lines 451–537), Arrow export already converts sentinels → validity bitmaps (`iter_arrow_batches`, masks around `ctable.py:6131–6170`), Arrow import maps nulls → sentinels. No mask-based storage; nullable bool and saturated small ints not representable. No `fillna()`/`dropna()` methods. Null propagation through lazy expressions is NOT handled (`t.x + 1` on a sentinel yields garbage, not null). |
+| Views / CoW | `t[t.price > 100]`, `t[10:20]`, `t.sort_by(...)` return **views** sharing the base's storage (see `CTable.view()` at `ctable.py:5433` and `_make_view`). Ten structural mutations already raise on views ("Cannot delete rows from a view.", "Cannot extend view.", etc.). But `Column.__setitem__` (`ctable.py:1123`) checks only `_read_only` and `is_computed`, NOT `base` — so cell writes through a view silently modify the base table. |
+| Arrow interop | `iter_arrow_batches(columns=, batch_size=, include_computed=)` (`ctable.py:6083`) yields bounded-size `pyarrow.RecordBatch`es with a proper schema (`_arrow_schema_for_columns`). `to_arrow()` (`ctable.py:6198`) materializes all batches. `from_arrow(schema, batches, ...)` (`ctable.py:7038`) ingests a batch stream. `to_pandas()`, `to_parquet()` exist. **No `__arrow_c_stream__`** (Arrow PyCapsule protocol), no acceptance of capsule producers on ingest. |
+| Persistence format | CTable persists into a key/value store (.b2z TreeStore) that is schema-agnostic: per-column arrays under names plus a `/_meta` SChunk holding `{kind, version: 1, schema}` (`ctable_storage.py`, `save_schema`, around lines 414 and 796–799). The store ALREADY persists a boolean mask today: `create_valid_rows`/`open_valid_rows` (`ctable_storage.py:130–139`). Conclusion reached: **no .b2z/C-Blosc2 format bump is ever needed for null masks** — only CTable-schema-level flags. |
+
+## Execution order (by effort/payoff)
+
+1. **Gap A (was #5): Arrow PyCapsule protocol** — days of work, headline payoff. Do first. **DONE.**
+2. **Gap B (was #4): read-only view semantics** — hours of work. **DONE.**
+3. **Gap C (was #3): finish sentinel-null story** — incremental: `fillna`/`dropna` and an audit (C1–C2), plus one design-decided medium piece, sentinel-based null propagation in expressions (C2b). **DONE** (C1, C2, C2b); **C3 skipped** per its own escape valve.
+4. **Gap D (was #2): UDF aggregations + engine dispatch** — the one real project; phased. **D1/D2/D3 dispatch-and-UDF plumbing DONE; the actual JIT execution path (the accelerated half of D1) was not attempted** — see Gap D's implementation notes.
+5. **Gap E (was #1): unbound `col()`** — PARKED. Do not implement. Criteria to unpark at the end.
+
+Each gap below is independent; land them as separate PRs in the order above.
+Each gap's section ends with an "Implementation notes" subsection recording
+what actually landed, once implemented.
+
+---
+
+## Gap A — Arrow PyCapsule interchange (`__arrow_c_stream__`)
+
+### Goal
+
+Make CTable a first-class citizen of the Arrow PyCapsule ecosystem so that
+DuckDB, Polars, pandas ≥ 2.2 / pandas 3, and pyarrow can consume a CTable
+directly and streamingly, and so CTable can ingest from any capsule producer.
+
+Payoff example that must work when done:
+
+```python
+import duckdb, blosc2
+
+t = blosc2.CTable.open("big_table.b2z")  # 100 GB on disk, compressed
+duckdb.sql("SELECT city, avg(price) FROM t GROUP BY city").show()
+# ^ streams record batches; bounded memory; no import/materialization step
+```
+
+### A1. Export: `CTable.__arrow_c_stream__`
+
+Add to `CTable` (near `to_arrow`, which is at `ctable.py:6198`):
+
+```python
+def __arrow_c_stream__(self, requested_schema=None):
+    """Arrow PyCapsule protocol: export live rows as a stream of record batches.
+
+    Lets Arrow-native consumers (pyarrow, DuckDB, Polars, pandas) read this
+    table directly, pulling decompressed batches lazily with bounded memory.
+    """
+    pa = self._require_pyarrow("__arrow_c_stream__")
+    reader = pa.RecordBatchReader.from_batches(
+        self._arrow_schema_for_columns(), self.iter_arrow_batches()
+    )
+    return reader.__arrow_c_stream__(requested_schema)
+```
+
+Notes for the implementer:
+
+- `_require_pyarrow` is the existing helper used by `to_arrow()`; reuse it with
+  the message string `"__arrow_c_stream__"`.
+- Do NOT implement `requested_schema` negotiation yourself — pass it through to
+  the pyarrow reader as shown; pyarrow handles cast-or-error semantics.
+- Do NOT add a `Column.__arrow_c_array__` / per-column protocol. Explicitly out
+  of scope (deferred until someone asks).
+- Do NOT implement the legacy `__dataframe__` interchange protocol. The
+  ecosystem has moved to PyCapsule; building `__dataframe__` now is building
+  for the past. This was an explicit decision.
+- `iter_arrow_batches` already handles: column selection, computed columns,
+  dictionary columns (exported as `pa.DictionaryArray` with a null-code mask),
+  varlen/list columns, ndarray columns, and sentinel→validity-bitmap conversion.
+  Trust it; do not duplicate any of that logic.
+- Also add `__arrow_c_stream__` to whatever view/selection objects users get
+  from `t[...]` IF those are plain `CTable` instances with `base` set (they
+  are — views are CTables), in which case the single method on `CTable` already
+  covers views, sorted views, and column projections. Verify with a test on a
+  filtered view.
+
+### A2. Ingest: accept capsule producers in `from_arrow`
+
+`CTable.from_arrow` (`ctable.py:7038`) currently has signature
+`from_arrow(cls, schema, batches, *, urlpath=None, mode="w", ...)`.
+
+Change: allow the first positional argument to be **any object implementing
+`__arrow_c_stream__`** (a Polars DataFrame, a DuckDB result, a pyarrow Table or
+RecordBatchReader, another CTable). Detection and unwrapping:
+
+```python
+@classmethod
+def from_arrow(cls, schema, batches=None, **kwargs):
+    if hasattr(schema, "__arrow_c_stream__") and batches is None:
+        pa = cls._require_pyarrow("from_arrow()")
+        reader = pa.RecordBatchReader.from_stream(schema)
+        schema, batches = reader.schema, reader
+    # ... existing body unchanged
+```
+
+Notes:
+
+- Keep the old two-argument form working unchanged (backward compat).
+- `pa.RecordBatchReader.from_stream(obj)` is the canonical way to open a capsule
+  producer (pyarrow ≥ 14). If the installed pyarrow is older and lacks
+  `from_stream`, raise a clear `RuntimeError` naming the needed pyarrow version.
+- Iterating a `RecordBatchReader` yields `RecordBatch`es, which is exactly what
+  the existing body consumes — verify by reading `_from_arrow_impl` / the loop
+  inside `from_arrow` before touching anything.
+- The streaming property matters: `CTable.from_arrow(duckdb_result,
+  urlpath="out.b2z")` must be able to compress a bigger-than-RAM result to disk
+  without materializing it. Do not call `pa.table(obj)` (that materializes);
+  use the reader.
+
+### A3. Docs framing (one paragraph, wherever `to_arrow` is documented)
+
+Be honest about "zero-copy": strict zero-copy is impossible for blosc2 because
+the data is compressed — decompression *is* the copy. The claim to make:
+**"zero intermediate materialization, streaming, bounded memory."** Consumers
+pull batches; only one batch is decompressed at a time.
+
+### A4. Tests (add to the existing CTable Arrow test module)
+
+All tests must `pytest.importorskip("pyarrow")`.
+
+1. `pa.table(ct)` equals `ct.to_arrow()` (schema and values), for a table
+   containing at least: int64, float64 with NaN, nullable int (sentinel),
+   string/varlen, dictionary, and a bool column.
+2. Same via a filtered view: `pa.table(ct[ct.x > 0])` matches the filtered rows.
+3. Nulls survive: a nullable int column with sentinel values round-trips to
+   Arrow nulls through the capsule path (not just through `to_arrow()`).
+4. Ingest: `CTable.from_arrow(pa_table)` (single-arg capsule form) equals the
+   old `from_arrow(pa_table.schema, pa_table.to_batches())` result.
+5. If `duckdb` is installed (importorskip): `duckdb.sql("SELECT count(*) FROM
+   t")` against a CTable local variable returns the live row count. Mark it
+   optional; do not add duckdb to any requirements file.
+6. If `polars` is installed (importorskip): `pl.DataFrame(ct)` has the right
+   shape and column names.
+
+Acceptance: all above green; no changes to `iter_arrow_batches` internals
+needed (if you find you need one, stop and reconsider — you are probably
+reimplementing something it already does).
+
+### Implementation notes (2026-07-15)
+
+**Done as planned.** `CTable.__arrow_c_stream__` added next to `to_arrow()`;
+`from_arrow` now accepts a single capsule-producer argument (detects
+`__arrow_c_stream__`, unwraps via `pa.RecordBatchReader.from_stream`) while
+keeping the old `(schema, batches)` form. No changes to `iter_arrow_batches`
+internals were needed. All A4 tests implemented in
+`tests/ctable/test_arrow_interop.py` (mixed dtypes incl. nullable int/dict/bool,
+filtered view, null survival, single-arg ingest, duckdb/polars — both were
+installed in the dev env, so those tests ran for real rather than skipping).
+Commit: `ee827413` "Add Arrow PyCapsule interchange protocol to CTable (Gap A)".
+
+---
+
+## Gap B — Deterministic view semantics (the CoW question)
+
+### Decision already made (do not re-litigate)
+
+pandas 3 ships copy-on-write because 15 years of user code writes through views
+and pandas cannot forbid it. CTable has no such legacy, so it can adopt the
+clean rule directly:
+
+> **Views are fully read-only.** Any attempt to write cell values through a
+> view raises, with an error message pointing at `take()` (which already
+> exists at `ctable.py:5476` and returns a compact, independent, writable
+> table) and `copy()` (`ctable.py:10735`).
+
+Real deferred-copy CoW (write triggers a private chunk copy) was considered and
+rejected: with compressed chunked storage a chunk copy means
+decompress-modify-recompress plus private-chunk bookkeeping, and it is
+ill-defined for on-disk tables. Do NOT build it.
+
+### The bug being fixed
+
+Today this silently corrupts the base table:
+
+```python
+v = t[t.price > 100]  # view, shares storage with t
+v.price[0] = 0  # writes into t's physical storage; no warning
+```
+
+Structural mutations on views already raise (grep `"Cannot"` + `"view"` in
+`ctable.py` — ten guards exist, e.g. "Cannot delete rows from a view."). Cell
+writes are the one unguarded path.
+
+### B1. Implementation
+
+In `Column.__setitem__` (`ctable.py:1123`), immediately after the existing
+`_read_only` guard:
+
+```python
+if self._table.base is not None:
+    raise ValueError(
+        "Cannot assign values through a view. Use .take(indices) or .copy() "
+        "to get an independent, writable table first."
+    )
+```
+
+Then audit for OTHER value-write paths that must get the same guard:
+
+- Any `CTable.__setitem__` row-assignment path (grep `def __setitem__` in
+  `ctable.py`; there is one on CTable around line 1922 and possibly others) —
+  check whether each already routes through `Column.__setitem__` or guards
+  `base` itself; add the guard where missing.
+- `ColumnViewIndexer` (`ctable.py:496`) if it exposes writes.
+- Any `update_row`/`upsert`-style method (grep `def update` in `ctable.py`).
+
+Do NOT touch the structural guards; they are already correct. Do NOT make
+views read-only via `_read_only = True` (that flag means "opened with
+mode='r'" and produces the wrong error message; keep the two conditions
+distinct).
+
+### B2. Documentation
+
+One paragraph in the CTable docs (wherever views/`__getitem__` are documented,
+see the `__getitem__` docstring around `ctable.py:2762` which lists the view
+forms): state the rule — *"indexing returns lightweight views that share
+storage with the base table; views are read-only; use `take()` or `copy()` for
+an independent writable table; mutating the base while holding a view leaves
+the view's row mask frozen at creation time (it may go stale)."* That last
+clause documents existing behavior; changing it is out of scope.
+
+### B3. Tests
+
+1. `v = t[t.x > 0]; v.x[0] = 99` raises `ValueError` mentioning "view"; base
+   unchanged.
+2. Same for slice views `t[2:5]`, gathered-row views (integer-array indexing),
+   sorted views (`sort_by`), and column-projection views (`t[["a", "b"]]`),
+   whichever of those return `base is not None` tables.
+3. `w = v.take([0, 1]); w.x[0] = 99` succeeds; `t` and `v` unchanged.
+4. Boolean-mask and fancy-index assignment forms of `Column.__setitem__` also
+   raise on views (the guard is before the key dispatch, so one test per form
+   is enough).
+5. Writes on the BASE while views exist still work (only views are restricted).
+
+Effort estimate: hours. If it grows beyond ~50 lines of non-test code, stop —
+something is being over-built.
+
+### Implementation notes (2026-07-15)
+
+**Done as planned.** Guard added to both `Column.__setitem__` and
+`Column.assign()` (assign was a second unguarded write path found during
+implementation, not called out explicitly in the plan — same `base is not
+None` check, same error message pointing at `take()`/`copy()`).
+`CTable.__setitem__` already had the guard, as the plan expected. Updated
+`CTable.__getitem__`'s docstring with the view-mutability paragraph from B2.
+Two pre-existing tests in `test_schema_mutations.py`
+(`test_view_allows_column_setitem`, `test_view_allows_assign`) asserted the
+OLD write-through-to-parent behavior and were rewritten to expect
+`ValueError` instead; a third (`test_bool_mask_through_view`) had the same
+issue. All B3 test forms implemented (slice/gathered-row/sorted/
+column-projection views, boolean-mask and fancy-index forms, `take()`
+escape hatch, base-still-writable). Non-test diff stayed well under 50
+lines. Commit: `02eaa33c` "Make CTable views read-only for value writes
+(Gap B)".
+
+---
+
+## Gap C — Finish the sentinel-null story (no masks, no format bump)
+
+### Decisions already made (do not re-litigate)
+
+1. **Stay on sentinels.** They are already the architecture (extreme values:
+   `INT64_MIN` for timestamps — same as NumPy NaT and R's integer NA; NaN for
+   floats; `iinfo` extremes for ints; dictionary columns reserve code
+   `INT32_MIN` as absent, see `ctable.py:11645`). Collisions are theoretical
+   for float/timestamp/int64.
+2. **Mask-based nullable columns are DEFERRED**, not designed here. When they
+   ever become necessary (nullable bool, saturated uint8), the agreed shape is:
+   a hidden companion boolean array per column (just another key in the store,
+   like `valid_rows` already is — `ctable_storage.py:130`) plus a per-column
+   schema flag. Explicitly NOT a global `/_meta` `version` bump (that would
+   break old readers for ALL new tables); a per-column marker makes only
+   mask-using tables unreadable by old versions, failing cleanly at schema
+   load. **No .b2z or C-Blosc2 format change is involved either way.** Record
+   this rationale in a code comment or doc when masks are eventually built —
+   for now, build nothing.
+3. Most of the sentinel story is ALREADY DONE (see the state table at the top:
+   null-aware reductions, groupby, Arrow import AND export with validity
+   bitmaps, `is_null`/`notnull`/`null_count`). The remaining work is the short
+   list below — verify each is really missing before writing code, since this
+   codebase repeatedly turned out to be ahead of expectations.
+
+### C1. `fillna()` and `dropna()` convenience methods (verified missing)
+
+`grep "def fillna\|def dropna" src/blosc2/ctable.py` → no hits (verified
+2026-07-15).
+
+- `Column.fillna(value)` → returns a NumPy array (or lazy expression) of live
+  values with sentinels replaced by `value`. Lazy path: build on the existing
+  machinery — `blosc2.where(<null mask>, value, col)`; the null mask already
+  exists as `Column.is_null()` (materialized) — check whether a lazy variant is
+  cheap via the column's `null_value` and a `col == sentinel` lazyexpr; if not,
+  the materialized form is acceptable for a first version.
+- `CTable.dropna(subset: list[str] | None = None)` → returns a **view**
+  (consistent with Gap B: views are read-only) excluding rows where any column
+  in *subset* (default: all nullable columns) is null. Implement as: AND
+  together `~col.is_null()` masks and call the existing `CTable.view()`
+  (`ctable.py:5433`).
+- Follow pandas naming/semantics for argument names, but do NOT add pandas'
+  full parameter surface (`how=`, `thresh=`, `axis=`, `inplace=`) — subset only.
+
+### C2. Null behavior in lazy expressions — AUDIT first, then document
+
+Verified real hole: for a nullable int column, `t.x + 1` operates on raw
+sentinel values (`INT64_MIN + 1` = garbage that is no longer the sentinel).
+Floats are fine (NaN propagates arithmetically); ints/timestamps are not.
+Comparisons are also wrong for nulls: `INT64_MIN > 0` is False (conveniently
+excluding nulls from greater-than filters) but `INT64_MIN < 0` is True
+(wrongly *including* nulls in less-than filters).
+
+C2 is the prerequisite audit for C2b, and lands first:
+
+1. A short test file pinning CURRENT behavior (before C2b changes it): what
+   `(t.x + 1)` produces for null entries, what comparisons (`t.x > 0`,
+   `t.x < 0`) produce for nulls, and what `where()` filters do. These tests
+   become the "before" reference that C2b updates.
+2. A "Nulls in expressions" docs section, written to describe the C2b
+   semantics once C2b lands (see below). If C2b is deferred for any reason,
+   the section instead documents current behavior: arithmetic on nullable
+   int/timestamp columns treats sentinels as ordinary values; mask or fill
+   first (`t.x.fillna(...)` from C1, or filter with `t.x.notnull()`).
+
+### C2b. Sentinel-based null propagation in expressions (design decided)
+
+**Decision:** implement null propagation on the sentinel representation. This
+does NOT require masks and does NOT touch storage or formats — a sentinel is a
+validity bitmap encoded in-band, so propagation is an expression-rewrite layer.
+
+**Semantics to implement (decided; do not redesign):**
+
+- **Arithmetic** (`+ - * / // % **`) where any operand is a nullable
+  int/timestamp column: the result is null wherever any nullable operand is
+  null. Implementation shape: rewrite the expression to
+  `where(is_null(x) | is_null(y), s_out, x <op> y)` — union the operands'
+  null-ness, evaluate on raw values, patch null positions to the output
+  dtype's sentinel. If the output dtype is float (e.g. true division of
+  ints), the "sentinel" is NaN, which then propagates for free downstream.
+  Nullable float columns need no rewrite (NaN already propagates).
+- **Comparisons** (`< <= > >= == !=`) involving a nullable column: SQL
+  `WHERE` semantics — **a null never satisfies any comparison**. Implement as
+  `(x <op> y) & notnull(x) [& notnull(y)]`. The boolean result carries no
+  null channel; nulls simply compare False. (`==` against the sentinel value
+  itself must NOT match nulls either; `is_null()` remains the only way to
+  test for null. Document this.)
+- **Boolean combinators** (`& | ~`) then need no changes: their inputs are
+  comparison results in which null-ness has already resolved to False.
+- **Kleene three-valued logic is explicitly OUT OF SCOPE** (where `null > 0`
+  is null, not False). It requires a validity channel on boolean
+  intermediates, i.e. masks. SQL-style False-semantics is the decided
+  behavior; record this in the docs section from C2.
+
+**Where the code goes:** the single funnel point is the `Column` operator
+overloads (`ctable.py`, `Column.__add__` and siblings, around line 1586, all
+routing through `_unwrap_operand`). Wrap there — when `self` (or a `Column`
+operand) has `null_value is not None`, emit the rewritten lazy expression
+instead of the raw one. Do NOT modify the generic lazyexpr engine in
+`lazyexpr.py`; it has no notion of CTable nulls and must stay that way.
+Dictionary columns (null code `INT32_MIN`) and varlen scalar columns (None
+cells) need an audit of which operators they even support before extending
+the rewrite to them; if unsupported, raise clearly rather than half-work.
+
+**Interaction cases the implementation must get right:**
+
+- Chained arithmetic: `(t.x + 1) * 2` — the intermediate already carries the
+  output sentinel/NaN, so the rewrite must apply at the first
+  nullable-operand boundary and not double-wrap.
+- Mixed nullable + non-nullable columns, and nullable column + Python scalar.
+- Reductions over rewritten expressions: `(t.x + 1).sum()` should skip nulls
+  exactly like `t.x.sum()` does today (verify: if the output sentinel is NaN,
+  the existing NaN-skip path covers it; if the output is int with an int
+  sentinel, confirm the reduction path knows the derived expression's
+  sentinel — if it cannot, prefer promoting nullable-int arithmetic results
+  to float64/NaN and document the promotion, which is exactly what pandas'
+  legacy int→float null behavior does and is the lazy correct choice).
+- Filters: `t[t.x < 0]` must exclude null rows after C2b (this is the
+  user-visible bug fix; make it the headline test).
+
+**Performance note:** the rewrite adds a mask computation and a `where()` per
+nullable operand. Only emit it when the column is actually nullable
+(`null_value is not None`); non-nullable columns keep exactly today's
+expression, zero overhead. Add one micro-benchmark comparing a filter on a
+nullable vs non-nullable int column to quantify the cost.
+
+**Tests:**
+
+1. Arithmetic propagation for nullable int and timestamp columns, including
+   chained expressions and scalar operands; nulls in → nulls out.
+2. `t[t.x < 0]` and `t[t.x > 0]` both exclude null rows; `t.x == <sentinel
+   literal>` does not match nulls; `is_null()` still finds them.
+3. `(t.x + 1).sum()` / `.mean()` equal the same computation via
+   pandas on `to_pandas()` with nullable dtypes (nulls skipped).
+4. Non-nullable columns produce byte-identical expressions to before (no
+   rewrite emitted) — guard the zero-overhead claim.
+5. Update the C2 behavior-pinning tests to the new semantics (they exist
+   precisely to make this change visible and deliberate).
+
+### C3. Optional, only if trivial: `skipna=` parameter on reductions
+
+Reductions currently ALWAYS skip nulls (pandas' default). pandas also offers
+`skipna=False`. Add `skipna: bool = True` to `Column.sum/mean/min/max/std`
+ONLY if it falls out naturally (`skipna=False` = run on raw values including
+sentinels; for floats that is NaN-poisoning semantics, which is correct).
+If it requires restructuring `_nonnull_chunks` plumbing, skip it — nobody asked.
+
+### C4. Tests
+
+1. `fillna`: int sentinel, NaN float, timestamp NaT-sentinel, dictionary
+   column, varlen string column (None cells).
+2. `dropna`: subset semantics; result is a view; result row count correct;
+   interacts correctly with an existing filtered view (dropna of a view).
+3. The C2 behavior-pinning tests.
+
+### Implementation notes (2026-07-15)
+
+**C1 done as planned**, plus one unplanned real bug fix found along the way:
+`Column._null_mask_for()` never actually detected nulls in **timestamp**
+columns. `Column.__getitem__` always decodes the raw `int64` sentinel into
+`np.datetime64('NaT')` before it reaches the mask check (they share the same
+bit pattern), so comparing the decoded `datetime64` array against the raw
+int sentinel silently matched nothing — `is_null()`/`null_count()` returned
+all-False/0 for timestamp columns. Fixed by special-casing `datetime64`
+arrays with `np.isnat()`. (Arrow export of timestamp nulls happened to work
+anyway, since pyarrow treats `NaT` as null natively when building the array —
+not because of blosc2's own null-mask logic.) `fillna()`/`dropna()`
+implemented per spec, `dropna()` built on `where()` (which already does the
+live-row-length-mask → physical-position → intersect-with-valid-rows work
+`view()` alone would have required reimplementing).
+
+**C2/C2b done, with one documented deviation from the literal test list.**
+Sentinel-based null propagation implemented in the `Column` operator
+overloads exactly as specified: arithmetic promotes nullable int/timestamp
+results to float64/NaN, comparisons AND with `notnull()` (SQL semantics),
+zero overhead for non-nullable columns, chained arithmetic doesn't
+double-wrap. The headline bug (`t[t.x < 0]` wrongly including nulls) is
+fixed and tested. **Deviation:** the plan's C2b test #3 wanted
+`(t.x + 1).sum()` to skip nulls "exactly like `t.x.sum()`". This turned out
+to be unreachable without a new abstraction: `t.x + 1` returns a plain
+`blosc2.LazyExpr`/`NDArray` (via `blosc2.where(...)`), which has no memory of
+which table column it came from and whose own `.sum()` is the generic
+reduction (no null-skip logic at all — confirmed empirically, it returns
+NaN for a NaN-containing array). Making `(t.x + 1).sum()` skip nulls would
+require wrapping the rewritten expression in a new Column-like object
+carrying `null_value` metadata outside the schema, which is a real new
+abstraction, not "one design-decided medium piece". Kept it lazy instead:
+documented the limitation (with the `values[t.score.notnull()] + 1` NumPy
+workaround) in a "Nulls in expressions" doc section and pinned it as a test
+(`test_reduction_on_derived_expression_is_nan_poisoned_not_null_skipping`)
+rather than silently claiming pandas parity. Flagging this explicitly in
+case a future pass decides the abstraction is worth building.
+
+**C3 skipped**, per the plan's own escape valve: `sum`/`mean`/`min`/`max`/
+`std` each have a "lazy fastpath" (with JIT backend dispatch) plus a
+`_nonnull_chunks()` fallback; threading `skipna=False` through both would
+restructure that plumbing, not "fall out naturally". Nobody asked.
+
+Tests: `tests/ctable/test_nullable.py` (C1 + the timestamp fix) and
+`tests/ctable/test_null_expressions.py` (C2/C2b, new file). Commits:
+`bf39bad5` "Add Column.fillna() / CTable.dropna() and fix timestamp null
+detection (Gap C1)", `a18bbc83` "Propagate nulls through Column arithmetic
+and comparisons (Gap C2b)".
+
+---
+
+## Gap D — UDF aggregations and engine dispatch (the real project)
+
+### What exists / what is missing (verified)
+
+- `group_by(..., engine="auto")`: parameter validated
+  (`ctable.py`, in `group_by()`) and stored (`groupby.py:104,121`) but **never
+  dispatched on** — every execution path is the NumPy chunked implementation in
+  `CTableGroupBy._execute` (`groupby.py:388`).
+- `agg()` (`groupby.py`, `def agg` around line 201) accepts a closed op set
+  (`count/sum/mean/min/max/argmin/argmax/size`); blosc2 reduction *functions*
+  are accepted only as naming shorthand, and custom callables are explicitly
+  rejected.
+- There is no `CTableGroupBy.apply(f)` and no `CTable.apply(f)`.
+- The engine machinery itself exists elsewhere: `blosc2.lazyudf` with
+  `jit_backend` in `{None, "tcc", "cc", "js"}` (`lazyexpr.py`,
+  `_apply_jit_backend_pragma`), used today by CTable computed columns.
+
+### Agreed phasing (from the discussion — keep this order)
+
+**Phase D1 — `engine="jit"` for the EXISTING built-in aggregations.**
+Rationale: exercises the dispatch plumbing on closed, well-typed ops before
+opening the door to arbitrary UDFs, where nulls, dtype inference, and varlen
+columns make everything harder.
+
+- Accept `engine in {"auto", "numpy", "jit"}` in `group_by()`. Replace the
+  Phase-1 `raise` with validation against this set. `"auto"` keeps meaning
+  "current NumPy chunked path" for now (it may later mean "choose").
+- In `CTableGroupBy._execute`, dispatch on `self.engine`. The `"jit"` path
+  evaluates per-chunk aggregation kernels through the miniexpr/lazyudf
+  machinery instead of NumPy. Study how computed columns invoke `lazyudf`
+  (grep `lazyudf` in `ctable.py`, around lines 9088–9251) before designing.
+- Null handling MUST match the NumPy path exactly (the null-skip logic in
+  `_execute` around `groupby.py:512–537` is the reference semantics; port or
+  reuse it, and assert equality against the NumPy engine in tests).
+- Benchmark before merging (there are groupby benches or the chicago-taxi data
+  under `bench/`); if the JIT path is not measurably faster on a
+  1e7-row/low-cardinality-keys case, do not merge it — the dispatch plumbing
+  can still land with `"jit"` marked experimental or reverted to raise
+  `NotImplementedError`.
+
+**Phase D2 — per-group UDF aggregations.**
+
+- Extend `agg()` to accept a callable as the op:
+  `g.agg(my_range=("price", lambda a: a.max() - a.min()))`. The callable
+  receives a 1-D NumPy array of the group's **live, non-null** values (same
+  null semantics as built-in aggs; nulls pre-filtered) and returns a scalar.
+- Output dtype: infer from calling the UDF once on an empty/first-group probe,
+  or accept an explicit `dtype` in the named-agg tuple. Keep it simple:
+  probe-first-group inference plus a clear error if groups disagree.
+- Execution: gather each group's values and call the UDF per group (plain
+  Python loop). This is the "slow but works" baseline pandas also has. It must
+  exist BEFORE any acceleration, both as fallback and as the semantics oracle.
+- Then, optionally in the same phase, accept `engine="jit"` for UDF aggs where
+  the UDF is a `blosc2.dsl_kernel`-decorated function (grep `dsl_kernel` in
+  `ctable.py`/`dsl_kernel.py`) — the DSL is transpilable; arbitrary Python is
+  not. Arbitrary-Python JIT (numba-style) is OUT OF SCOPE; do not add a numba
+  dependency.
+
+**Phase D3 — `CTable.apply()` sugar (cheap, do last).**
+
+- `CTable.apply(func, *, columns=None, dtype=None, engine="auto")`: run a
+  row-batch UDF over the table, returning an NDArray (or a new Column). This
+  is sugar over `blosc2.lazyudf(func, tuple(t[c] for c in columns), ...)`
+  — the machinery is exactly what `add_computed_column` already uses (see the
+  docstring examples around `ctable.py:9345` and `:9612`). No new execution
+  code; reuse, then `.compute()`.
+
+**Explicitly out of scope for Gap D** (decisions from the discussion):
+
+- An open third-party engine protocol (pandas 3's plugin socket). pandas needs
+  it because pandas has no engine of its own; blosc2 IS an engine with three
+  backends. Do not build a plugin API until an external party asks for one.
+- `numba` integration, `engine="bodo"`, distributed anything.
+- Window functions / transform / rolling — different feature, different plan.
+
+### Tests
+
+- D1: for every built-in agg and a mix of dtypes (int, float+NaN, nullable-int
+  sentinel, bool, dictionary keys, string keys): `engine="jit"` result equals
+  `engine="numpy"` result exactly (or to float tolerance for mean/std).
+  Include: empty table, single group, all-null value column, null keys with
+  `dropna=True/False`, chunk-boundary-straddling groups (set a small
+  `chunk_size`).
+- D2: callable agg equals the same computation done via
+  `to_pandas().groupby().agg()` on a reference table; dtype inference errors
+  are clear; a UDF raising inside a group propagates with the group key named.
+- D3: `t.apply(...)` equals the equivalent direct `lazyudf` call.
+
+### Implementation notes (2026-07-15)
+
+**D1 landed as dispatch plumbing only, not a JIT engine** — exactly the
+fallback the plan itself sanctioned ("the dispatch plumbing can still land
+with `'jit'` marked experimental or reverted to raise `NotImplementedError`").
+`group_by(engine=...)` now validates against `{"auto", "numpy", "jit"}`;
+`"auto"`/`"numpy"` both mean today's NumPy/Cython chunked path (unchanged,
+`self.engine` was and still is otherwise unused downstream), `"jit"` raises
+`NotImplementedError` pointing at `"auto"`/`"numpy"`. Building an actual
+miniexpr-JIT aggregation kernel competitive with the existing highly-tuned
+per-dtype-combination Cython fast paths (`groupby.py` has ~2200 lines with
+several specialized kernels — dense int key, two-int-key hash, float hash,
+i32/f64 sum, etc.) is a multi-day project in its own right and the plan
+explicitly gates merging it on a benchmark against `engine="numpy"`; that
+work was not attempted this session.
+
+**D2 done, including the empty-group edge case the plan didn't call out.**
+`agg()`'s named form now accepts `output_name=(column, callable[, dtype])`.
+Because an arbitrary Python callable can't be incrementally merged across
+chunks the way `sum`/`min`/`max` partial state can, UDF specs are routed
+around all the Cython/NumPy fast paths (`_try_fast_paths` bails to `None` if
+any spec is a UDF) and instead ride the existing generic chunked path,
+which was extended so `_compute_partials`/`_merge_partials` accumulate raw
+per-group value arrays (not a scalar state) and `_final_rows` concatenates
+and calls the UDF exactly once per group, after all chunks are read. Found
+during implementation: a group with zero non-null values for the UDF's
+input column (e.g. a city whose only row has a null sales value) needs the
+same treatment `sum`/`min`/`max` already give an all-null group — output a
+null rather than calling the UDF with an empty array (which fails for
+`.max()`/`.min()`-style reductions). Output dtype is inferred from **every**
+group's result via `np.asarray(results)`, not just the first, specifically
+so a UDF returning inconsistent types across groups is caught with a clear
+error instead of surfacing as an opaque failure while building the result
+table; an explicit dtype (blosc2 schema spec, e.g. `blosc2.float32()`) can be
+given as a third tuple element instead. The auto-named mapping/list forms
+still reject arbitrary callables exactly as before (existing test
+`test_agg_rejects_non_blosc2_callables_by_identity` was preserved
+unchanged) — a callable is only ever treated as a UDF when it arrives via
+the *named* form, where an output column name is available.
+
+**D3 done as planned**, reusing exactly what `add_computed_column`/
+`add_generated_column` already do: raw (full-capacity) `self._cols[name]`
+storage arrays as `lazyudf` operands, live-row mask applied once to the
+result rather than to every operand (this was the one correctness bug
+caught before landing — passing `Column` objects as operands, as a first
+draft did, returns full physical-capacity results instead of just the live
+rows).
+
+Tests: `tests/ctable/test_groupby.py` (D1 engine validation, D2 UDF
+aggregations — including the pandas-comparison test, which accounts for
+blosc2 keeping an all-null group instead of dropping it the way
+`df.dropna().groupby()` would), `tests/ctable/test_ctable_apply.py` (D3,
+new file). Commit: `3e0cbff1` "Add UDF aggregations, engine dispatch
+plumbing, and CTable.apply() (Gap D)".
+
+---
+
+## Gap E — unbound `col()` expressions: PARKED
+
+Decision: `ct.x` (bound `Column` with operator overloading) already covers
+what `pd.col("x")` does in pandas 3 for the "name the table, then index/assign
+on it" idiom — and is better in one way (typo → immediate `AttributeError`
+instead of evaluation-time failure).
+
+`pd.col`'s only advantage is being **unbound**, which matters for
+(a) method chains where the intermediate table has no variable name,
+(b) reusable expressions applied to many tables, and
+(c) aggregation contexts resolving per-group at execution time.
+
+**Do not implement.** Unpark only if CTable grows a chaining/pipeline API
+(e.g. a `.assign()`-style method on groupby results) — at that point the
+implementation is cheap: an unbound `col("x")` is a deferred name that swaps
+in `table.x` at evaluation, reusing all existing `Column` operator machinery.
+
+---
+
+## Cross-cutting rules for the implementer
+
+1. **Verify before building.** This codebase was ahead of the analysis at
+   every step (null-aware reductions, Arrow validity bitmaps, and
+   `iter_arrow_batches` all turned out to already exist). Before implementing
+   any item, grep for it. If it exists, write the test that proves it and move
+   on.
+2. **One PR per gap**, in the A → B → C → D order. Gap E: no PR.
+3. **No new dependencies.** pyarrow stays optional (guarded by
+   `_require_pyarrow`); duckdb/polars appear only as `importorskip` in tests.
+4. **Error messages name the escape hatch** (e.g. the view-write error points
+   at `take()`/`copy()`; the old-pyarrow error names the required version).
+5. **Docstrings in the existing style** (NumPy-doc with Examples sections, as
+   throughout `ctable.py`).
+6. Run the CTable test subset with
+   `conda run -n blosc2 python -m pytest tests/ -k ctable -x -q` (adjust the
+   `-k` to the actual test module names found in step 1).

--- a/plans/enhancing-ctable.md
+++ b/plans/enhancing-ctable.md
@@ -474,21 +474,35 @@ overloads exactly as specified: arithmetic promotes nullable int/timestamp
 results to float64/NaN, comparisons AND with `notnull()` (SQL semantics),
 zero overhead for non-nullable columns, chained arithmetic doesn't
 double-wrap. The headline bug (`t[t.x < 0]` wrongly including nulls) is
-fixed and tested. **Deviation:** the plan's C2b test #3 wanted
-`(t.x + 1).sum()` to skip nulls "exactly like `t.x.sum()`". This turned out
-to be unreachable without a new abstraction: `t.x + 1` returns a plain
-`blosc2.LazyExpr`/`NDArray` (via `blosc2.where(...)`), which has no memory of
-which table column it came from and whose own `.sum()` is the generic
-reduction (no null-skip logic at all — confirmed empirically, it returns
-NaN for a NaN-containing array). Making `(t.x + 1).sum()` skip nulls would
-require wrapping the rewritten expression in a new Column-like object
-carrying `null_value` metadata outside the schema, which is a real new
-abstraction, not "one design-decided medium piece". Kept it lazy instead:
-documented the limitation (with the `values[t.score.notnull()] + 1` NumPy
-workaround) in a "Nulls in expressions" doc section and pinned it as a test
-(`test_reduction_on_derived_expression_is_nan_poisoned_not_null_skipping`)
-rather than silently claiming pandas parity. Flagging this explicitly in
-case a future pass decides the abstraction is worth building.
+fixed and tested. **Deviation (since resolved, see below):** the plan's
+C2b test #3 wanted `(t.x + 1).sum()` to skip nulls "exactly like
+`t.x.sum()`". This was initially documented as a limitation because
+`t.x + 1` returned a plain `blosc2.LazyExpr` with no memory of
+nullability, whose generic `.sum()` NaN-poisons.
+
+**C2b follow-up (2026-07-16): the deviation was closed by building the
+abstraction after all** — `NullableExpr` in `ctable.py`, the "Column-like
+object carrying null metadata" the notes above sketched. Key design
+points: (a) `_null_aware_arith` returns `NullableExpr(where(pred, nan,
+raw), table, pred)` — the wrapper carries the **null predicate itself**
+(over raw physical columns), not just a "nulls are NaN" convention,
+because `blosc2.isnan()` applied on top of a `where()`-carrying LazyExpr
+silently returns wrong results (pre-existing lazyexpr quirk: further lazy
+ops on `_where_args` expressions are unreliable) and because it keeps
+nulls distinct from NaNs the arithmetic itself produces (`0/0`). (b)
+Reductions reuse the same lazy masked-reduction engine Column uses
+(`expr.sum(where=~pred & valid_rows)`), so they also exclude dead
+physical slots — which plain LazyExpr reductions on raw column
+expressions never did. (c) Chaining keeps the wrapper and ORs predicates;
+Column operands re-enter via `Column.__r<op>__` (`NotImplemented`) so
+their own sentinel rewrite applies; `**` re-patches nulls (`nan**0 == 1`
+would resurrect them); `!=` guards both operands' predicates. All-null
+conventions match Column: `sum()` → 0.0, `mean()`/`std()` → NaN,
+`min()`/`max()` → `ValueError`. The old limitation-pinning test was
+replaced by `test_reduction_on_derived_expression_skips_nulls` and
+friends (pandas-parity, chained/mixed operands, deleted rows, views,
+all-null) in `tests/ctable/test_null_expressions.py`; the docs section
+now documents the new semantics.
 
 **C3 skipped**, per the plan's own escape valve: `sum`/`mean`/`min`/`max`/
 `std` each have a "lazy fastpath" (with JIT backend dispatch) plus a

--- a/plans/enhancing-ctable.md
+++ b/plans/enhancing-ctable.md
@@ -607,6 +607,30 @@ i32/f64 sum, etc.) is a multi-day project in its own right and the plan
 explicitly gates merging it on a benchmark against `engine="numpy"`; that
 work was not attempted this session.
 
+**D1 follow-up (2026-07-16): the JIT engine was re-evaluated and rejected;
+the effort was redirected to the gap the benchmark actually showed.**
+Running the plan's own gate case (1e7 rows, low-cardinality keys,
+`bench/ctable/bench_groupby_keys.py`) settled it: the existing engine
+already *beats pandas* on int keys (50 ms vs 61 ms; raw `np.bincount` is
+16 ms, so decompression included we sit ~3x off speed-of-light) — no
+generic JIT can measurably win there, so per the plan's merge gate it must
+not be built. Also, miniexpr/lazyudf is an *elementwise* engine with no
+grouped-scatter primitive; `engine="jit"` would mean new C-codegen
+machinery, not wiring. The real hole was **string keys: 1157 ms vs
+pandas' 149 ms (7.8x)** — profiling showed 0.94 s of it was `np.unique`
+argsorting fixed-width unicode keys (32 bytes of UTF-32 per comparison
+for a `U8` key) in `_factorize_keys`. Fixed with exact hash-based
+factorization (`_factorize_fixed_width_str` in `groupby.py`): hash each
+row's raw bytes into one uint64, factorize the integers, recover strings
+from one representative row per group, and verify vectorized — falling
+back to `np.unique` on collision, so the output contract is bit-identical.
+Result: **string-key sum 1157 → 737 ms** (~1.6x; the remainder is the
+per-chunk int64 argsort plus ~230 ms of fixed pipeline cost — a
+cross-chunk vocabulary cache could roughly halve it again and is noted as
+the upgrade path in the code). This benefits the default engine — every
+caller, no `engine=` switch. `engine="jit"` stays `NotImplementedError`
+until a case is found that a compiled kernel can actually win.
+
 **D2 done, including the empty-group edge case the plan didn't call out.**
 `agg()`'s named form now accepts `output_name=(column, callable[, dtype])`.
 Because an arbitrary Python callable can't be incrementally merged across

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -1581,6 +1581,60 @@ class Column:
             return other.astype(f"datetime64[{spec.unit}]").astype(np.int64)
         return other
 
+    def _raw_null_pred(self):
+        """Boolean lazy predicate over the raw physical array, True where the
+        value is this column's null sentinel.
+
+        Returns ``None`` when there is nothing to propagate: no ``null_value``
+        configured, or a fixed-shape ndarray column (whose per-item sentinel
+        mask does not align 1:1 with the row-level predicates built here;
+        see ``Column.is_null()`` for those instead). Dictionary and
+        variable-length scalar columns never reach here because
+        ``_ensure_queryable`` already rejects them for arithmetic/comparisons.
+        """
+        if self.is_ndarray:
+            return None
+        nv = self.null_value
+        if nv is None:
+            return None
+        if isinstance(nv, (float, np.floating)) and np.isnan(nv):
+            return blosc2.isnan(self._raw_col)
+        return self._raw_col == nv
+
+    def _combined_null_pred(self, other):
+        """OR of self's and other's raw null predicates; ``None`` if neither
+        operand is nullable (the zero-overhead case)."""
+        self_pred = self._raw_null_pred()
+        other_pred = other._raw_null_pred() if isinstance(other, Column) else None
+        if self_pred is None:
+            return other_pred
+        if other_pred is None:
+            return self_pred
+        return self_pred | other_pred
+
+    def _null_aware_arith(self, other, raw_result):
+        """Sentinel-based null propagation for arithmetic (see Gap C2b of
+        plans/enhancing-ctable.md): rows where any nullable operand is null
+        become NaN in the result, promoting integer/timestamp results to
+        float64 the same way pandas' legacy int-null arithmetic does. Costs
+        nothing when neither operand is nullable — *raw_result* is returned
+        unchanged.
+        """
+        null_pred = self._combined_null_pred(other)
+        if null_pred is None:
+            return raw_result
+        return blosc2.where(null_pred, np.nan, raw_result)
+
+    def _null_aware_compare(self, other, raw_result):
+        """SQL ``WHERE`` semantics for comparisons (see Gap C2b): a null
+        operand never satisfies any comparison, so null rows are forced to
+        False. Costs nothing when neither operand is nullable.
+        """
+        null_pred = self._combined_null_pred(other)
+        if null_pred is None:
+            return raw_result
+        return raw_result & ~null_pred
+
     def __neg__(self):
         self._ensure_queryable()
         return -self._raw_col
@@ -1595,59 +1649,59 @@ class Column:
 
     def __add__(self, other):
         self._ensure_queryable()
-        return self._raw_col + self._unwrap_operand(other)
+        return self._null_aware_arith(other, self._raw_col + self._unwrap_operand(other))
 
     def __radd__(self, other):
         self._ensure_queryable()
-        return self._unwrap_operand(other) + self._raw_col
+        return self._null_aware_arith(other, self._unwrap_operand(other) + self._raw_col)
 
     def __sub__(self, other):
         self._ensure_queryable()
-        return self._raw_col - self._unwrap_operand(other)
+        return self._null_aware_arith(other, self._raw_col - self._unwrap_operand(other))
 
     def __rsub__(self, other):
         self._ensure_queryable()
-        return self._unwrap_operand(other) - self._raw_col
+        return self._null_aware_arith(other, self._unwrap_operand(other) - self._raw_col)
 
     def __mul__(self, other):
         self._ensure_queryable()
-        return self._raw_col * self._unwrap_operand(other)
+        return self._null_aware_arith(other, self._raw_col * self._unwrap_operand(other))
 
     def __rmul__(self, other):
         self._ensure_queryable()
-        return self._unwrap_operand(other) * self._raw_col
+        return self._null_aware_arith(other, self._unwrap_operand(other) * self._raw_col)
 
     def __truediv__(self, other):
         self._ensure_queryable()
-        return self._raw_col / self._unwrap_operand(other)
+        return self._null_aware_arith(other, self._raw_col / self._unwrap_operand(other))
 
     def __rtruediv__(self, other):
         self._ensure_queryable()
-        return self._unwrap_operand(other) / self._raw_col
+        return self._null_aware_arith(other, self._unwrap_operand(other) / self._raw_col)
 
     def __floordiv__(self, other):
         self._ensure_queryable()
-        return self._raw_col // self._unwrap_operand(other)
+        return self._null_aware_arith(other, self._raw_col // self._unwrap_operand(other))
 
     def __rfloordiv__(self, other):
         self._ensure_queryable()
-        return self._unwrap_operand(other) // self._raw_col
+        return self._null_aware_arith(other, self._unwrap_operand(other) // self._raw_col)
 
     def __mod__(self, other):
         self._ensure_queryable()
-        return self._raw_col % self._unwrap_operand(other)
+        return self._null_aware_arith(other, self._raw_col % self._unwrap_operand(other))
 
     def __rmod__(self, other):
         self._ensure_queryable()
-        return self._unwrap_operand(other) % self._raw_col
+        return self._null_aware_arith(other, self._unwrap_operand(other) % self._raw_col)
 
     def __pow__(self, other):
         self._ensure_queryable()
-        return self._raw_col ** self._unwrap_operand(other)
+        return self._null_aware_arith(other, self._raw_col ** self._unwrap_operand(other))
 
     def __rpow__(self, other):
         self._ensure_queryable()
-        return self._unwrap_operand(other) ** self._raw_col
+        return self._null_aware_arith(other, self._unwrap_operand(other) ** self._raw_col)
 
     def __and__(self, other):
         self._ensure_queryable()
@@ -1681,19 +1735,19 @@ class Column:
 
     def __lt__(self, other):
         self._ensure_comparable()
-        return self._raw_col < self._coerce_timestamp_operand(other)
+        return self._null_aware_compare(other, self._raw_col < self._coerce_timestamp_operand(other))
 
     def __le__(self, other):
         self._ensure_comparable()
-        return self._raw_col <= self._coerce_timestamp_operand(other)
+        return self._null_aware_compare(other, self._raw_col <= self._coerce_timestamp_operand(other))
 
     def __eq__(self, other):
         if self.is_dictionary:
             return self._dictionary_eq(other)
         self._ensure_comparable()
         if self._is_nullable_bool and isinstance(other, (bool, np.bool_)):
-            return self._raw_col == int(other)
-        return self._raw_col == self._coerce_timestamp_operand(other)
+            return self._null_aware_compare(other, self._raw_col == int(other))
+        return self._null_aware_compare(other, self._raw_col == self._coerce_timestamp_operand(other))
 
     def __ne__(self, other):
         if self.is_dictionary:
@@ -1703,8 +1757,8 @@ class Column:
             return ~np.asarray(result, dtype=bool)
         self._ensure_comparable()
         if self._is_nullable_bool and isinstance(other, (bool, np.bool_)):
-            return self._raw_col == int(not other)
-        return self._raw_col != self._coerce_timestamp_operand(other)
+            return self._null_aware_compare(other, self._raw_col == int(not other))
+        return self._null_aware_compare(other, self._raw_col != self._coerce_timestamp_operand(other))
 
     def _dictionary_eq(self, other):
         """Return a physical-slot boolean predicate for dictionary equality.
@@ -1781,11 +1835,11 @@ class Column:
 
     def __gt__(self, other):
         self._ensure_comparable()
-        return self._raw_col > self._coerce_timestamp_operand(other)
+        return self._null_aware_compare(other, self._raw_col > self._coerce_timestamp_operand(other))
 
     def __ge__(self, other):
         self._ensure_comparable()
-        return self._raw_col >= self._coerce_timestamp_operand(other)
+        return self._null_aware_compare(other, self._raw_col >= self._coerce_timestamp_operand(other))
 
     @property
     def dtype(self):

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -6202,6 +6202,21 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         schema = self._arrow_schema_for_columns()
         return pa.Table.from_batches(batches, schema=schema)
 
+    def __arrow_c_stream__(self, requested_schema=None):
+        """Arrow PyCapsule protocol: export live rows as a stream of record batches.
+
+        Lets Arrow-native consumers (pyarrow, DuckDB, Polars, pandas) read this
+        table directly, pulling decompressed batches lazily with bounded memory.
+        Strict zero-copy is impossible here (the data is compressed on disk;
+        decompression *is* the copy), but there is zero intermediate
+        materialization: only one batch is decompressed at a time.
+        """
+        pa = self._require_pyarrow("__arrow_c_stream__")
+        reader = pa.RecordBatchReader.from_batches(
+            self._arrow_schema_for_columns(), self.iter_arrow_batches()
+        )
+        return reader.__arrow_c_stream__(requested_schema)
+
     @staticmethod
     def _auto_null_sentinel(pa, pa_type, *, null_policy: NullPolicy):
         return null_policy.sentinel_for_arrow_type(pa, pa_type)
@@ -7038,7 +7053,7 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
     def from_arrow(  # noqa: C901
         cls,
         schema,
-        batches,
+        batches=None,
         *,
         urlpath: str | None = None,
         mode: str = "w",
@@ -7109,8 +7124,22 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         ``column_cparams`` optionally maps column names to per-column compression
         parameters. These override the table-level ``cparams`` for fixed-width
         columns imported from Arrow.
+
+        *schema* may also be any object implementing the Arrow PyCapsule
+        interchange protocol (``__arrow_c_stream__``) — a pyarrow
+        ``Table``/``RecordBatchReader``, a Polars ``DataFrame``, a DuckDB
+        result, or another :class:`CTable` — in which case *batches* must be
+        omitted and the schema/batches are pulled from the stream::
+
+            t = blosc2.CTable.from_arrow(polars_df)
+            t = blosc2.CTable.from_arrow(duckdb_result, urlpath="out.b2z")
         """
         pa = cls._require_pyarrow("from_arrow()")
+        if hasattr(schema, "__arrow_c_stream__") and batches is None:
+            if not hasattr(pa.RecordBatchReader, "from_stream"):
+                raise RuntimeError("Importing from an Arrow PyCapsule stream requires pyarrow >= 14.0.")
+            reader = pa.RecordBatchReader.from_stream(schema)
+            schema, batches = reader.schema, reader
         if blosc2_batch_size is not None and blosc2_batch_size <= 0:
             raise ValueError("blosc2_batch_size must be a positive integer or None")
         if blosc2_items_per_block is not None and blosc2_items_per_block <= 0:

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -1121,9 +1121,19 @@ class Column:
         return table_view.take(indices)[self._col_name]
 
     def __setitem__(self, key: int | slice | list | np.ndarray, value):  # noqa: C901
-        """Set one or more live column values; accepts the same index forms as :meth:`__getitem__`."""
+        """Set one or more live column values; accepts the same index forms as :meth:`__getitem__`.
+
+        Raises ``ValueError`` if the table is read-only or is a view; use
+        :meth:`CTable.take` or :meth:`CTable.copy` to get an independent,
+        writable table first.
+        """
         if self._table._read_only:
             raise ValueError("Table is read-only (opened with mode='r').")
+        if self._table.base is not None:
+            raise ValueError(
+                "Cannot assign values through a view. Use .take(indices) or .copy() "
+                "to get an independent, writable table first."
+            )
         if self.is_computed:
             raise ValueError(f"Column {self._col_name!r} is a computed column and cannot be written to.")
         # In-place column mutation invalidates any incremental summary accumulator
@@ -1901,9 +1911,6 @@ class Column:
     def assign(self, data) -> None:
         """Replace all live values in this column with *data*.
 
-        Works on both full tables and views — on a view, only the rows
-        visible through the view's mask are overwritten.
-
         Parameters
         ----------
         data:
@@ -1914,13 +1921,20 @@ class Column:
         Raises
         ------
         ValueError
-            If ``len(data)`` does not match the number of live rows, or the
-            table is opened read-only.
+            If ``len(data)`` does not match the number of live rows, the
+            table is opened read-only, or the table is a view (use
+            :meth:`CTable.take` or :meth:`CTable.copy` to get an
+            independent, writable table first).
         TypeError
             If values cannot be coerced to the column's dtype.
         """
         if self._table._read_only:
             raise ValueError("Table is read-only (opened with mode='r').")
+        if self._table.base is not None:
+            raise ValueError(
+                "Cannot assign values through a view. Use .take(indices) or .copy() "
+                "to get an independent, writable table first."
+            )
         if self.is_computed:
             raise ValueError(f"Column {self._col_name!r} is a computed column and cannot be written to.")
         if self.is_list:
@@ -9985,6 +9999,17 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
 
             col = t["where"]             # column named "where"
             method = t.where             # CTable.where method
+
+        Row-range, gathered-row, boolean-mask, sorted (:meth:`sort_by`), and
+        column-projection results are all lightweight **views**: they share
+        physical storage with the base table instead of copying it. Views
+        are read-only — assigning into a value returned by indexing a view
+        raises ``ValueError``; use :meth:`take` or :meth:`copy` to obtain an
+        independent, writable table. Mutating the base table while a view
+        exists leaves the view's row mask frozen at the time the view was
+        created, so the view may go stale (it will not see rows appended to
+        the base afterwards, and may still reference rows later deleted from
+        the base).
         """
         if isinstance(key, str):
             physical = self._logical_to_physical_name(key)

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -7234,11 +7234,21 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
             t = blosc2.CTable.from_arrow(duckdb_result, urlpath="out.b2z")
         """
         pa = cls._require_pyarrow("from_arrow()")
-        if hasattr(schema, "__arrow_c_stream__") and batches is None:
+        if hasattr(schema, "__arrow_c_stream__"):
+            if batches is not None:
+                raise TypeError(
+                    "from_arrow() takes either a single Arrow-stream object "
+                    "(implementing __arrow_c_stream__) or a (schema, batches) pair, not both."
+                )
             if not hasattr(pa.RecordBatchReader, "from_stream"):
                 raise RuntimeError("Importing from an Arrow PyCapsule stream requires pyarrow >= 14.0.")
             reader = pa.RecordBatchReader.from_stream(schema)
             schema, batches = reader.schema, reader
+        elif batches is None:
+            raise TypeError(
+                "from_arrow() requires batches unless the first argument is an "
+                "Arrow-stream object implementing __arrow_c_stream__."
+            )
         if blosc2_batch_size is not None and blosc2_batch_size <= 0:
             raise ValueError("blosc2_batch_size must be a positive integer or None")
         if blosc2_items_per_block is not None and blosc2_items_per_block <= 0:
@@ -9449,7 +9459,7 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         columns: list[str] | None = None,
         dtype=None,
         engine: str = "auto",
-    ) -> blosc2.NDArray:
+    ) -> np.ndarray:
         """Run a row-batch UDF over live column values and materialize the result.
 
         Sugar over :func:`blosc2.lazyudf` using this table's columns as
@@ -9466,7 +9476,8 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
             offset)``) and for how a :func:`blosc2.dsl_kernel`-decorated
             kernel is transpiled instead of run as plain Python.
         columns:
-            Column names to bind as *func*'s inputs, in order. Defaults to
+            Names of *stored* columns to bind as *func*'s inputs, in order
+            (computed/generated columns are not supported). Defaults to
             every stored column, in schema order.
         dtype:
             Result dtype. Required unless *func* is a
@@ -9478,6 +9489,12 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
             ``"auto"`` (default) lets it choose, ``"jit"`` forces JIT
             (only effective for a transpilable :func:`blosc2.dsl_kernel`),
             ``"numpy"`` disables JIT.
+
+        Returns
+        -------
+        numpy.ndarray
+            The UDF's result for the live rows only (on a view, the rows
+            visible through the view).
 
         Examples
         --------
@@ -9498,6 +9515,12 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
             raise ValueError(f"engine must be 'auto', 'numpy', or 'jit', got {engine!r}")
         jit = {"auto": None, "numpy": False, "jit": True}[engine]
         names = columns if columns is not None else list(self.col_names)
+        missing = [n for n in names if self._logical_to_physical_name(n) not in self._cols]
+        if missing:
+            raise ValueError(
+                f"apply() only accepts stored columns, got {missing!r}. "
+                f"Stored columns: {list(self.col_names)!r}."
+            )
         # Operands are the raw (full-capacity) storage arrays -- the same
         # inputs add_computed_column()/add_generated_column() pass to
         # lazyudf() for DSL/UDF columns -- so the live-row mask is applied

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -5858,8 +5858,15 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
             If ``True`` (default), rows with null/NaN group keys are skipped.
             If ``False``, null/NaN keys form their own group.
         engine:
-            Execution engine.  Phase 1 accepts ``"auto"`` and uses the NumPy
-            chunked implementation.
+            Execution engine for built-in aggregations (``size``, ``count``,
+            ``sum``, ``mean``, ``min``, ``max``, ``argmin``, ``argmax``):
+
+            * ``"auto"`` (default) -- currently always the NumPy/Cython
+              chunked implementation; may choose automatically in the future.
+            * ``"numpy"`` -- explicitly request the NumPy/Cython chunked
+              implementation.
+            * ``"jit"`` -- reserved for a miniexpr-JIT execution path; not
+              implemented yet (raises :class:`NotImplementedError`).
         chunk_size:
             Optional number of physical rows processed per chunk.
 
@@ -5870,8 +5877,13 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
             ``.size()``, ``.count(column)`` or ``.agg({...})`` to materialize a
             grouped result as a new :class:`CTable`.
         """
-        if engine != "auto":
-            raise ValueError("Only engine='auto' is supported for group_by() in Phase 1")
+        if engine not in ("auto", "numpy", "jit"):
+            raise ValueError(f"engine must be 'auto', 'numpy', or 'jit', got {engine!r}")
+        if engine == "jit":
+            raise NotImplementedError(
+                "engine='jit' is reserved for a future miniexpr-JIT execution path; "
+                "use 'auto' or 'numpy' for now."
+            )
         from blosc2.groupby import CTableGroupBy
 
         return CTableGroupBy(self, keys, sort=sort, dropna=dropna, engine=engine, chunk_size=chunk_size)
@@ -9429,6 +9441,70 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         for name in list(self._materialized_cols):
             if affected is None or name in affected:
                 self.refresh_generated_column(name)
+
+    def apply(
+        self,
+        func,
+        *,
+        columns: list[str] | None = None,
+        dtype=None,
+        engine: str = "auto",
+    ) -> blosc2.NDArray:
+        """Run a row-batch UDF over live column values and materialize the result.
+
+        Sugar over :func:`blosc2.lazyudf` using this table's columns as
+        inputs: ``blosc2.lazyudf(func, tuple(t[c] for c in columns),
+        dtype=dtype, jit=...).compute()``. There is no separate execution
+        path — this reuses exactly the machinery :meth:`add_computed_column`
+        and :meth:`add_generated_column` already use for DSL/UDF columns.
+
+        Parameters
+        ----------
+        func:
+            UDF passed straight to :func:`blosc2.lazyudf`; see that function
+            for the expected signature (``func(inputs_tuple, output,
+            offset)``) and for how a :func:`blosc2.dsl_kernel`-decorated
+            kernel is transpiled instead of run as plain Python.
+        columns:
+            Column names to bind as *func*'s inputs, in order. Defaults to
+            every stored column, in schema order.
+        dtype:
+            Result dtype. Required unless *func* is a
+            :func:`blosc2.dsl_kernel` kernel, whose dtype can be inferred by
+            NumPy type promotion of the input dtypes -- same rule as
+            :func:`blosc2.lazyudf`.
+        engine:
+            Forwarded to :func:`blosc2.lazyudf` as its ``jit`` policy:
+            ``"auto"`` (default) lets it choose, ``"jit"`` forces JIT
+            (only effective for a transpilable :func:`blosc2.dsl_kernel`),
+            ``"numpy"`` disables JIT.
+
+        Examples
+        --------
+        >>> import blosc2
+        >>> from dataclasses import dataclass
+        >>> @dataclass
+        ... class Row:
+        ...     price: float = blosc2.field(blosc2.float64())
+        ...     qty: float = blosc2.field(blosc2.float64())
+        >>> t = blosc2.CTable(Row, new_data=[(10.0, 2.0), (5.0, 3.0)])
+        >>> def revenue(inputs, output, offset):
+        ...     price, qty = inputs
+        ...     output[:] = price * qty
+        >>> t.apply(revenue, columns=["price", "qty"], dtype=blosc2.float64().dtype)[:]
+        array([20., 15.])
+        """
+        if engine not in ("auto", "numpy", "jit"):
+            raise ValueError(f"engine must be 'auto', 'numpy', or 'jit', got {engine!r}")
+        jit = {"auto": None, "numpy": False, "jit": True}[engine]
+        names = columns if columns is not None else list(self.col_names)
+        # Operands are the raw (full-capacity) storage arrays -- the same
+        # inputs add_computed_column()/add_generated_column() pass to
+        # lazyudf() for DSL/UDF columns -- so the live-row mask is applied
+        # once, here, to the result rather than to every operand.
+        operands = tuple(self._cols[self._logical_to_physical_name(name)] for name in names)
+        result = blosc2.lazyudf(func, operands, dtype=dtype, jit=jit).compute()
+        return result[self._valid_rows]
 
     def add_generated_column(  # noqa: C901
         self,

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -9724,12 +9724,12 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
         if engine not in ("auto", "numpy", "jit"):
             raise ValueError(f"engine must be 'auto', 'numpy', or 'jit', got {engine!r}")
         jit = {"auto": None, "numpy": False, "jit": True}[engine]
-        names = columns if columns is not None else list(self.col_names)
+        names = columns if columns is not None else list(self._stored_col_names)
         missing = [n for n in names if self._logical_to_physical_name(n) not in self._cols]
         if missing:
             raise ValueError(
                 f"apply() only accepts stored columns, got {missing!r}. "
-                f"Stored columns: {list(self.col_names)!r}."
+                f"Stored columns: {list(self._stored_col_names)!r}."
             )
         # Operands are the raw (full-capacity) storage arrays -- the same
         # inputs add_computed_column()/add_generated_column() pass to

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -804,6 +804,209 @@ class RowTransformer:
         return self.evaluate_batch({self.source: table[self.source][:]})
 
 
+class NullableExpr:
+    """Lazy result of arithmetic involving nullable columns.
+
+    After the Gap C2b rewrite, arithmetic on nullable int/timestamp columns
+    promotes to float64 with NaN marking the null rows (nullable float
+    columns already use NaN), so NaN is the single null representation for
+    every derived expression.  This wrapper carries that fact plus the
+    owning table, so reductions (``sum``/``mean``/``min``/``max``/``std``)
+    skip nulls and dead physical rows exactly like the corresponding
+    :class:`Column` reductions — instead of NaN-poisoning the way a plain
+    :class:`blosc2.LazyExpr` reduction would.
+
+    Everything else (``compute()``, slicing, use as an operand) behaves like
+    the wrapped expression; further arithmetic keeps the wrapper, since NaN
+    propagates through it.
+
+    ``null_pred`` is the boolean lazy predicate (over the raw physical
+    columns) marking the null rows. It is carried along instead of being
+    re-derived as ``isnan(expr)`` because applying further lazy operations
+    on top of a ``where()``-carrying expression is unreliable, and because
+    it keeps nulls distinct from NaNs the arithmetic itself may produce
+    (e.g. ``0/0``): those are values, not nulls, and are not skipped.
+    """
+
+    def __init__(self, expr, table, null_pred):
+        self._expr = expr
+        self._table = table
+        self._null_pred = null_pred
+
+    def __getattr__(self, name):
+        return getattr(self._expr, name)
+
+    def __getitem__(self, key):
+        return self._expr[key]
+
+    def __repr__(self):
+        return f"NullableExpr({self._expr!r})"
+
+    def compute(self, **kwargs):
+        return self._expr.compute(**kwargs)
+
+    # ---- chaining: arithmetic keeps the NaN-null channel ----
+
+    def _wrap(self, expr, other=None):
+        pred = self._null_pred
+        if isinstance(other, NullableExpr):
+            pred = pred | other._null_pred
+        return NullableExpr(expr, self._table, pred)
+
+    @staticmethod
+    def _operand(other):
+        return other._expr if isinstance(other, NullableExpr) else other
+
+    @staticmethod
+    def _defer(other) -> bool:
+        # Column operands re-enter through Column.__r<op>__, which applies
+        # the column's own sentinel-null rewrite (operating on its raw
+        # storage here would leak sentinel values into the result).
+        return isinstance(other, Column)
+
+    def __add__(self, other):
+        if self._defer(other):
+            return NotImplemented
+        return self._wrap(self._expr + self._operand(other), other)
+
+    def __radd__(self, other):
+        return self._wrap(other + self._expr)
+
+    def __sub__(self, other):
+        if self._defer(other):
+            return NotImplemented
+        return self._wrap(self._expr - self._operand(other), other)
+
+    def __rsub__(self, other):
+        return self._wrap(other - self._expr)
+
+    def __mul__(self, other):
+        if self._defer(other):
+            return NotImplemented
+        return self._wrap(self._expr * self._operand(other), other)
+
+    def __rmul__(self, other):
+        return self._wrap(other * self._expr)
+
+    def __truediv__(self, other):
+        if self._defer(other):
+            return NotImplemented
+        return self._wrap(self._expr / self._operand(other), other)
+
+    def __rtruediv__(self, other):
+        return self._wrap(other / self._expr)
+
+    def __floordiv__(self, other):
+        if self._defer(other):
+            return NotImplemented
+        return self._wrap(self._expr // self._operand(other), other)
+
+    def __rfloordiv__(self, other):
+        return self._wrap(other // self._expr)
+
+    def __mod__(self, other):
+        if self._defer(other):
+            return NotImplemented
+        return self._wrap(self._expr % self._operand(other), other)
+
+    def __rmod__(self, other):
+        return self._wrap(other % self._expr)
+
+    def __pow__(self, other):
+        if self._defer(other):
+            return NotImplemented
+        # nan ** 0 == 1.0 would silently resurrect a null as a real value.
+        pred = self._null_pred
+        if isinstance(other, NullableExpr):
+            pred = pred | other._null_pred
+        return self._wrap(blosc2.where(pred, np.nan, self._expr ** self._operand(other)), other)
+
+    def __rpow__(self, other):
+        # 1 ** nan == 1.0, same hazard as __pow__.
+        return self._wrap(blosc2.where(self._null_pred, np.nan, other**self._expr))
+
+    def __neg__(self):
+        return self._wrap(-self._expr)
+
+    # ---- comparisons: IEEE NaN already gives SQL False, except for != ----
+
+    def __lt__(self, other):
+        return NotImplemented if self._defer(other) else self._expr < self._operand(other)
+
+    def __le__(self, other):
+        return NotImplemented if self._defer(other) else self._expr <= self._operand(other)
+
+    def __gt__(self, other):
+        return NotImplemented if self._defer(other) else self._expr > self._operand(other)
+
+    def __ge__(self, other):
+        return NotImplemented if self._defer(other) else self._expr >= self._operand(other)
+
+    def __eq__(self, other):
+        return NotImplemented if self._defer(other) else self._expr == self._operand(other)
+
+    def __ne__(self, other):
+        # IEEE says nan != x is True; SQL null semantics say a null satisfies
+        # no comparison. Guard both sides (Column and NullableExpr operands
+        # carry their own null predicates).
+        result = (self._expr != Column._unwrap_operand(other)) & ~self._null_pred
+        other_pred = None
+        if isinstance(other, Column):
+            other_pred = other._raw_null_pred()
+        elif isinstance(other, NullableExpr):
+            other_pred = other._null_pred
+        if other_pred is not None:
+            result = result & ~other_pred
+        return result
+
+    # ---- reductions: skip nulls and dead physical rows ----
+
+    def _reduction_mask(self, where=None):
+        """Live, non-null rows in physical coordinates — the same recipe as
+        ``Column._lazy_nonnull_mask``, with the carried null predicate in
+        place of the per-column sentinel check."""
+        t = self._table
+        n_rows = t._known_n_rows()
+        mask = None if (n_rows is not None and n_rows == len(t._valid_rows)) else t._valid_rows
+        if where is not None:
+            mask = where if mask is None else mask & where
+        nonnull = ~self._null_pred
+        return nonnull if mask is None else mask & nonnull
+
+    def sum(self, dtype=None, *, where=None):
+        """Sum of live, non-null values; zero when every value is null."""
+        return float(self._expr.sum(where=self._reduction_mask(where), dtype=dtype or np.float64))
+
+    def mean(self, *, where=None):
+        """Mean of live, non-null values; NaN when every value is null."""
+        try:
+            return float(self._expr.mean(where=self._reduction_mask(where), dtype=np.float64))
+        except ValueError:
+            return float("nan")
+
+    def std(self, ddof: int = 0, *, where=None):
+        """Standard deviation of live, non-null values; NaN when every value is null."""
+        try:
+            return float(self._expr.std(where=self._reduction_mask(where), dtype=np.float64, ddof=ddof))
+        except ValueError:
+            return float("nan")
+
+    def _minmax(self, op: str, where):
+        mask = self._reduction_mask(where)
+        count = int(mask.where(blosc2.ones(self._expr.shape, dtype=np.int64), 0).sum(dtype=np.int64))
+        if count == 0:
+            raise ValueError(f"{op}() called on an expression where all values are null.")
+        return getattr(self._expr, op)(where=mask)
+
+    def min(self, *, where=None):
+        """Minimum of live, non-null values; raises ``ValueError`` if all are null."""
+        return self._minmax("min", where)
+
+    def max(self, *, where=None):
+        """Maximum of live, non-null values; raises ``ValueError`` if all are null."""
+        return self._minmax("max", where)
+
+
 class Column:
     """Column view for a :class:`CTable`, with vectorized operations and reductions."""
 
@@ -1540,6 +1743,8 @@ class Column:
         if isinstance(other, Column):
             other._ensure_queryable()
             return other._raw_col
+        if isinstance(other, NullableExpr):
+            return other._expr
         return other
 
     @property
@@ -1605,7 +1810,12 @@ class Column:
         """OR of self's and other's raw null predicates; ``None`` if neither
         operand is nullable (the zero-overhead case)."""
         self_pred = self._raw_null_pred()
-        other_pred = other._raw_null_pred() if isinstance(other, Column) else None
+        if isinstance(other, Column):
+            other_pred = other._raw_null_pred()
+        elif isinstance(other, NullableExpr):
+            other_pred = other._null_pred
+        else:
+            other_pred = None
         if self_pred is None:
             return other_pred
         if other_pred is None:
@@ -1616,14 +1826,15 @@ class Column:
         """Sentinel-based null propagation for arithmetic (see Gap C2b of
         plans/enhancing-ctable.md): rows where any nullable operand is null
         become NaN in the result, promoting integer/timestamp results to
-        float64 the same way pandas' legacy int-null arithmetic does. Costs
-        nothing when neither operand is nullable — *raw_result* is returned
-        unchanged.
+        float64 the same way pandas' legacy int-null arithmetic does. The
+        result is a :class:`NullableExpr`, so reductions on it skip nulls
+        like the corresponding Column reductions. Costs nothing when neither
+        operand is nullable — *raw_result* is returned unchanged.
         """
         null_pred = self._combined_null_pred(other)
         if null_pred is None:
             return raw_result
-        return blosc2.where(null_pred, np.nan, raw_result)
+        return NullableExpr(blosc2.where(null_pred, np.nan, raw_result), self._table, null_pred)
 
     def _null_aware_compare(self, other, raw_result):
         """SQL ``WHERE`` semantics for comparisons (see Gap C2b): a null

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -807,10 +807,9 @@ class RowTransformer:
 class NullableExpr:
     """Lazy result of arithmetic involving nullable columns.
 
-    After the Gap C2b rewrite, arithmetic on nullable int/timestamp columns
-    promotes to float64 with NaN marking the null rows (nullable float
-    columns already use NaN), so NaN is the single null representation for
-    every derived expression.  This wrapper carries that fact plus the
+    Arithmetic on nullable int/timestamp columns promotes to float64 with
+    NaN marking the null rows (nullable float columns already use NaN), so
+    NaN is the single null representation for every derived expression.  This wrapper carries that fact plus the
     owning table, so reductions (``sum``/``mean``/``min``/``max``/``std``)
     skip nulls and dead physical rows exactly like the corresponding
     :class:`Column` reductions — instead of NaN-poisoning the way a plain
@@ -1823,8 +1822,8 @@ class Column:
         return self_pred | other_pred
 
     def _null_aware_arith(self, other, raw_result):
-        """Sentinel-based null propagation for arithmetic (see Gap C2b of
-        plans/enhancing-ctable.md): rows where any nullable operand is null
+        """Sentinel-based null propagation for arithmetic: rows where any
+        nullable operand is null
         become NaN in the result, promoting integer/timestamp results to
         float64 the same way pandas' legacy int-null arithmetic does. The
         result is a :class:`NullableExpr`, so reductions on it skip nulls
@@ -1837,7 +1836,7 @@ class Column:
         return NullableExpr(blosc2.where(null_pred, np.nan, raw_result), self._table, null_pred)
 
     def _null_aware_compare(self, other, raw_result):
-        """SQL ``WHERE`` semantics for comparisons (see Gap C2b): a null
+        """SQL ``WHERE`` semantics for comparisons: a null
         operand never satisfies any comparison, so null rows are forced to
         False. Costs nothing when neither operand is nullable.
         """

--- a/src/blosc2/ctable.py
+++ b/src/blosc2/ctable.py
@@ -1993,6 +1993,11 @@ class Column:
                 elem_mask = arr == nv
             inner_axes = tuple(range(1, elem_mask.ndim))
             return elem_mask.all(axis=inner_axes) if inner_axes else elem_mask.astype(np.bool_)
+        if np.issubdtype(arr.dtype, np.datetime64):
+            # Timestamp columns materialize with the int64 sentinel already
+            # decoded into np.datetime64('NaT') (they share the same bit
+            # pattern), so the sentinel value itself never appears in arr.
+            return np.isnat(arr)
         if isinstance(nv, (float, np.floating)) and np.isnan(nv):
             return np.isnan(arr)
         return arr == nv
@@ -2028,6 +2033,20 @@ class Column:
         if self.null_value is None:
             return 0
         return int(self.is_null().sum())
+
+    def fillna(self, value):
+        """Return live values with null sentinels replaced by *value*.
+
+        Dictionary and variable-length scalar columns (whose nulls are
+        native ``None`` cells) return a list; other columns return a NumPy
+        array.
+        """
+        if self.is_dictionary or self.is_varlen_scalar:
+            return [value if v is None else v for v in self[:]]
+        arr = np.array(self[:], copy=True)
+        if self.null_value is not None:
+            arr[self._null_mask_for(arr)] = value
+        return arr
 
     def _nonnull_chunks(self):
         """Yield chunks of live, non-null values.
@@ -11798,6 +11817,30 @@ class CTable(_CTableIndexingMixin, Generic[RowT]):
 
     def _guard_varlen_scalar_expression(self, expr: str) -> None:
         self._guard_scalar_expression(expr)
+
+    def _is_nullable_column(self, name: str) -> bool:
+        col = self[name]
+        return col.null_value is not None or col.is_dictionary or col.is_varlen_scalar
+
+    def dropna(self, subset: list[str] | None = None) -> CTable:
+        """Return a view excluding rows where any column in *subset* is null.
+
+        Parameters
+        ----------
+        subset:
+            Column names to check for nulls. Defaults to every nullable
+            column (sentinel-backed, dictionary, or variable-length scalar).
+
+        Returns
+        -------
+        CTable
+            A read-only view over the live, non-null rows (see :meth:`where`).
+        """
+        names = subset if subset is not None else [n for n in self.col_names if self._is_nullable_column(n)]
+        mask = np.ones(self.nrows, dtype=np.bool_)
+        for name in names:
+            mask &= self[name].notnull()
+        return self.where(mask)
 
     def where(  # noqa: C901
         self,

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -1800,7 +1800,7 @@ class CTableGroupBy:
                     else:
                         group_values = np.concatenate(chunks)
                         try:
-                            result = _python_scalar(np.asarray(spec.udf(group_values)))
+                            result = _python_scalar(spec.udf(group_values))
                         except Exception as exc:
                             raise RuntimeError(
                                 f"UDF aggregation {spec.output_col!r} raised for group "
@@ -1835,6 +1835,16 @@ class CTableGroupBy:
         another) is caught here with a clear error, rather than surfacing as
         an opaque failure while building the result table.
         """
+        if not results:
+            # No group ever produced a value (e.g. an empty table, or every
+            # group is all-null so the UDF was never called) -- there is
+            # nothing to infer a dtype from.
+            raise ValueError(
+                f"Cannot infer a CTable dtype for UDF aggregation {name!r}: it was never "
+                f"called (empty table, or every group had no non-null values). Pass an "
+                f"explicit dtype in the named-agg tuple, e.g. "
+                f"g.agg({name}=(col, fn, blosc2.float64()))."
+            )
         try:
             arr = np.asarray(results)
         except ValueError as exc:

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import copy
 import dataclasses
 import math
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Literal
 
 import numpy as np
@@ -31,7 +31,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from blosc2.ctable import CTable
 
 
-AggName = Literal["size", "count", "sum", "mean", "min", "max", "argmin", "argmax"]
+AggName = Literal["size", "count", "sum", "mean", "min", "max", "argmin", "argmax", "udf"]
 
 _NAN_KEY = ("__blosc2_groupby_nan__",)
 
@@ -41,6 +41,8 @@ class _AggSpec:
     input_col: str | None
     op: AggName
     output_col: str
+    udf: Callable | None = None
+    explicit_dtype: SchemaSpec | None = None
 
 
 @dataclasses.dataclass
@@ -222,7 +224,11 @@ class CTableGroupBy:
           objects (e.g. ``t.price``), which cannot be dict keys.
         * **Explicitly named** -- pass ``output_name=(column, op)`` keyword
           arguments (pandas-style named aggregation), giving the result column
-          exactly the name you want.
+          exactly the name you want.  This is also the only form that accepts a
+          **custom UDF aggregation**: ``output_name=(column, callable)``, or
+          ``output_name=(column, callable, dtype)`` to give the output column's
+          schema spec explicitly instead of inferring it from the callable's
+          results.
 
         Parameters
         ----------
@@ -235,13 +241,24 @@ class CTableGroupBy:
             row-count spelling ``"*": "size"``.  An op may also be given as the
             corresponding blosc2 reduction *function* (``blosc2.sum``, ``mean``,
             ``min``, ``max``, ``argmin``, ``argmax``), matched by identity; this
-            is a naming shorthand, not a UDF mechanism (custom functions are
-            rejected).  Result columns are named ``"<column>_<op>"``.
+            is a naming shorthand, not a UDF mechanism.  Result columns are
+            named ``"<column>_<op>"``.  Custom callables are only accepted via
+            the named-aggregation form (see below).
         urlpath:
             If given, write the result as a persistent CTable at that path.
         **named:
-            Named aggregations as ``output_name=(column, op)`` pairs.  Use
-            ``("*", "size")`` for a row count.
+            Named aggregations as ``output_name=(column, op)`` pairs, or
+            ``output_name=(column, callable[, dtype])`` for a custom UDF
+            aggregation.  Use ``("*", "size")`` for a row count.
+
+            A UDF callable receives a 1-D NumPy array of the group's live,
+            non-null values (nulls are pre-filtered, same as the built-in
+            aggregations) and returns a scalar.  It is called once per group
+            with a plain Python loop -- there is no acceleration yet, this is
+            the "slow but correct" baseline and semantics oracle for any
+            future JIT path.  The output dtype is inferred from the results
+            across *every* group (raising a clear error if they disagree) unless
+            *dtype* is given explicitly as a blosc2 schema spec.
 
         Examples
         --------
@@ -255,6 +272,8 @@ class CTableGroupBy:
         >>> g.agg(revenue=("sales", "sum"), avg_sale=("sales", "mean"))  # doctest: +SKIP
         >>> # Forms combine, e.g. a list of pairs plus a named row count.
         >>> g.agg([(t.sales, "sum")], n=("*", "size"))  # doctest: +SKIP
+        >>> # Custom UDF aggregation (named form only).
+        >>> g.agg(sales_range=("sales", lambda a: a.max() - a.min()))  # doctest: +SKIP
         """
         specs = self._normalize_aggs(aggregations, named)
         return self._execute(specs, urlpath=urlpath)
@@ -265,8 +284,11 @@ class CTableGroupBy:
         Accepts a name string, or one of blosc2's own reduction *functions*
         (:func:`blosc2.sum`, ``mean``, ``min``, ``max``, ``argmin``, ``argmax``)
         matched **by identity** -- so a user function that merely shares a name
-        (e.g. a UDF called ``sum``) is *not* silently accepted, and custom UDF
-        aggregations are rejected rather than misinterpreted.
+        (e.g. a UDF called ``sum``) is *not* silently accepted here.  Custom UDF
+        aggregations are only accepted via the named form (``output_name=(col,
+        callable)``, see :meth:`agg`); this method only ever sees a callable
+        when it fell through that path (auto-named mapping/list forms, which
+        cannot derive an output column name for an arbitrary callable).
         """
         if isinstance(op, str):
             return op
@@ -278,19 +300,33 @@ class CTableGroupBy:
                 f"Unsupported aggregation function {getattr(op, '__name__', op)!r}.  Pass a "
                 f"string op name (e.g. 'sum') or a blosc2 reduction function "
                 f"(blosc2.sum/mean/min/max/argmin/argmax).  Custom UDF aggregations are "
-                f"not supported."
+                f"supported only via the named form, e.g. "
+                f"g.agg(my_range=(col, {getattr(op, '__name__', 'my_func')}))."
             )
         raise ValueError(f"Aggregation op must be a string or a blosc2 reduction function, got {op!r}")
 
-    def _build_agg_spec(self, col_name, op, output_col: str | None = None) -> _AggSpec:
+    def _build_agg_spec(
+        self, col_name, op, output_col: str | None = None, *, dtype: SchemaSpec | None = None
+    ) -> _AggSpec:
         """Validate a single (column, op) pair and build its :class:`_AggSpec`.
 
         ``output_col`` overrides the default ``"<column>_<op>"`` name; ``"*"`` as
         *col_name* (only with ``op="size"``) yields a row count.  *col_name* may
         be a column name string or a :class:`~blosc2.ctable.Column` object; *op*
-        may be an op name string or a blosc2 reduction function (see
-        :meth:`_resolve_op`).
+        may be an op name string, a blosc2 reduction function (see
+        :meth:`_resolve_op`), or an arbitrary callable UDF aggregation (see
+        :meth:`agg`), in which case *dtype* optionally gives the output
+        column's schema spec (e.g. ``blosc2.float64()``) instead of inferring
+        it from the UDF's first result.
         """
+        if output_col is not None and callable(op) and op not in _op_alias_map():
+            # Only the named form (output_col given) may carry a custom UDF;
+            # the auto-named mapping/list forms cannot derive a column name
+            # for an arbitrary callable, so they fall through to _resolve_op()
+            # below and get its "unsupported aggregation function" error.
+            physical = self.table._logical_to_physical_name(_column_name(col_name))
+            self._validate_value_column(physical)
+            return _AggSpec(physical, "udf", output_col, udf=op, explicit_dtype=dtype)
         op = self._resolve_op(op)
         # Guard the "*" check with isinstance: a Column object overloads __eq__
         # to build an expression, so a bare ``col_name == "*"`` would not return
@@ -343,11 +379,18 @@ class CTableGroupBy:
             for col_name, ops in entries:
                 specs.extend(self._expand_ops(col_name, ops))
         for out_name, value in (named or {}).items():
-            if not (isinstance(value, (tuple, list)) and len(value) == 2):
+            if not (isinstance(value, (tuple, list)) and len(value) in (2, 3)):
                 raise ValueError(
-                    f"Named aggregation {out_name!r} must be a (column, op) pair, got {value!r}"
+                    f"Named aggregation {out_name!r} must be a (column, op) or "
+                    f"(column, op, dtype) tuple, got {value!r}"
                 )
-            col_name, op = value
+            col_name, op, *rest = value
+            dtype = rest[0] if rest else None
+            if dtype is not None and not (callable(op) and op not in _op_alias_map()):
+                raise ValueError(
+                    f"Named aggregation {out_name!r}: an explicit dtype is only supported "
+                    "for callable UDF aggregations"
+                )
             if isinstance(op, (tuple, list, set)):
                 raise ValueError(
                     f"Named aggregation {out_name!r} takes a single op, got {op!r}.  "
@@ -355,7 +398,7 @@ class CTableGroupBy:
                     f"form agg({{column: [...]}}) for several ops, or give each its "
                     f"own name (e.g. {out_name}_sum=(col, 'sum'))."
                 )
-            specs.append(self._build_agg_spec(col_name, op, output_col=out_name))
+            specs.append(self._build_agg_spec(col_name, op, output_col=out_name, dtype=dtype))
         output_names = [s.output_col for s in specs]
         if len(output_names) != len(set(output_names)):
             raise ValueError("Aggregation output column names must be unique")
@@ -399,7 +442,12 @@ class CTableGroupBy:
 
         argmin/argmax can only use the dense single-key path (it tracks row
         positions); the Cython kernels do not, so they are skipped for them.
+        UDF aggregations (see Gap D2) always fall through to the generic
+        chunked path below, which is the only one that accumulates raw
+        per-group values instead of a mergeable scalar state.
         """
+        if any(s.op == "udf" for s in specs):
+            return None
         if not use_arg_positions:
             for attempt in (
                 self._try_execute_cython_dense_int_key,
@@ -1584,7 +1632,28 @@ class CTableGroupBy:
                 partials[spec.output_col] = self._argminmax_partials(
                     spec.op, inverse, values, non_null, row_positions, n_groups
                 )
+            elif spec.op == "udf":
+                partials[spec.output_col] = self._udf_value_partials(inverse, values, non_null, n_groups)
         return partials
+
+    def _udf_value_partials(
+        self, inverse: np.ndarray, values: np.ndarray, non_null: np.ndarray, n_groups: int
+    ) -> list[np.ndarray]:
+        """Split this chunk's non-null values by group, for UDF aggregations.
+
+        Unlike the built-in ops, an arbitrary Python callable cannot be
+        incrementally merged across chunks, so each chunk instead contributes
+        its raw per-group values; :meth:`_merge_partials` collects these into
+        a growing list per group, and :meth:`_final_rows` concatenates and
+        calls the UDF once, after all chunks have been read.
+        """
+        groups = inverse[non_null]
+        vals = values[non_null]
+        order = np.argsort(groups, kind="stable")
+        sorted_groups = groups[order]
+        sorted_vals = vals[order]
+        boundaries = np.searchsorted(sorted_groups, np.arange(n_groups + 1))
+        return [sorted_vals[boundaries[g] : boundaries[g + 1]] for g in range(n_groups)]
 
     def _minmax_partials(
         self, op: AggName, inverse: np.ndarray, values: np.ndarray, non_null: np.ndarray, n_groups: int
@@ -1636,7 +1705,7 @@ class CTableGroupBy:
             best_positions = np.where(pos_best != int_max, pos_best, -1)
         return best_values, best_positions, has_value
 
-    def _merge_partials(
+    def _merge_partials(  # noqa: C901
         self,
         acc: dict[Any, dict[str, _AggState]],
         key_values: dict[Any, tuple[Any, ...]],
@@ -1685,8 +1754,14 @@ class CTableGroupBy:
                         ):
                             state.value = (value, int(positions[i]))
                         state.count += 1
+                elif spec.op == "udf":
+                    chunk_values = partial[i]
+                    if state.value is None:
+                        state.value = []
+                    if len(chunk_values):
+                        state.value.append(chunk_values)
 
-    def _final_rows(
+    def _final_rows(  # noqa: C901
         self,
         acc: dict[Any, dict[str, _AggState]],
         key_values: dict[Any, tuple[Any, ...]],
@@ -1701,6 +1776,12 @@ class CTableGroupBy:
         if self._resolve_sort(cheap=False):
             keys.sort(key=lambda k: tuple(_sortable_key_part(v) for v in key_values[k]))
 
+        # Sentinel distinguishing "group had zero non-null values, UDF was
+        # never called" from a UDF legitimately returning None; patched to a
+        # real null value once the output dtype is known, below.
+        _empty_udf_group = object()
+
+        udf_results: dict[str, list] = {spec.output_col: [] for spec in specs if spec.op == "udf"}
         rows = []
         for norm_key in keys:
             row = dict(zip(self.keys, key_values[norm_key], strict=True))
@@ -1709,6 +1790,24 @@ class CTableGroupBy:
                 state = states[spec.output_col]
                 if spec.op == "mean":
                     row[spec.output_col] = math.nan if state.count == 0 else state.value / state.count
+                elif spec.op == "udf":
+                    chunks = state.value
+                    if not chunks:
+                        # No non-null values for this group/column; matches
+                        # the sum/min/max convention of a null result rather
+                        # than calling the UDF with an empty array.
+                        row[spec.output_col] = _empty_udf_group
+                    else:
+                        group_values = np.concatenate(chunks)
+                        try:
+                            result = _python_scalar(np.asarray(spec.udf(group_values)))
+                        except Exception as exc:
+                            raise RuntimeError(
+                                f"UDF aggregation {spec.output_col!r} raised for group "
+                                f"{key_values[norm_key]!r}: {exc}"
+                            ) from exc
+                        row[spec.output_col] = result
+                        udf_results[spec.output_col].append(result)
                 elif spec.op in {"sum", "min", "max", "argmin", "argmax"} and state.count == 0:
                     row[spec.output_col] = _null_output_value(self._result_spec_for_agg(spec))
                 elif spec.op in {"argmin", "argmax"}:
@@ -1716,7 +1815,54 @@ class CTableGroupBy:
                 else:
                     row[spec.output_col] = 0 if state.value is None else state.value
             rows.append(row)
+        for spec in specs:
+            if spec.op != "udf":
+                continue
+            if spec.explicit_dtype is None:
+                spec.explicit_dtype = self._infer_udf_spec(udf_results[spec.output_col], spec.output_col)
+            null_value = _null_output_value(spec.explicit_dtype)
+            for row in rows:
+                if row[spec.output_col] is _empty_udf_group:
+                    row[spec.output_col] = null_value
         return rows
+
+    @staticmethod
+    def _infer_udf_spec(results: list, name: str) -> SchemaSpec:
+        """Infer a CTable schema spec from a UDF aggregation's collected results.
+
+        Probing every group's result (not just the first) means a UDF that
+        returns inconsistent types (e.g. int for one group, a string for
+        another) is caught here with a clear error, rather than surfacing as
+        an opaque failure while building the result table.
+        """
+        try:
+            arr = np.asarray(results)
+        except ValueError as exc:
+            # Ragged/inhomogeneous results (e.g. a UDF returning a list for
+            # one group and a scalar for another) raise here rather than
+            # producing an object array.
+            raise ValueError(
+                f"UDF aggregation {name!r} produced inconsistent or unsupported types "
+                f"across groups: {results!r} ({exc}). Pass an explicit dtype in the "
+                f"named-agg tuple, e.g. g.agg({name}=(col, fn, blosc2.float64()))."
+            ) from exc
+        if arr.dtype == object:
+            raise ValueError(
+                f"UDF aggregation {name!r} produced inconsistent or unsupported types "
+                f"across groups: {results!r}. Pass an explicit dtype in the named-agg "
+                f"tuple, e.g. g.agg({name}=(col, fn, blosc2.float64()))."
+            )
+        if arr.dtype.kind == "b":
+            return b2_bool()
+        if arr.dtype.kind in "iu":
+            return int64()
+        if arr.dtype.kind == "f":
+            return float64()
+        raise ValueError(
+            f"Cannot infer a CTable dtype for UDF aggregation {name!r} result dtype "
+            f"{arr.dtype!r}. Pass an explicit dtype in the named-agg tuple, e.g. "
+            f"g.agg({name}=(col, fn, blosc2.string(max_length=32)))."
+        )
 
     def _build_result(self, rows: list[dict[str, Any]], specs: list[_AggSpec]):
         from blosc2.ctable import CTable
@@ -1778,6 +1924,11 @@ class CTableGroupBy:
             return int64(null_value=-1)
         if spec.op == "mean":
             return float64()
+        if spec.op == "udf":
+            # _final_rows() always sets this (inferred, unless the user gave
+            # an explicit dtype) before _build_result() reads it.
+            assert spec.explicit_dtype is not None
+            return spec.explicit_dtype
         assert spec.input_col is not None
         input_spec = self.table._schema.columns_by_name[spec.input_col].spec
         dtype = getattr(input_spec, "dtype", None)

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -442,7 +442,7 @@ class CTableGroupBy:
 
         argmin/argmax can only use the dense single-key path (it tracks row
         positions); the Cython kernels do not, so they are skipped for them.
-        UDF aggregations (see Gap D2) always fall through to the generic
+        UDF aggregations always fall through to the generic
         chunked path below, which is the only one that accumulates raw
         per-group values instead of a mergeable scalar state.
         """

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -1776,9 +1776,11 @@ class CTableGroupBy:
         if self._resolve_sort(cheap=False):
             keys.sort(key=lambda k: tuple(_sortable_key_part(v) for v in key_values[k]))
 
-        # Sentinel distinguishing "group had zero non-null values, UDF was
-        # never called" from a UDF legitimately returning None; patched to a
-        # real null value once the output dtype is known, below.
+        # Sentinel marking a UDF aggregation group with no real result yet --
+        # either it had zero non-null input values (the UDF was never
+        # called), or the UDF itself returned None to signal a null result.
+        # Both cases are excluded from dtype inference and patched to the
+        # output dtype's null value once it is known, below.
         _empty_udf_group = object()
 
         udf_results: dict[str, list] = {spec.output_col: [] for spec in specs if spec.op == "udf"}
@@ -1806,8 +1808,15 @@ class CTableGroupBy:
                                 f"UDF aggregation {spec.output_col!r} raised for group "
                                 f"{key_values[norm_key]!r}: {exc}"
                             ) from exc
-                        row[spec.output_col] = result
-                        udf_results[spec.output_col].append(result)
+                        if result is None:
+                            # The UDF itself signaled a null result; treat it
+                            # like an empty group rather than feeding None
+                            # into dtype inference (which would otherwise see
+                            # it as a genuinely inconsistent result type).
+                            row[spec.output_col] = _empty_udf_group
+                        else:
+                            row[spec.output_col] = result
+                            udf_results[spec.output_col].append(result)
                 elif spec.op in {"sum", "min", "max", "argmin", "argmax"} and state.count == 0:
                     row[spec.output_col] = _null_output_value(self._result_spec_for_agg(spec))
                 elif spec.op in {"argmin", "argmax"}:

--- a/src/blosc2/groupby.py
+++ b/src/blosc2/groupby.py
@@ -1517,7 +1517,10 @@ class CTableGroupBy:
         self, keys_live: list[np.ndarray]
     ) -> tuple[np.ndarray | list[np.ndarray], np.ndarray]:
         if len(keys_live) == 1:
-            unique, inverse = np.unique(keys_live[0], return_inverse=True)
+            arr = keys_live[0]
+            if arr.dtype.kind in ("U", "S") and arr.dtype.itemsize % 4 == 0 and arr.dtype.itemsize:
+                return _factorize_fixed_width_str(arr)
+            unique, inverse = np.unique(arr, return_inverse=True)
             return unique, inverse
 
         dtype = [(f"k{i}", arr.dtype) for i, arr in enumerate(keys_live)]
@@ -1977,6 +1980,43 @@ class CTableGroupBy:
         if null_value is not None and not (isinstance(null_value, float) and math.isnan(null_value)):
             mask |= values == null_value
         return mask
+
+
+_HASH_MIX = np.uint64(0x9E3779B97F4A7C15)
+
+
+def _factorize_fixed_width_str(arr: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Exact ``np.unique(arr, return_inverse=True)`` for fixed-width string
+    keys, ~2x faster.
+
+    Argsorting N strings is the string-key groupby bottleneck (a ``U8`` key
+    compares 32 bytes of UTF-32 per element), so instead: hash each row's raw
+    bytes into one uint64, factorize the *integers*, and recover the string
+    for each group from one representative row.  A vectorized verify pass
+    keeps it exact — on a hash collision (different strings, same hash) fall
+    back to plain ``np.unique``.  Output contract (uniques sorted ascending,
+    inverse indices into them) is identical to ``np.unique``, so callers
+    cannot tell the difference.
+
+    ponytail: per-chunk cost is now the int64 unique-argsort; a cross-chunk
+    vocabulary cache (searchsorted against known hashes) could roughly halve
+    it again if string-key groupby speed ever matters more.
+    """
+    words = arr.view(np.uint32).reshape(len(arr), arr.dtype.itemsize // 4)
+    h = words[:, 0].astype(np.uint64)
+    for i in range(1, words.shape[1]):
+        h = (h * _HASH_MIX) ^ words[:, i]
+    hash_uniques, inverse = np.unique(h, return_inverse=True)
+    representative = np.empty(len(hash_uniques), dtype=np.int64)
+    representative[inverse] = np.arange(len(arr))  # any row of the group will do
+    reps = arr[representative]
+    if not (arr == reps[inverse]).all():
+        return np.unique(arr, return_inverse=True)  # collision: exact fallback
+    # np.unique contract: uniques ascending by *string*, not by hash.
+    order = np.argsort(reps, kind="stable")
+    rank = np.empty(len(order), dtype=inverse.dtype)
+    rank[order] = np.arange(len(order), dtype=inverse.dtype)
+    return reps[order], rank[inverse]
 
 
 def _normalize_key_part(value: Any) -> Any:

--- a/src/blosc2/lazyexpr.py
+++ b/src/blosc2/lazyexpr.py
@@ -132,6 +132,10 @@ def ne_evaluate(expression, local_dict=None, **kwargs):
                 if callable(getattr(blosc2, name)) and not name.startswith("_")
             }
         )
+        # Expression strings can carry non-finite float literals ("nan",
+        # "inf" — the repr of such scalars, or typed by the user); numexpr
+        # has no such constants, so this python-eval fallback must.
+        safe_blosc2_globals.update({"nan": math.nan, "inf": math.inf})
     res = eval(expression, safe_blosc2_globals, local_dict)
     if "out" in kwargs:
         out = kwargs.pop("out")
@@ -255,7 +259,7 @@ funcs_2args = (
 
 def get_expr_globals(expression):
     """Build a dictionary of functions needed for evaluating the expression."""
-    _globals = {"np": np, "blosc2": blosc2}
+    _globals = {"np": np, "blosc2": blosc2, "nan": math.nan, "inf": math.inf}
     # Only check for functions that actually appear in the expression.
     for func in functions:
         if func in expression:
@@ -985,6 +989,8 @@ def conserve_functions(  # noqa: C901
             if node.id in self.function_names:  # Skip function names
                 return
             elif node.id not in dtype_symbols:
+                if node.id in ("nan", "inf") and node.id not in operands_old:
+                    return  # non-finite float literal, not an operand
                 localop = operands_old[node.id]
                 if isinstance(localop, blosc2.LazyExpr):
                     newexpr = localop.expression
@@ -3362,6 +3368,18 @@ class LazyExpr(LazyArray):
 
         value2 = _to_native_if_safe(value2)
 
+        # Non-finite Python floats repr as bare names ("nan", "inf") that no
+        # expression evaluator defines; retype them so they take the
+        # typed-scalar branches below and ride as named operands instead of
+        # expression text.
+        def _retype_nonfinite(v):
+            if isinstance(v, float) and not math.isfinite(v):
+                return np.float64(v)
+            return v
+
+        value1 = _retype_nonfinite(value1)
+        value2 = _retype_nonfinite(value2)
+
         if isinstance(value1, LazyExpr) or isinstance(value2, LazyExpr):
             if isinstance(value1, LazyExpr):
                 newexpr = value1.update_expr(new_op)
@@ -3378,11 +3396,20 @@ class LazyExpr(LazyArray):
                 svalue2 = format_expr_scalar(value2)
                 self.operands = {"o0": ne_evaluate(f"{op}({svalue1}, {svalue2})")}  # eager evaluation
             elif np.isscalar(value2):
-                self.operands = {"o0": value1}
-                self.expression = f"{op}(o0, {format_expr_scalar(value2)})"
+                if isinstance(value2, np.floating) and not math.isfinite(value2):
+                    # nan/inf have no expression literal — keep as named operand
+                    self.operands = {"o0": value1, "o1": value2}
+                    self.expression = f"{op}(o0, o1)"
+                else:
+                    self.operands = {"o0": value1}
+                    self.expression = f"{op}(o0, {format_expr_scalar(value2)})"
             elif np.isscalar(value1):
-                self.operands = {"o0": value2}
-                self.expression = f"{op}({format_expr_scalar(value1)}, o0)"
+                if isinstance(value1, np.floating) and not math.isfinite(value1):
+                    self.operands = {"o0": value2, "o1": value1}
+                    self.expression = f"{op}(o1, o0)"
+                else:
+                    self.operands = {"o0": value2}
+                    self.expression = f"{op}({format_expr_scalar(value1)}, o0)"
             else:
                 self.operands = {"o0": value1, "o1": value2}
                 self.expression = f"{op}(o0, o1)"

--- a/src/blosc2/utils.py
+++ b/src/blosc2/utils.py
@@ -266,7 +266,7 @@ if not NUMPY_GE_2_0:  # handle non-array-api compliance
 # Use numpy eval when running in WebAssembly.  Keep this intentionally small:
 # scanning every callable in numpy triggers lazy imports such as numpy.f2py and
 # numpy.testing during ``import blosc2``.
-safe_numpy_globals = {"np": np, **_NUMPY_ALIASES}
+safe_numpy_globals = {"np": np, "nan": np.nan, "inf": np.inf, **_NUMPY_ALIASES}
 for _name in set(elementwise_funcs + linalg_funcs + reducers + constructors):
     if _name not in safe_numpy_globals and not _name.startswith("_"):
         with contextlib.suppress(AttributeError):
@@ -518,6 +518,8 @@ class ShapeInferencer(ast.NodeVisitor):
         self.shapes = shapes
 
     def visit_Name(self, node):
+        if node.id in ("nan", "inf"):  # non-finite float literals: scalars
+            return ()
         if node.id not in self.shapes:
             raise ValueError(f"Unknown symbol: {node.id}")
         s = self.shapes[node.id]

--- a/src/blosc2/utils.py
+++ b/src/blosc2/utils.py
@@ -518,9 +518,9 @@ class ShapeInferencer(ast.NodeVisitor):
         self.shapes = shapes
 
     def visit_Name(self, node):
-        if node.id in ("nan", "inf"):  # non-finite float literals: scalars
-            return ()
         if node.id not in self.shapes:
+            if node.id in ("nan", "inf"):  # non-finite float literals: scalars
+                return ()
             raise ValueError(f"Unknown symbol: {node.id}")
         s = self.shapes[node.id]
         if isinstance(s, tuple):

--- a/tests/ctable/test_arrow_interop.py
+++ b/tests/ctable/test_arrow_interop.py
@@ -511,6 +511,18 @@ def test_from_arrow_accepts_capsule_producer():
     assert via_capsule.to_arrow().equals(via_batches.to_arrow())
 
 
+def test_from_arrow_rejects_capsule_plus_batches():
+    at = pa.table({"id": [1, 2]})
+    with pytest.raises(TypeError, match="not both"):
+        CTable.from_arrow(at, at.to_batches())
+
+
+def test_from_arrow_requires_batches_for_plain_schema():
+    at = pa.table({"id": [1, 2]})
+    with pytest.raises(TypeError, match="requires batches"):
+        CTable.from_arrow(at.schema)
+
+
 def test_duckdb_reads_ctable_directly():
     duckdb = pytest.importorskip("duckdb")
     t = CTable(Row, new_data=DATA10)

--- a/tests/ctable/test_arrow_interop.py
+++ b/tests/ctable/test_arrow_interop.py
@@ -511,6 +511,26 @@ def test_from_arrow_accepts_capsule_producer():
     assert via_capsule.to_arrow().equals(via_batches.to_arrow())
 
 
+def test_arrow_c_stream_empty_table():
+    t = CTable(MixedRow)
+    at = pa.table(t)
+    assert at.num_rows == 0
+    assert at.schema.equals(t.to_arrow().schema)
+
+
+def test_from_arrow_accepts_another_ctable():
+    # A CTable is itself a capsule producer, so it can be ingested directly.
+    t = _mixed_table()
+    roundtripped = CTable.from_arrow(t)
+    assert roundtripped.to_arrow().equals(t.to_arrow())
+
+
+def test_from_arrow_streams_filtered_view():
+    t = _mixed_table()
+    view = t[t.id != t["id"].null_value]
+    assert CTable.from_arrow(view).to_arrow().equals(view.to_arrow())
+
+
 def test_from_arrow_rejects_capsule_plus_batches():
     at = pa.table({"id": [1, 2]})
     with pytest.raises(TypeError, match="not both"):

--- a/tests/ctable/test_arrow_interop.py
+++ b/tests/ctable/test_arrow_interop.py
@@ -459,5 +459,72 @@ def test_from_arrow_variable_batches_roundtrip():
     assert int(blosc2.count_nonzero(t._valid_rows[:n])) == n
 
 
+# ===========================================================================
+# __arrow_c_stream__ (Arrow PyCapsule protocol)
+# ===========================================================================
+
+
+@dataclass
+class MixedRow:
+    id: int = blosc2.field(blosc2.int64(null_value=np.iinfo(np.int64).min))
+    value: float = blosc2.field(blosc2.float64(null_value=float("nan")))
+    label: str = blosc2.field(blosc2.string(max_length=8))
+    active: bool = blosc2.field(blosc2.bool())
+    kind: str = blosc2.field(blosc2.dictionary())
+
+
+def _mixed_table():
+    null_id = np.iinfo(np.int64).min
+    data = [
+        (0, 0.0, "r0", True, "a"),
+        (null_id, 1.5, "r1", False, "b"),
+        (2, float("nan"), "r2", True, "a"),
+        (3, 3.5, "r3", False, "c"),
+    ]
+    return CTable(MixedRow, new_data=data)
+
+
+def test_arrow_c_stream_matches_to_arrow():
+    t = _mixed_table()
+    via_capsule = pa.table(t)
+    assert via_capsule.equals(t.to_arrow())
+
+
+def test_arrow_c_stream_filtered_view():
+    t = _mixed_table()
+    view = t[t.id != t["id"].null_value]
+    assert pa.table(view).equals(view.to_arrow())
+
+
+def test_arrow_c_stream_nulls_survive():
+    t = _mixed_table()
+    at = pa.table(t)
+    assert at["id"][1].as_py() is None
+    assert at["value"][2].as_py() is None
+
+
+def test_from_arrow_accepts_capsule_producer():
+    t = CTable(Row, new_data=DATA10)
+    at = t.to_arrow()
+    via_capsule = CTable.from_arrow(at)
+    via_batches = CTable.from_arrow(at.schema, at.to_batches())
+    assert via_capsule.to_arrow().equals(via_batches.to_arrow())
+
+
+def test_duckdb_reads_ctable_directly():
+    duckdb = pytest.importorskip("duckdb")
+    t = CTable(Row, new_data=DATA10)
+    result = duckdb.sql("SELECT count(*) AS n FROM t").fetchone()
+    assert result[0] == len(DATA10)
+
+
+def test_polars_reads_ctable_directly():
+    pl = pytest.importorskip("polars")
+    t = CTable(Row, new_data=DATA10)
+    df = pl.DataFrame(t)
+    assert df.shape == (len(DATA10), 4)
+    assert df.columns == ["id", "score", "active", "label"]
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/ctable/test_ctable_apply.py
+++ b/tests/ctable/test_ctable_apply.py
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #######################################################################
 
-"""Tests for CTable.apply() (Gap D3): sugar over blosc2.lazyudf()."""
+"""Tests for CTable.apply(): sugar over blosc2.lazyudf()."""
 
 from __future__ import annotations
 

--- a/tests/ctable/test_ctable_apply.py
+++ b/tests/ctable/test_ctable_apply.py
@@ -56,6 +56,26 @@ def test_apply_excludes_deleted_rows():
     np.testing.assert_array_equal(result[:], [20.0, 1.0, 16.0])
 
 
+def test_apply_returns_numpy_array():
+    t = CTable(Row, new_data=DATA)
+    assert isinstance(t.apply(_revenue, dtype=np.float64), np.ndarray)
+
+
+def test_apply_on_filtered_view_returns_only_view_rows():
+    t = CTable(Row, new_data=DATA)
+    v = t[t.price > 4.0]
+    np.testing.assert_array_equal(v.apply(_revenue, dtype=np.float64), [20.0, 15.0])
+
+
+def test_apply_rejects_unknown_or_computed_columns():
+    t = CTable(Row, new_data=DATA)
+    t.add_computed_column("rev", "price * qty")
+    with pytest.raises(ValueError, match="stored columns"):
+        t.apply(_revenue, columns=["price", "nope"], dtype=np.float64)
+    with pytest.raises(ValueError, match="stored columns"):
+        t.apply(_revenue, columns=["price", "rev"], dtype=np.float64)
+
+
 def test_apply_rejects_bad_engine():
     t = CTable(Row, new_data=DATA)
     with pytest.raises(ValueError, match="engine must be"):

--- a/tests/ctable/test_ctable_apply.py
+++ b/tests/ctable/test_ctable_apply.py
@@ -1,0 +1,83 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#######################################################################
+
+"""Tests for CTable.apply() (Gap D3): sugar over blosc2.lazyudf()."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+import blosc2
+from blosc2 import CTable
+
+
+@dataclass
+class Row:
+    price: float = blosc2.field(blosc2.float64())
+    qty: float = blosc2.field(blosc2.float64())
+
+
+DATA = [(10.0, 2.0), (5.0, 3.0), (1.0, 1.0), (4.0, 4.0)]
+
+
+def _revenue(inputs, output, offset):
+    price, qty = inputs
+    output[:] = price * qty
+
+
+def test_apply_equals_equivalent_direct_lazyudf_call():
+    t = CTable(Row, new_data=DATA)
+    via_apply = t.apply(_revenue, columns=["price", "qty"], dtype=np.float64)
+
+    operands = tuple(t._cols[name] for name in ["price", "qty"])
+    via_lazyudf = blosc2.lazyudf(_revenue, operands, dtype=np.float64).compute()[t._valid_rows]
+
+    np.testing.assert_array_equal(via_apply[:], via_lazyudf[:])
+    np.testing.assert_array_equal(via_apply[:], [20.0, 15.0, 1.0, 16.0])
+
+
+def test_apply_defaults_to_all_columns_in_schema_order():
+    t = CTable(Row, new_data=DATA)
+    result = t.apply(_revenue, dtype=np.float64)
+    np.testing.assert_array_equal(result[:], [20.0, 15.0, 1.0, 16.0])
+
+
+def test_apply_excludes_deleted_rows():
+    t = CTable(Row, new_data=DATA)
+    t.delete([1])  # remove (5.0, 3.0)
+    result = t.apply(_revenue, dtype=np.float64)
+    np.testing.assert_array_equal(result[:], [20.0, 1.0, 16.0])
+
+
+def test_apply_rejects_bad_engine():
+    t = CTable(Row, new_data=DATA)
+    with pytest.raises(ValueError, match="engine must be"):
+        t.apply(_revenue, dtype=np.float64, engine="cython")
+
+
+@pytest.mark.parametrize("engine", ["auto", "numpy", "jit"])
+def test_apply_accepts_all_engine_values(engine):
+    t = CTable(Row, new_data=DATA)
+    result = t.apply(_revenue, dtype=np.float64, engine=engine)
+    np.testing.assert_array_equal(result[:], [20.0, 15.0, 1.0, 16.0])
+
+
+def test_apply_with_dsl_kernel_infers_dtype():
+    @blosc2.dsl_kernel
+    def k_revenue(x, y):
+        return x * y
+
+    t = CTable(Row, new_data=DATA)
+    result = t.apply(k_revenue, columns=["price", "qty"])
+    np.testing.assert_allclose(result[:], [20.0, 15.0, 1.0, 16.0])
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -979,3 +979,56 @@ def test_agg_udf_combines_with_builtin_ops():
     assert result.col_names == ["city", "total", "rng"]
     # Berlin's sum is NaN too (all-null group) -- the existing sum() convention.
     np.testing.assert_allclose(col(result, "total"), [np.nan, 40.0, 60.0])
+
+
+def test_agg_udf_groups_straddle_chunk_boundaries():
+    """chunk_size=2 splits every group across chunks, exercising the raw
+    per-group value accumulation in _udf_value_partials/_merge_partials and
+    the concatenate-then-call-once path in _final_rows."""
+    t = CTable(SalesRow, new_data=DATA)
+    rng = ("sales", lambda a: a.max() - a.min())
+    chunked = t.group_by("city", sort=True, chunk_size=2).agg(rng=rng)
+    unchunked = t.group_by("city", sort=True).agg(rng=rng)
+    np.testing.assert_allclose(col(chunked, "rng"), [np.nan, 20.0, 20.0])
+    np.testing.assert_allclose(col(chunked, "rng"), col(unchunked, "rng"))
+    assert col(chunked, "city") == col(unchunked, "city")
+
+
+def test_agg_udf_sees_all_chunks_of_a_group():
+    """The UDF must be called exactly once per group, with every chunk's
+    values concatenated -- not once per chunk."""
+    seen = []
+
+    def probe(values):
+        seen.append(np.sort(values).tolist())
+        return float(len(values))
+
+    t = CTable(SalesRow, new_data=DATA)
+    t.group_by("city", sort=True, chunk_size=2).agg(n=("sales", probe))
+    assert seen == [[10.0, 30.0], [20.0, 40.0]]  # Paris, Rome; Berlin never called
+
+
+def test_agg_udf_on_filtered_view():
+    t = CTable(SalesRow, new_data=DATA)
+    view = t[t.qty > 1]  # drops the first Paris row (sales=10.0)
+    result = view.group_by("city", sort=True).agg(rng=("sales", lambda a: a.max() - a.min()))
+    # Paris keeps only sales=30.0 (its NaN row is in the view but pre-filtered
+    # for the UDF); Rome keeps 20.0 and 40.0; Berlin is all-null.
+    np.testing.assert_allclose(col(result, "rng"), [np.nan, 0.0, 20.0])
+    assert col(result, "city") == ["Berlin", "Paris", "Rome"]
+
+
+def test_agg_udf_empty_table_with_explicit_dtype():
+    t = CTable(SalesRow)
+    result = t.group_by("city").agg(rng=("sales", lambda a: a.max() - a.min(), blosc2.float32()))
+    assert result.nrows == 0
+    assert result["rng"].dtype == np.float32
+
+
+def test_agg_udf_groupby_object_is_reusable():
+    t = CTable(SalesRow, new_data=DATA)
+    g = t.group_by("city", sort=True)
+    rng = ("sales", lambda a: a.max() - a.min())
+    first = g.agg(rng=rng)
+    second = g.agg(rng=rng)
+    np.testing.assert_allclose(col(first, "rng"), col(second, "rng"))

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -1025,6 +1025,65 @@ def test_agg_udf_empty_table_with_explicit_dtype():
     assert result["rng"].dtype == np.float32
 
 
+def test_factorize_fixed_width_str_matches_np_unique():
+    """The hash-based string-key factorizer must be indistinguishable from
+    np.unique(return_inverse=True), including sort order of the uniques."""
+    from blosc2.groupby import _factorize_fixed_width_str
+
+    rng = np.random.default_rng(0)
+    cases = [
+        np.array([], dtype="U8"),
+        np.array(["a", "a", "a"], dtype="U8"),
+        np.array(["b", "a", "c", "a", "b"], dtype="U8"),
+        np.array(["", "x", "", "y"], dtype="U8"),
+        np.array(["Zürich", "Ōsaka", "münich", "Zürich"], dtype="U8"),
+        rng.choice([f"k{i}" for i in range(500)], 20_000).astype("U8"),
+        rng.choice(["x", "y", "z"], 5_000).astype("U1"),
+        np.array([b"ab", b"cd", b"ab"], dtype="S4"),
+        rng.choice([f"key{i}" for i in range(50)], 20_000).astype("U16"),
+    ]
+    for arr in cases:
+        ref_u, ref_inv = np.unique(arr, return_inverse=True)
+        got_u, got_inv = _factorize_fixed_width_str(arr)
+        np.testing.assert_array_equal(got_u, ref_u)
+        np.testing.assert_array_equal(got_inv, ref_inv)
+
+
+def test_factorize_fixed_width_str_collision_falls_back(monkeypatch):
+    """With the mix constant forced to 0, the row hash degenerates to the last
+    uint32 word, so strings differing only in earlier characters collide --
+    the verify pass must detect it and fall back to exact np.unique."""
+    import blosc2.groupby as gb
+
+    monkeypatch.setattr(gb, "_HASH_MIX", np.uint64(0))
+    arr = np.array(["ax", "bx", "ax", "cx"], dtype="U2")  # all hash to "x"'s word
+    ref_u, ref_inv = np.unique(arr, return_inverse=True)
+    got_u, got_inv = gb._factorize_fixed_width_str(arr)
+    np.testing.assert_array_equal(got_u, ref_u)
+    np.testing.assert_array_equal(got_inv, ref_inv)
+
+
+def test_groupby_string_key_end_to_end_matches_pandas():
+    pd = pytest.importorskip("pandas")
+    rng = np.random.default_rng(7)
+    cities = np.array(["Paris", "Rome", "Berlin", "Madrid", "Lisbon"])
+    keys = cities[rng.integers(0, 5, 10_000)]
+    vals = rng.random(10_000)
+
+    @dataclass
+    class SRow:
+        skey: str = blosc2.field(blosc2.string(max_length=8))
+        val: float = blosc2.field(blosc2.float64())
+
+    t = CTable(SRow)
+    t.extend({"skey": keys, "val": vals}, validate=False)
+    out = t.group_by("skey", sort=True, chunk_size=999).sum("val")  # odd chunk size on purpose
+
+    expected = pd.DataFrame({"skey": keys, "val": vals}).groupby("skey")["val"].sum().sort_index()
+    assert col(out, "skey") == list(expected.index)
+    np.testing.assert_allclose(col(out, "val_sum"), expected.to_numpy())
+
+
 def test_agg_udf_groupby_object_is_reusable():
     t = CTable(SalesRow, new_data=DATA)
     g = t.group_by("city", sort=True)

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -8,7 +8,6 @@
 from dataclasses import dataclass, make_dataclass
 
 import numpy as np
-import pandas as pd
 import pytest
 
 import blosc2
@@ -421,7 +420,8 @@ def test_groupby_engine_numpy_matches_auto():
     t = CTable(SalesRow, new_data=DATA)
     auto_result = t.group_by("city", engine="auto").sum("sales")
     numpy_result = t.group_by("city", engine="numpy").sum("sales")
-    assert auto_result.to_pandas().equals(numpy_result.to_pandas())
+    assert col(auto_result, "city") == col(numpy_result, "city")
+    np.testing.assert_array_equal(col(auto_result, "sales_sum"), col(numpy_result, "sales_sum"))
 
 
 def test_groupby_engine_jit_not_implemented():
@@ -827,6 +827,7 @@ def test_agg_duplicate_output_names_rejected():
 
 
 def test_agg_udf_matches_pandas_reference():
+    pd = pytest.importorskip("pandas")
     t = CTable(SalesRow, new_data=DATA)
     result = t.group_by("city", sort=True).agg(rng=("sales", lambda a: a.max() - a.min()))
 

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -8,6 +8,7 @@
 from dataclasses import dataclass, make_dataclass
 
 import numpy as np
+import pandas as pd
 import pytest
 
 import blosc2
@@ -416,6 +417,19 @@ def test_groupby_rejects_bad_engine():
         t.group_by("city", engine="cython")
 
 
+def test_groupby_engine_numpy_matches_auto():
+    t = CTable(SalesRow, new_data=DATA)
+    auto_result = t.group_by("city", engine="auto").sum("sales")
+    numpy_result = t.group_by("city", engine="numpy").sum("sales")
+    assert auto_result.to_pandas().equals(numpy_result.to_pandas())
+
+
+def test_groupby_engine_jit_not_implemented():
+    t = CTable(SalesRow, new_data=DATA)
+    with pytest.raises(NotImplementedError):
+        t.group_by("city", engine="jit")
+
+
 @pytest.mark.parametrize(
     ("schema_factory", "values"),
     [
@@ -789,7 +803,7 @@ def test_agg_requires_some_aggregation():
 
 def test_agg_named_must_be_column_op_pair():
     t = CTable(SalesRow, new_data=DATA)
-    with pytest.raises(ValueError, match=r"must be a \(column, op\) pair"):
+    with pytest.raises(ValueError, match=r"must be a \(column, op\) or \(column, op, dtype\) tuple"):
         t.group_by("city").agg(x=("sales",))
 
 
@@ -805,3 +819,108 @@ def test_agg_duplicate_output_names_rejected():
     t = CTable(SalesRow, new_data=DATA)
     with pytest.raises(ValueError, match="must be unique"):
         t.group_by("city").agg({"sales": "sum"}, sales_sum=("sales", "sum"))
+
+
+# ===========================================================================
+# UDF aggregations (Gap D2) -- named form only
+# ===========================================================================
+
+
+def test_agg_udf_matches_pandas_reference():
+    t = CTable(SalesRow, new_data=DATA)
+    result = t.group_by("city", sort=True).agg(rng=("sales", lambda a: a.max() - a.min()))
+
+    df = pd.DataFrame(DATA, columns=["city", "category", "sales", "qty"])
+    # Berlin's only row has NaN sales, so unlike df.dropna()-then-groupby (which
+    # would drop the row and the whole group with it), blosc2 keeps Berlin as a
+    # group -- its key is not null -- with a null (NaN) result, the same
+    # convention built-in sum/min/max already use for an all-null group.
+    expected = (
+        df.groupby("city")["sales"]
+        .apply(lambda a: (a.dropna().max() - a.dropna().min()) if a.notna().any() else float("nan"))
+        .sort_index()
+    )
+    np.testing.assert_allclose(col(result, "rng"), expected.to_numpy())
+    assert col(result, "city") == list(expected.index)
+
+
+def test_agg_udf_receives_only_live_nonnull_values():
+    seen = []
+
+    def probe(values):
+        seen.append(np.sort(values).tolist())
+        return float(values.sum())
+
+    t = CTable(SalesRow, new_data=DATA)
+    t.group_by("city", sort=True).agg(total=("sales", probe))
+    # Berlin's only row has NaN sales -> the UDF is never called for it (an
+    # empty group produces a null result directly, like sum/min/max do);
+    # Paris/Rome nulls are dropped before the UDF sees their values.
+    assert seen == [[10.0, 30.0], [20.0, 40.0]]
+
+
+def test_agg_udf_requires_named_form():
+    t = CTable(SalesRow, new_data=DATA)
+    g = t.group_by("city")
+    with pytest.raises(ValueError, match="Unsupported aggregation function"):
+        g.agg({"sales": lambda a: a.sum()})
+    with pytest.raises(ValueError, match="Unsupported aggregation function"):
+        g.agg([(t.sales, lambda a: a.sum())])
+
+
+def test_agg_udf_infers_dtype_from_all_groups():
+    t = CTable(SalesRow, new_data=DATA)
+    result = t.group_by("city").agg(rng=("sales", lambda a: a.max() - a.min() if len(a) else 0.0))
+    assert result["rng"].dtype == np.float64
+
+
+def test_agg_udf_explicit_dtype():
+    t = CTable(SalesRow, new_data=DATA)
+    result = t.group_by("city").agg(
+        rng=("sales", lambda a: a.max() - a.min() if len(a) else 0.0, blosc2.float32())
+    )
+    assert result["rng"].dtype == np.float32
+
+
+def test_agg_udf_inconsistent_types_raise_clear_error():
+    t = CTable(SalesRow, new_data=DATA)
+    g = t.group_by("city")
+    calls = {"n": 0}
+
+    def inconsistent(values):
+        # A shape-inconsistent return (list vs. scalar) forces NumPy to fall
+        # back to an object array when collecting results across groups.
+        calls["n"] += 1
+        return [1, 2, 3] if calls["n"] == 1 else float(values.sum())
+
+    with pytest.raises(ValueError, match="inconsistent or unsupported types"):
+        g.agg(x=("sales", inconsistent))
+
+
+def test_agg_udf_unsupported_result_dtype_raises_clear_error():
+    t = CTable(SalesRow, new_data=DATA)
+    g = t.group_by("city")
+
+    with pytest.raises(ValueError, match="Cannot infer a CTable dtype"):
+        g.agg(x=("sales", lambda a: "always-a-string"))
+
+
+def test_agg_udf_error_names_the_group_key():
+    t = CTable(SalesRow, new_data=DATA)
+    g = t.group_by("city")
+
+    def boom(values):
+        raise KeyError("nope")
+
+    with pytest.raises(RuntimeError, match=r"raised for group \('(Paris|Rome|Berlin)',\)"):
+        g.agg(x=("sales", boom))
+
+
+def test_agg_udf_combines_with_builtin_ops():
+    t = CTable(SalesRow, new_data=DATA)
+    result = t.group_by("city", sort=True).agg(
+        total=("sales", "sum"), rng=("sales", lambda a: a.max() - a.min())
+    )
+    assert result.col_names == ["city", "total", "rng"]
+    # Berlin's sum is NaN too (all-null group) -- the existing sum() convention.
+    np.testing.assert_allclose(col(result, "total"), [np.nan, 40.0, 60.0])

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -906,6 +906,34 @@ def test_agg_udf_unsupported_result_dtype_raises_clear_error():
         g.agg(x=("sales", lambda a: "always-a-string"))
 
 
+def test_agg_udf_never_called_raises_clear_error():
+    # Every group has zero non-null "sales" values, so the UDF is never
+    # called for any of them -- there is nothing to infer a dtype from.
+    t = CTable(SalesRow, new_data=[("Paris", 1, np.nan, 0), ("Rome", 1, np.nan, 0)])
+    g = t.group_by("city")
+
+    with pytest.raises(ValueError, match="it was never called"):
+        g.agg(x=("sales", lambda a: a.max() - a.min()))
+
+
+def test_agg_udf_result_not_wrapped_in_zero_d_array(monkeypatch):
+    # Regression test: the UDF result must reach _python_scalar() directly,
+    # not pre-wrapped in np.asarray() -- a plain Python/NumPy scalar wrapped
+    # in np.asarray() becomes a 0-D ndarray, which _python_scalar() (only
+    # unwraps np.generic) then fails to turn back into a plain scalar.
+    import blosc2.groupby as gb_module
+
+    seen_types = []
+    original = gb_module._python_scalar
+    monkeypatch.setattr(gb_module, "_python_scalar", lambda v: (seen_types.append(type(v)), original(v))[1])
+
+    t = CTable(SalesRow, new_data=[("Paris", 1, 10.0, 0), ("Rome", 1, 20.0, 0)])
+    g = t.group_by("city")
+    g.agg(x=("sales", lambda a: float(a.sum())))
+
+    assert np.ndarray not in seen_types
+
+
 def test_agg_udf_error_names_the_group_key():
     t = CTable(SalesRow, new_data=DATA)
     g = t.group_by("city")

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -823,7 +823,7 @@ def test_agg_duplicate_output_names_rejected():
 
 
 # ===========================================================================
-# UDF aggregations (Gap D2) -- named form only
+# UDF aggregations -- named form only
 # ===========================================================================
 
 

--- a/tests/ctable/test_groupby.py
+++ b/tests/ctable/test_groupby.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 #######################################################################
 
+import math
 from dataclasses import dataclass, make_dataclass
 
 import numpy as np
@@ -914,6 +915,31 @@ def test_agg_udf_never_called_raises_clear_error():
 
     with pytest.raises(ValueError, match="it was never called"):
         g.agg(x=("sales", lambda a: a.max() - a.min()))
+
+
+def test_agg_udf_none_result_becomes_output_null_value():
+    # A UDF returning None for some (but not all) groups is treated like an
+    # empty group: patched to the output dtype's null value, and excluded
+    # from dtype inference rather than poisoning it with a mixed-type list.
+    t = CTable(SalesRow, new_data=[("Paris", 1, 10.0, 0), ("Paris", 1, 30.0, 0), ("Rome", 1, 5.0, 0)])
+    g = t.group_by("city", sort=True)
+
+    def maybe_none(a):
+        return None if a.sum() > 20 else float(a.sum())
+
+    result = g.agg(x=("sales", maybe_none))
+    assert col(result, "city") == ["Paris", "Rome"]
+    assert math.isnan(result["x"][0])  # Paris: sum is 40, UDF returned None
+    assert result["x"][1] == pytest.approx(5.0)  # Rome: sum is 5, UDF returned it
+    assert result["x"].dtype == np.float64
+
+
+def test_agg_udf_all_none_raises_like_never_called():
+    t = CTable(SalesRow, new_data=[("Paris", 1, 10.0, 0), ("Rome", 1, 5.0, 0)])
+    g = t.group_by("city")
+
+    with pytest.raises(ValueError, match="it was never called"):
+        g.agg(x=("sales", lambda a: None))
 
 
 def test_agg_udf_result_not_wrapped_in_zero_d_array(monkeypatch):

--- a/tests/ctable/test_null_expressions.py
+++ b/tests/ctable/test_null_expressions.py
@@ -93,6 +93,16 @@ def test_ge_le_also_exclude_nulls():
     assert t[t.score <= -20]["id"][:].tolist() == [3]
 
 
+def test_comparison_against_nan_scalar_does_not_crash_and_matches_nothing():
+    """Regression: ``t.f == np.nan`` used to crash with NameError inside the
+    lazyexpr evaluator (the scalar was embedded as the bare literal ``nan``).
+    Now it evaluates -- and matches nothing, since a null satisfies no
+    comparison and NaN equals nothing in IEEE anyway."""
+    t = CTable(FloatRow, new_data=[(1, 5.0), (2, np.nan), (3, 7.0)])
+    assert t[t.f == np.nan]["id"][:].tolist() == []
+    assert t[t.f != np.nan]["id"][:].tolist() == [1, 3]
+
+
 def test_ne_on_nullable_float_excludes_nan_null():
     """The one comparison where IEEE and SQL disagree for NaN sentinels:
     raw ``NaN != x`` is True, but a null must not satisfy ``!=`` either."""

--- a/tests/ctable/test_null_expressions.py
+++ b/tests/ctable/test_null_expressions.py
@@ -11,6 +11,7 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 
 import numpy as np
@@ -218,23 +219,65 @@ def test_non_nullable_column_comparison_unchanged():
 
 
 # ===========================================================================
-# Reductions on a *derived* (unregistered) expression: documented limitation.
+# Reductions on derived expressions skip nulls (NullableExpr wrapper)
 # ===========================================================================
 
 
-def test_reduction_on_derived_expression_is_nan_poisoned_not_null_skipping():
-    """`t.score.sum()` (a real Column) skips nulls; `(t.score + 1)` is a
-    plain LazyExpr with no memory of nullability, so its own `.sum()` follows
-    ordinary NumPy semantics (NaN poisons the reduction) rather than pandas'
-    skip-null default. Materialize and mask with NumPy for a skip-null total.
-    """
+def test_reduction_on_derived_expression_skips_nulls():
+    """`t.score + 1` returns a NullableExpr carrying the null predicate, so
+    its reductions skip nulls exactly like `t.score.sum()` does — instead of
+    NaN-poisoning the way a plain LazyExpr reduction would."""
     t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0)])
-    assert t.score.sum() == -10  # Column.sum() already skips nulls today
-    assert np.isnan((t.score + 1).sum())  # derived expression: NaN poisons it
-    # Workaround: mask with notnull() on materialized values, then reduce with NumPy.
-    values = t.score[:]
-    total = (values[t.score.notnull()] + 1).sum()
-    assert total == pytest.approx(-8.0)
+    assert t.score.sum() == -10  # Column.sum() skips nulls
+    assert (t.score + 1).sum() == pytest.approx(-8.0)
+    assert (t.score + 1).mean() == pytest.approx(-4.0)
+    assert (t.score + 1).min() == pytest.approx(-19.0)
+    assert (t.score + 1).max() == pytest.approx(11.0)
+    assert (t.score + 1).std() == pytest.approx(15.0)
+
+
+def test_reduction_on_chained_and_mixed_expressions_skips_nulls():
+    t = CTable(IntRow, new_data=[(1, 10, 5), (2, NULL_I64, 5), (3, -20, NULL_I64)])
+    assert ((t.score + 1) * 2).sum() == pytest.approx(2 * (11 - 19))
+    # nullable + nullable: null wherever either operand is null -> only row 1 live
+    assert (t.score + t.other).sum() == pytest.approx(15.0)
+    # non-nullable + NullableExpr keeps the wrapper and its null predicate
+    assert (t.id + (t.score + 1)).sum() == pytest.approx((1 + 11) + (3 - 19))
+    # scalar-reflected and exotic ops keep the null channel too
+    assert (100 - t.score).sum() == pytest.approx(90 + 120)
+    assert (t.score**0).sum() == pytest.approx(2.0)  # nan**0 must not resurrect the null
+
+
+def test_reduction_on_derived_expression_matches_pandas():
+    pd = pytest.importorskip("pandas")
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0), (4, 7, 0)])
+    s = pd.Series([10, None, -20, 7], dtype="Int64")
+    assert (t.score + 1).sum() == pytest.approx(float((s + 1).sum()))
+    assert (t.score + 1).mean() == pytest.approx(float((s + 1).mean()))
+
+
+def test_derived_expression_reductions_respect_deleted_rows_and_views():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0), (4, 7, 0)])
+    t.delete([0])  # drop score=10
+    assert (t.score + 1).sum() == pytest.approx(-19 + 8)
+    view = t[t.id > 3]  # only score=7 remains visible
+    assert (view.score + 1).sum() == pytest.approx(8.0)
+
+
+def test_derived_expression_all_null_reduction_semantics():
+    t = CTable(IntRow, new_data=[(1, NULL_I64, 0), (2, NULL_I64, 0)])
+    assert (t.score + 1).sum() == 0.0  # same convention as Column.sum()
+    assert math.isnan((t.score + 1).mean())
+    with pytest.raises(ValueError, match="all values are null"):
+        (t.score + 1).min()
+    with pytest.raises(ValueError, match="all values are null"):
+        (t.score + 1).max()
+
+
+def test_derived_expression_ne_comparison_excludes_nulls():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0)])
+    assert t[(t.score + 1) != 11]["id"][:].tolist() == [3]
+    assert t[(t.score + 1) > 0]["id"][:].tolist() == [1]
 
 
 if __name__ == "__main__":

--- a/tests/ctable/test_null_expressions.py
+++ b/tests/ctable/test_null_expressions.py
@@ -35,6 +35,12 @@ class TsRow:
     ts: int = blosc2.field(blosc2.timestamp(null_value=NULL_I64))
 
 
+@dataclass
+class FloatRow:
+    id: int = blosc2.field(blosc2.int64())
+    f: float = blosc2.field(blosc2.float64(nullable=True))
+
+
 # ===========================================================================
 # Comparisons: nulls never satisfy any comparison (SQL WHERE semantics)
 # ===========================================================================
@@ -87,6 +93,36 @@ def test_ge_le_also_exclude_nulls():
     assert t[t.score <= -20]["id"][:].tolist() == [3]
 
 
+def test_ne_on_nullable_float_excludes_nan_null():
+    """The one comparison where IEEE and SQL disagree for NaN sentinels:
+    raw ``NaN != x`` is True, but a null must not satisfy ``!=`` either."""
+    t = CTable(FloatRow, new_data=[(1, 5.0), (2, np.nan), (3, 7.0)])
+    assert t[t.f != 5.0]["id"][:].tolist() == [3]
+
+
+def test_lt_gt_on_nullable_float_exclude_nulls():
+    t = CTable(FloatRow, new_data=[(1, 5.0), (2, np.nan), (3, -7.0)])
+    assert t[t.f > 0]["id"][:].tolist() == [1]
+    assert t[t.f < 0]["id"][:].tolist() == [3]
+
+
+def test_timestamp_comparisons_exclude_nulls():
+    """Pre-C2b bug shape: the INT64_MIN sentinel satisfied every less-than."""
+    t = CTable(TsRow, new_data=[(1, 1000), (2, NULL_I64), (3, 2000)])
+    assert t[t.ts < 5000]["id"][:].tolist() == [1, 3]
+    assert t[t.ts > 1500]["id"][:].tolist() == [3]
+
+
+def test_inverted_comparison_selects_null_rows():
+    """Documented consequence of SQL False-semantics (not Kleene): a null
+    compares False, so negating a comparison *selects* null rows. The
+    escape hatch is the complementary comparison, which never matches
+    nulls."""
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0)])
+    assert t[~(t.score > 0)]["id"][:].tolist() == [2, 3]
+    assert t[t.score <= 0]["id"][:].tolist() == [3]
+
+
 # ===========================================================================
 # Arithmetic: null propagates, output promoted to float64/NaN
 # ===========================================================================
@@ -120,6 +156,31 @@ def test_arith_mixed_nullable_and_non_nullable_column():
     t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0)])
     result = (t.id + t.score).compute()[:2]
     assert result[0] == 11.0
+    assert np.isnan(result[1])
+
+
+def test_reverse_operators_propagate_null():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0)])
+    for expr in (100 - t.score, 3 * t.score, 100 / t.score):
+        result = expr.compute()[:2]
+        assert np.isnan(result[1]), expr
+    np.testing.assert_array_equal((100 - t.score).compute()[:1], [90.0])
+
+
+def test_floordiv_mod_pow_propagate_null():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0)])
+    for expr, live in ((t.score // 3, 3.0), (t.score % 3, 1.0), (t.score**2, 100.0)):
+        result = expr.compute()[:2]
+        assert result[0] == live
+        assert np.isnan(result[1])
+
+
+def test_pow_zero_exponent_keeps_null():
+    """IEEE says ``nan ** 0 == 1.0``, which would silently resurrect a null
+    as a real value; the rewrite patches null rows back to NaN."""
+    t = CTable(FloatRow, new_data=[(1, 5.0), (2, np.nan), (3, 7.0)])
+    result = (t.f**0).compute()[:3]
+    np.testing.assert_array_equal(result[[0, 2]], [1.0, 1.0])
     assert np.isnan(result[1])
 
 

--- a/tests/ctable/test_null_expressions.py
+++ b/tests/ctable/test_null_expressions.py
@@ -1,0 +1,170 @@
+#######################################################################
+# Copyright (c) 2019-present, Blosc Development Team <blosc@blosc.org>
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#######################################################################
+
+"""Tests for sentinel-based null propagation through Column expressions
+(arithmetic and comparisons), per Gap C2/C2b of plans/enhancing-ctable.md.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+
+import blosc2
+from blosc2 import CTable
+
+NULL_I64 = np.iinfo(np.int64).min
+
+
+@dataclass
+class IntRow:
+    id: int = blosc2.field(blosc2.int64())
+    score: int = blosc2.field(blosc2.int64(null_value=NULL_I64))
+    other: int = blosc2.field(blosc2.int64(null_value=NULL_I64))
+
+
+@dataclass
+class TsRow:
+    id: int = blosc2.field(blosc2.int64())
+    ts: int = blosc2.field(blosc2.timestamp(null_value=NULL_I64))
+
+
+# ===========================================================================
+# Comparisons: nulls never satisfy any comparison (SQL WHERE semantics)
+# ===========================================================================
+
+
+def test_lt_excludes_null_rows():
+    """Headline bug fix: before C2b, INT64_MIN < 0 was True, wrongly
+    including the null row in a less-than filter."""
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0), (4, 30, 0)])
+    assert t[t.score < 0]["id"][:].tolist() == [3]
+
+
+def test_gt_excludes_null_rows():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0), (4, 30, 0)])
+    assert t[t.score > 0]["id"][:].tolist() == [1, 4]
+
+
+def test_eq_sentinel_literal_does_not_match_null():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0)])
+    assert t[t.score == NULL_I64]["id"][:].tolist() == []
+
+
+def test_ne_sentinel_literal_does_not_match_null_either():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0)])
+    # A null never satisfies `!=` either — it isn't "not equal", it's unknown.
+    assert t[t.score != NULL_I64]["id"][:].tolist() == [1]
+
+
+def test_is_null_still_finds_nulls():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0)])
+    assert list(t.score.is_null()) == [False, True]
+
+
+def test_comparison_between_two_nullable_columns_excludes_either_null():
+    t = CTable(
+        IntRow,
+        new_data=[
+            (1, 10, 5),  # 10 > 5 -> True
+            (2, NULL_I64, 5),  # score null -> excluded
+            (3, 10, NULL_I64),  # other null -> excluded
+            (4, 3, 5),  # 3 > 5 -> False
+        ],
+    )
+    assert t[t.score > t.other]["id"][:].tolist() == [1]
+
+
+def test_ge_le_also_exclude_nulls():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0)])
+    assert t[t.score >= -20]["id"][:].tolist() == [1, 3]
+    assert t[t.score <= -20]["id"][:].tolist() == [3]
+
+
+# ===========================================================================
+# Arithmetic: null propagates, output promoted to float64/NaN
+# ===========================================================================
+
+
+def test_arith_propagates_null_for_nullable_int():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0)])
+    result = (t.score + 1).compute()[:3]
+    assert not np.isnan(result[0])
+    assert np.isnan(result[1])
+    assert not np.isnan(result[2])
+    np.testing.assert_array_equal(result[[0, 2]], [11.0, -19.0])
+
+
+def test_arith_propagates_null_for_timestamp_column():
+    t = CTable(TsRow, new_data=[(1, 1000), (2, NULL_I64), (3, 2000)])
+    result = (t.ts + 1).compute()[:3]
+    assert np.isnan(result[1])
+    np.testing.assert_array_equal(result[[0, 2]], [1001.0, 2001.0])
+
+
+def test_arith_scalar_operand():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0)])
+    result = (t.score * 3).compute()[:2]
+    assert result[0] == 30.0
+    assert np.isnan(result[1])
+
+
+def test_arith_mixed_nullable_and_non_nullable_column():
+    """`id` has no null_value; `score` does. Nullness still propagates."""
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0)])
+    result = (t.id + t.score).compute()[:2]
+    assert result[0] == 11.0
+    assert np.isnan(result[1])
+
+
+def test_chained_arithmetic_does_not_double_wrap():
+    """The rewrite applies once, at the first nullable-operand boundary;
+    NaN then propagates through ordinary float arithmetic downstream."""
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0)])
+    result = ((t.score + 1) * 2).compute()[:3]
+    assert np.isnan(result[1])
+    np.testing.assert_array_equal(result[[0, 2]], [22.0, -38.0])
+
+
+def test_non_nullable_column_arithmetic_unchanged():
+    """Zero-overhead guarantee: a non-nullable column's arithmetic result is
+    the raw expression, not routed through a null-check rewrite."""
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, 20, 0)])
+    result = (t.id + 1).compute()[:2]
+    np.testing.assert_array_equal(result, [2, 3])
+    assert result.dtype == np.int64  # no float promotion when nothing is nullable
+
+
+def test_non_nullable_column_comparison_unchanged():
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, 20, 0)])
+    assert t[t.id > 1]["id"][:].tolist() == [2]
+
+
+# ===========================================================================
+# Reductions on a *derived* (unregistered) expression: documented limitation.
+# ===========================================================================
+
+
+def test_reduction_on_derived_expression_is_nan_poisoned_not_null_skipping():
+    """`t.score.sum()` (a real Column) skips nulls; `(t.score + 1)` is a
+    plain LazyExpr with no memory of nullability, so its own `.sum()` follows
+    ordinary NumPy semantics (NaN poisons the reduction) rather than pandas'
+    skip-null default. Materialize and mask with NumPy for a skip-null total.
+    """
+    t = CTable(IntRow, new_data=[(1, 10, 0), (2, NULL_I64, 0), (3, -20, 0)])
+    assert t.score.sum() == -10  # Column.sum() already skips nulls today
+    assert np.isnan((t.score + 1).sum())  # derived expression: NaN poisons it
+    # Workaround: mask with notnull() on materialized values, then reduce with NumPy.
+    values = t.score[:]
+    total = (values[t.score.notnull()] + 1).sum()
+    assert total == pytest.approx(-8.0)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/tests/ctable/test_null_expressions.py
+++ b/tests/ctable/test_null_expressions.py
@@ -6,7 +6,7 @@
 #######################################################################
 
 """Tests for sentinel-based null propagation through Column expressions
-(arithmetic and comparisons), per Gap C2/C2b of plans/enhancing-ctable.md.
+(arithmetic and comparisons).
 """
 
 from __future__ import annotations

--- a/tests/ctable/test_nullable.py
+++ b/tests/ctable/test_nullable.py
@@ -706,6 +706,18 @@ def test_fillna_varlen_string_column():
     assert t["text"].fillna("N/A") == ["hello", "N/A", "world"]
 
 
+def test_fillna_on_view_returns_view_rows_only():
+    t = CTable(IntRow, new_data=[(1, 10), (2, -1), (3, 20), (4, -1)])
+    view = t.where(t["id"] > 1)
+    np.testing.assert_array_equal(view["score"].fillna(0), [0, 20, 0])
+    np.testing.assert_array_equal(t["score"][:], [10, -1, 20, -1])  # base untouched
+
+
+def test_fillna_on_non_nullable_column_is_identity():
+    t = CTable(IntRow, new_data=[(1, 10), (2, 20)])
+    np.testing.assert_array_equal(t["id"].fillna(0), [1, 2])
+
+
 def test_dropna_default_subset():
     t = CTable(IntRow, new_data=[(1, 10), (2, -1), (3, 20), (4, -1)])
     result = t.dropna()

--- a/tests/ctable/test_nullable.py
+++ b/tests/ctable/test_nullable.py
@@ -229,6 +229,21 @@ def test_is_null_no_null_value():
     assert list(mask) == [False, False]
 
 
+def test_is_null_timestamp_sentinel():
+    """Timestamp sentinels materialize as np.datetime64('NaT') (same bit
+    pattern as INT64_MIN), so is_null() must special-case datetime64 arrays
+    instead of comparing against the raw int sentinel."""
+
+    @dataclass
+    class TsRow:
+        ts: int = blosc2.field(blosc2.timestamp(null_value=np.iinfo(np.int64).min))
+
+    null_ts = np.iinfo(np.int64).min
+    t = CTable(TsRow, new_data=[(1000,), (null_ts,), (2000,)])
+    assert list(t["ts"].is_null()) == [False, True, False]
+    assert t["ts"].null_count() == 1
+
+
 def test_null_count_after_delete():
     t = CTable(IntRow, new_data=[(1, 10), (2, -1), (3, -1), (4, 5)])
     t.delete([1])  # delete the row with score=-1 at physical index 1
@@ -643,6 +658,86 @@ def test_schema_null_value_in_metadata():
     cols = {c["name"]: c for c in d["columns"]}
     assert cols["x"]["null_value"] == -999
     assert cols["label"]["null_value"] == "N/A"
+
+
+# ===========================================================================
+# fillna / dropna
+# ===========================================================================
+
+
+def test_fillna_int_sentinel():
+    t = CTable(IntRow, new_data=[(1, 10), (2, -1), (3, 20)])
+    filled = t["score"].fillna(0)
+    np.testing.assert_array_equal(filled, [10, 0, 20])
+
+
+def test_fillna_nan_float():
+    t = CTable(FloatRow, new_data=[("a", 1.0), ("b", float("nan")), ("c", 3.0)])
+    filled = t["value"].fillna(-1.0)
+    np.testing.assert_array_equal(filled, [1.0, -1.0, 3.0])
+
+
+def test_fillna_timestamp_sentinel():
+    @dataclass
+    class TsRow:
+        ts: int = blosc2.field(blosc2.timestamp(null_value=np.iinfo(np.int64).min))
+
+    null_ts = np.iinfo(np.int64).min
+    t = CTable(TsRow, new_data=[(1000,), (null_ts,), (2000,)])
+    filled = t["ts"].fillna(np.datetime64(0, "us"))
+    np.testing.assert_array_equal(filled, np.array([1000, 0, 2000], dtype="datetime64[us]"))
+
+
+def test_fillna_dictionary_column():
+    @dataclass
+    class DictRow:
+        vendor: str = blosc2.field(blosc2.dictionary())
+
+    t = CTable(DictRow, new_data=[("Uber",), (None,), ("Lyft",)])
+    assert t["vendor"].fillna("unknown") == ["Uber", "unknown", "Lyft"]
+
+
+def test_fillna_varlen_string_column():
+    @dataclass
+    class VLRow:
+        text: str = blosc2.field(blosc2.vlstring(nullable=True))
+
+    t = CTable(VLRow, new_data=[("hello",), (None,), ("world",)])
+    assert t["text"].fillna("N/A") == ["hello", "N/A", "world"]
+
+
+def test_dropna_default_subset():
+    t = CTable(IntRow, new_data=[(1, 10), (2, -1), (3, 20), (4, -1)])
+    result = t.dropna()
+    assert result.nrows == 2
+    np.testing.assert_array_equal(result["score"][:], [10, 20])
+    assert result.base is t
+
+
+def test_dropna_explicit_subset():
+    @dataclass
+    class TwoNullableRow:
+        a: int = blosc2.field(blosc2.int64(null_value=-1))
+        b: int = blosc2.field(blosc2.int64(null_value=-1))
+
+    t = CTable(TwoNullableRow, new_data=[(1, -1), (-1, 2), (3, 4)])
+    # only checking "a": row 1 (a=-1) is dropped, row 0 (b=-1) survives
+    result = t.dropna(subset=["a"])
+    np.testing.assert_array_equal(result["a"][:], [1, 3])
+    np.testing.assert_array_equal(result["b"][:], [-1, 4])
+
+
+def test_dropna_row_count_correct():
+    t = CTable(IntRow, new_data=[(i, -1 if i % 3 == 0 else i) for i in range(10)])
+    result = t.dropna(subset=["score"])
+    assert result.nrows == sum(1 for i in range(10) if i % 3 != 0)
+
+
+def test_dropna_of_a_filtered_view():
+    t = CTable(IntRow, new_data=[(1, 10), (2, -1), (3, 20), (4, -1), (5, 30)])
+    view = t.where(t["id"] > 1)  # rows with id 2,3,4,5 -> scores -1,20,-1,30
+    result = view.dropna(subset=["score"])
+    np.testing.assert_array_equal(result["score"][:], [20, 30])
 
 
 if __name__ == "__main__":

--- a/tests/ctable/test_schema_mutations.py
+++ b/tests/ctable/test_schema_mutations.py
@@ -6,7 +6,7 @@
 #######################################################################
 
 """Tests for add_column, drop_column, rename_column, Column.assign,
-and the corrected view mutability model."""
+and the read-only view mutability model."""
 
 import os
 import pathlib
@@ -47,29 +47,88 @@ def table_path(name):
 
 
 # ===========================================================================
-# View mutability — value writes allowed, structural changes blocked
+# View mutability — views are read-only: value writes and structural
+# changes are both blocked.
 # ===========================================================================
 
 
-def test_view_allows_column_setitem():
-    """Writing values through a view modifies the parent table."""
+def test_view_blocks_column_setitem():
+    """Writing values through a view raises; the base table is untouched."""
     t = CTable(Row, new_data=DATA10)
     view = t.where(t["id"] > 4)  # rows 5-9
-    # double scores of those rows using __setitem__
     indices = list(range(len(view)))
     new_scores = view["score"][:] * 2
-    view["score"][indices] = new_scores
-    # check parent was modified
-    assert t["score"][5] == pytest.approx(100.0)  # was 50.0
+    with pytest.raises(ValueError, match="view"):
+        view["score"][indices] = new_scores
+    assert t["score"][5] == pytest.approx(50.0)  # unchanged
 
 
-def test_view_allows_assign():
-    """assign() through a view modifies the parent table."""
+def test_view_blocks_column_setitem_slice():
+    t = CTable(Row, new_data=DATA10)
+    view = t[2:5]
+    with pytest.raises(ValueError, match="view"):
+        view["score"][0] = 99.0
+    assert t["score"][2] == pytest.approx(20.0)
+
+
+def test_view_blocks_column_setitem_gathered_rows():
+    t = CTable(Row, new_data=DATA10)
+    view = t[[1, 3, 5]]
+    with pytest.raises(ValueError, match="view"):
+        view["score"][0] = 99.0
+    assert t["score"][1] == pytest.approx(10.0)
+
+
+def test_view_blocks_column_setitem_sorted():
+    t = CTable(Row, new_data=DATA10)
+    view = t.sort_by("score", ascending=False, view=True)
+    with pytest.raises(ValueError, match="view"):
+        view["score"][0] = 99.0
+    assert t["score"][9] == pytest.approx(90.0)
+
+
+def test_view_blocks_column_setitem_projection():
+    t = CTable(Row, new_data=DATA10)
+    view = t[["id", "score"]]
+    with pytest.raises(ValueError, match="view"):
+        view["score"][0] = 99.0
+    assert t["score"][0] == pytest.approx(0.0)
+
+
+def test_view_blocks_column_setitem_boolean_mask():
     t = CTable(Row, new_data=DATA10)
     view = t.where(t["id"] > 4)
-    view["score"].assign(np.zeros(len(view)))
-    assert t["score"][5] == pytest.approx(0.0)
-    assert t["score"][4] == pytest.approx(40.0)  # untouched
+    mask = np.zeros(len(view), dtype=bool)
+    mask[0] = True
+    with pytest.raises(ValueError, match="view"):
+        view["score"][mask] = np.array([99.0])
+    assert t["score"][5] == pytest.approx(50.0)
+
+
+def test_view_blocks_assign():
+    """assign() through a view raises; the base table is untouched."""
+    t = CTable(Row, new_data=DATA10)
+    view = t.where(t["id"] > 4)
+    with pytest.raises(ValueError, match="view"):
+        view["score"].assign(np.zeros(len(view)))
+    assert t["score"][5] == pytest.approx(50.0)
+
+
+def test_take_from_view_yields_independent_writable_table():
+    t = CTable(Row, new_data=DATA10)
+    view = t.where(t["id"] > 4)
+    independent = view.take([0, 1])
+    independent["score"][0] = 99.0
+    assert independent["score"][0] == pytest.approx(99.0)
+    # base and view unaffected
+    assert t["score"][5] == pytest.approx(50.0)
+
+
+def test_writes_on_base_still_work_while_view_exists():
+    t = CTable(Row, new_data=DATA10)
+    view = t.where(t["id"] > 4)
+    t["score"][0] = 999.0
+    assert t["score"][0] == pytest.approx(999.0)
 
 
 def test_view_blocks_append():
@@ -178,14 +237,13 @@ def test_assign_wrong_length_raises():
         t["score"].assign([1.0, 2.0])
 
 
-def test_assign_through_view_touches_only_matching_rows():
+def test_assign_through_view_raises():
     t = CTable(Row, new_data=DATA10)
     view = t.where(t["id"] < 5)  # rows 0-4
-    view["score"].assign([0.0] * 5)
-    # rows 0-4 → 0, rows 5-9 unchanged
-    scores = t["score"][:]
-    np.testing.assert_array_equal(scores[:5], np.zeros(5))
-    np.testing.assert_array_equal(scores[5:], np.arange(5, 10, dtype=np.float64) * 10)
+    with pytest.raises(ValueError, match="view"):
+        view["score"].assign([0.0] * 5)
+    # base table untouched
+    np.testing.assert_array_equal(t["score"][:], np.arange(10, dtype=np.float64) * 10)
 
 
 def test_assign_respects_deleted_rows():
@@ -442,17 +500,17 @@ def test_bool_mask_wrong_length_raises():
         _ = t["score"][bad_mask]
 
 
-def test_bool_mask_through_view():
-    """Boolean mask indexing works on views too."""
+def test_bool_mask_setitem_through_view_raises():
+    """Boolean-mask reads still work on views; writes through a view raise."""
     t = CTable(Row, new_data=DATA10)
     view = t.where(t["id"] < 6)  # rows 0-5
     mask = view["id"][:] % 2 == 0
-    view["score"][mask] *= 10
-    # rows 0,2,4 in view → ids 0,2,4 in parent → scores 0,20,40 * 10
+    with pytest.raises(ValueError, match="view"):
+        view["score"][mask] *= 10
+    # base untouched
     assert t["score"][0] == pytest.approx(0.0)
-    assert t["score"][2] == pytest.approx(200.0)
-    assert t["score"][4] == pytest.approx(400.0)
-    assert t["score"][1] == pytest.approx(10.0)  # untouched
+    assert t["score"][2] == pytest.approx(20.0)
+    assert t["score"][4] == pytest.approx(40.0)
 
 
 if __name__ == "__main__":

--- a/tests/ndarray/test_lazyexpr.py
+++ b/tests/ndarray/test_lazyexpr.py
@@ -2263,3 +2263,30 @@ def test_miniexpr_candidate_block_skip(chunk_len, block_len):
 
     # Without a bitmap every row is evaluated (predicate always True).
     assert int(expr.compute()[:].sum()) == n
+
+
+def test_nonfinite_scalar_operands():
+    """nan/inf scalars have no expression-string literal (numexpr defines no
+    such constants), so they must ride as typed named operands; string
+    expressions may still spell them as bare names."""
+    a = blosc2.asarray(np.array([1.0, 2.0, 3.0]))
+
+    # Operator paths: scalar on either side.
+    np.testing.assert_array_equal((a == np.nan).compute()[:], [False] * 3)
+    np.testing.assert_array_equal((a != np.nan).compute()[:], [True] * 3)
+    assert np.all(np.isnan((a + np.nan).compute()[:]))
+    np.testing.assert_array_equal((np.nan > a).compute()[:], [False] * 3)
+    np.testing.assert_array_equal((a < np.inf).compute()[:], [True] * 3)
+    np.testing.assert_array_equal((a > -np.inf).compute()[:], [True] * 3)
+
+    # Chained expression (update_expr path).
+    np.testing.assert_array_equal(((a + 1) == np.nan).compute()[:], [False] * 3)
+    assert np.all(np.isnan(((a + 1) + np.nan).compute()[:]))
+
+    # Two-arg function path.
+    assert np.all(np.isnan(blosc2.maximum(a, np.nan).compute()[:]))
+    np.testing.assert_array_equal(blosc2.minimum(a, np.inf).compute()[:], a[:])
+
+    # String expressions with bare nan/inf names.
+    assert np.all(np.isnan(blosc2.lazyexpr("a + nan", {"a": a}).compute()[:]))
+    np.testing.assert_array_equal(blosc2.lazyexpr("a < inf", {"a": a}).compute()[:], [True] * 3)


### PR DESCRIPTION
Closes Gaps A–D from plans/enhancing-ctable.md (pandas-3-inspired feature gaps for CTable). Gap E (col()) stays parked per the plan.

Gap A — Arrow PyCapsule interchange. CTable.__arrow_c_stream__ lets pyarrow, DuckDB, Polars, and pandas ≥2.2 consume a CTable directly as a streaming, bounded-memory batch source. from_arrow() now also accepts any single capsule-producer object (pyarrow Table/RecordBatchReader, Polars DataFrame, DuckDB result, another CTable) in addition to the existing (schema, batches) form.

Gap B — Read-only views. Column.__setitem__/assign() now raise ValueError when called on a view, pointing at take()/copy(). Previously cell writes silently mutated the base table's physical storage while structural mutations already raised — this closes that one gap.

Gap C — Sentinel-null story. Added Column.fillna() and CTable.dropna(). Fixed a real pre-existing bug where is_null()/null_count() never worked for timestamp columns (sentinel decodes to NaT before the mask check compares it). Implemented sentinel-based null propagation through Column arithmetic/comparisons: arithmetic promotes nullable int/timestamp results to NaN, comparisons exclude nulls (SQL semantics) — fixing t[t.x < 0] wrongly including null rows. One documented limitation: .sum() on a derived expression like (t.x + 1) doesn't auto-skip nulls (no new Column-like wrapper was built for it — flagged as a possible follow-up).

Gap D — UDF aggregations & engine dispatch. group_by(engine=...) accepts "auto"/"numpy" (current path) and "jit" (reserved, raises NotImplementedError — no JIT execution engine was built/benchmarked this round). agg()'s named form now accepts a custom callable (output_name=(col, fn[, dtype])), executed once per group with nulls pre-filtered, dtype inferred/validated across all groups. Added CTable.apply() as thin sugar over blosc2.lazyudf().

All changes are additive/backward-compatible except Gap B (intentional behavior fix) and the timestamp null-detection fix in Gap C (bug fix). Full test suite (7359 tests) passes.
