### PR TITLE
Fix asarray when chunk dims are greater than shape dims

### DIFF
--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -308,8 +308,6 @@ def are_partitions_behaved(shape, chunks, blocks):
     bool
         True if the partitions are well-behaved, False otherwise.
     """
-
-    # Spanning the innermost dimension keeps whole container rows; outer dimensions just tile evenly
     def check_contiguity(container, part):
         if container and container[-1] != part[-1]:
             return False

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -302,6 +302,9 @@ def are_partitions_behaved(shape, chunks, blocks):
     Check if the partitions defined by chunks and blocks are well-behaved with respect to the shape.
 
     This function verifies that partitions are C-contiguous with respect the outer container.
+    This means an unsplit innermost dimension and outer dimensions that the partition divides
+    evenly; a partition that overhangs the container in some dimension pads it, so it is not
+    well-behaved either.
 
     Returns
     -------
@@ -309,27 +312,13 @@ def are_partitions_behaved(shape, chunks, blocks):
         True if the partitions are well-behaved, False otherwise.
     """
 
-    # Check C-contiguity among partitions
-    def check_contiguity(shape, part):
-        ndims = len(shape)
-        inner_dim = ndims - 1
-        for i, size, unit in zip(reversed(range(ndims)), reversed(shape), reversed(part), strict=True):
-            if size > unit:
-                if i < inner_dim:
-                    if size % unit != 0:
-                        return False
-                else:
-                    if size != unit:
-                        return False
-                inner_dim = i
-        return True
+    # Spanning the innermost dimension keeps whole container rows; outer dimensions just tile evenly
+    def check_contiguity(container, part):
+        if container and container[-1] != part[-1]:
+            return False
+        return builtins.all(size % unit == 0 for size, unit in zip(container[:-1], part[:-1], strict=True))
 
-    # Check C-contiguity for blocks inside chunks
-    if not check_contiguity(chunks, blocks):
-        return False
-
-    # Check C-contiguity for chunks inside shape
-    return check_contiguity(shape, chunks)
+    return check_contiguity(chunks, blocks) and check_contiguity(shape, chunks)
 
 
 def get_flat_slices_orig(shape: tuple[int], s: tuple[slice, ...]) -> list[slice]:

--- a/src/blosc2/ndarray.py
+++ b/src/blosc2/ndarray.py
@@ -302,9 +302,6 @@ def are_partitions_behaved(shape, chunks, blocks):
     Check if the partitions defined by chunks and blocks are well-behaved with respect to the shape.
 
     This function verifies that partitions are C-contiguous with respect the outer container.
-    This means an unsplit innermost dimension and outer dimensions that the partition divides
-    evenly; a partition that overhangs the container in some dimension pads it, so it is not
-    well-behaved either.
 
     Returns
     -------

--- a/tests/ndarray/test_ndarray.py
+++ b/tests/ndarray/test_ndarray.py
@@ -103,6 +103,25 @@ def test_asarray(a):
         np.testing.assert_allclose(a, b[:])
 
 
+@pytest.mark.parametrize(
+    ("shape", "chunks", "blocks"),
+    [
+        ((146, 23802), (147, 23802), (1, 23802)),
+        ((2200, 1000), (1100, 1024), (10, 1024)),
+        ((20, 300, 500), (21, 300, 500), (1, 300, 500)),
+    ],
+)
+def test_asarray_chunks_larger_than_shape(shape, chunks, blocks):
+    # Above 16 MB, asarray fills chunk by chunk; padded chunks must skip update_data
+    a = np.arange(math.prod(shape), dtype=np.float64).reshape(shape)
+    assert a.nbytes > 2**24
+
+    b = blosc2.asarray(a, chunks=chunks, blocks=blocks)
+
+    np.testing.assert_array_equal(b[:], a)
+    assert not blosc2.are_partitions_behaved(shape, chunks, blocks)
+
+
 def test_asarray_persists_copy_with_urlpath(tmp_path):
     array = blosc2.asarray(np.arange(10, dtype=np.int64), chunks=(5,), blocks=(2,))
     path = tmp_path / "persisted_copy.b2nd"


### PR DESCRIPTION
`asarray()` leaves arrays over 16 MB unreadable when the chunk shape is greater than the shape:

```python
a = np.arange(146 * 23802, dtype=np.float64).reshape(146, 23802)
b = blosc2.asarray(a, chunks=(147, 23802), blocks=(1, 23802))
b[:]  # RuntimeError: Error while getting the buffer
```

This seems to be because `asarray` has a separate path for large arrays which calls `schunk.update_data()` on its fastpath if `are_partitions_behaved`. I have changed `are_partitions_behaved` to no longer return true for this example and tried to simplify the existing logic which I found hard to follow. I've tried to preserve the old behaviour whilst also checking that `size % unit == 0` if `size < unit`.

The other uses of `are_partitions_behaved` seem to live in `lazyexpr.py` and are of the form `behaved and result.shape == out.chunks and result.dtype == out.dtype` so I think they're unaffected. 